### PR TITLE
Fix #36 Avoid failure on start due to CreateTable

### DIFF
--- a/src/main/java/com/amazonaws/services/kinesis/leases/impl/LeaseManager.java
+++ b/src/main/java/com/amazonaws/services/kinesis/leases/impl/LeaseManager.java
@@ -115,6 +115,9 @@ public class LeaseManager<T extends Lease> implements ILeaseManager<T> {
         request.setProvisionedThroughput(throughput);
 
         try {
+            if (leaseTableExists()) {
+                return false;
+            }
             dynamoDBClient.createTable(request);
         } catch (ResourceInUseException e) {
             tableDidNotExist = false;


### PR DESCRIPTION
Current implementation uses a ResourceInUse side-effect to detect that the table already exists.
This requires that the user/role running the KCL have the CreateTable permission.  Update the
LeaseManager to check if the table exists to allow limited privilege users to run KCL code.