### PR TITLE
Removing explicit dependency on core

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,11 +34,6 @@
   <dependencies>
     <dependency>
       <groupId>com.amazonaws</groupId>
-      <artifactId>aws-java-sdk-core</artifactId>
-      <version>${aws-java-sdk.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk-dynamodb</artifactId>
       <version>${aws-java-sdk.version}</version>
     </dependency>


### PR DESCRIPTION
Allows customers to more intuitively override client dependencies. For example if I want a newer version of the dynamo db client I'd expect it to prefer it's dependency on core but since they are at the same level it's ambiguous which version of core will be resolved.

See https://github.com/aws/aws-sdk-java/issues/806