### PR TITLE
Change DefaultCWMetricsPublisher log level to debug

### DIFF
--- a/src/main/java/com/amazonaws/services/kinesis/metrics/impl/DefaultCWMetricsPublisher.java
+++ b/src/main/java/com/amazonaws/services/kinesis/metrics/impl/DefaultCWMetricsPublisher.java
@@ -62,7 +62,7 @@ public class DefaultCWMetricsPublisher implements ICWMetricsPublisher<CWMetricKe
             try {
                 cloudWatchClient.putMetricData(request);
 
-                LOG.info(String.format("Successfully published %d datums.", endIndex - startIndex));
+                LOG.debug(String.format("Successfully published %d datums.", endIndex - startIndex));
             } catch (AmazonClientException e) {
                 LOG.warn(String.format("Could not publish %d datums to CloudWatch", endIndex - startIndex), e);
             }


### PR DESCRIPTION
When running a KCL application that consumes from many shards, output from DefaultCWMetricsPublisher will often log too much unnecessary information.  This makes reading log files a bit of a headache and it wastes bytes when shipping log files to downstream log collectors.