### PR TITLE
Create table resilience

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
+*.iml
+.idea/
 target/
 AwsCredentials.properties


### PR DESCRIPTION
This breaks the dependency of worker start on the CreateTable API in DynamoDB, which prevented KCL workers from starting during the us-east-1 DynamoDB outage today.