### PR TITLE
Added Support for Time based iterators

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,3 +1,3 @@
 AmazonKinesisClientLibrary
-Copyright 2012-2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 

--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>DynamoDBLocal</artifactId>
-      <version>1.10.5.1</version>
+      <version>1.11.0.1</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/checkpoint/SentinelCheckpoint.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/checkpoint/SentinelCheckpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2013 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Amazon Software License (the "License").
  * You may not use this file except in compliance with the License.
@@ -31,5 +31,9 @@ public enum SentinelCheckpoint {
     /**
      * We've completely processed all records in this shard.
      */
-    SHARD_END;
+    SHARD_END,
+    /**
+     * Start from the record at or after the specified server-side timestamp.
+     */
+    AT_TIMESTAMP
 }

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/InitialPositionInStream.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/InitialPositionInStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2013 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Amazon Software License (the "License").
  * You may not use this file except in compliance with the License.
@@ -19,14 +19,18 @@ package com.amazonaws.services.kinesis.clientlibrary.lib.worker;
  * This is used during initial application bootstrap (when a checkpoint doesn't exist for a shard or its parents).
  */
 public enum InitialPositionInStream {
-    
     /**
      * Start after the most recent data record (fetch new data).
      */
     LATEST,
-    
+
     /**
      * Start from the oldest available data record.
      */
-    TRIM_HORIZON;
+    TRIM_HORIZON,
+
+    /**
+     * Start from the record at or after the specified server-side timestamp.
+     */
+    AT_TIMESTAMP
 }

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/InitialPositionInStreamExtended.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/InitialPositionInStreamExtended.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Amazon Software License (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://aws.amazon.com/asl/
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.services.kinesis.clientlibrary.lib.worker;
+
+import java.util.Date;
+
+/**
+ * Class that houses the entities needed to specify the position in the stream from where a new application should
+ * start.
+ */
+class InitialPositionInStreamExtended {
+
+    private final InitialPositionInStream position;
+    private final Date timestamp;
+
+    /**
+     * This is scoped as private to forbid callers from using it directly and to convey the intent to use the
+     * static methods instead.
+     *
+     * @param position  One of LATEST, TRIM_HORIZON, or AT_TIMESTAMP. The Amazon Kinesis Client Library will start
+     *                  fetching records from this position when the application starts up if there are no checkpoints.
+     *                  If there are checkpoints, we will process records from the checkpoint position.
+     * @param timestamp The timestamp to use with the AT_TIMESTAMP value for initialPositionInStream.
+     */
+    private InitialPositionInStreamExtended(final InitialPositionInStream position, final Date timestamp) {
+        this.position = position;
+        this.timestamp = timestamp;
+    }
+
+    /**
+     * Get the initial position in the stream where the application should start from.
+     *
+     * @return The initial position in stream.
+     */
+    protected InitialPositionInStream getInitialPositionInStream() {
+        return this.position;
+    }
+
+    /**
+     * Get the timestamp from where we need to start the application.
+     * Valid only for initial position of type AT_TIMESTAMP, returns null for other positions.
+     *
+     * @return The timestamp from where we need to start the application.
+     */
+    protected Date getTimestamp() {
+        return this.timestamp;
+    }
+
+    protected static InitialPositionInStreamExtended newInitialPosition(final InitialPositionInStream position) {
+        switch (position) {
+            case LATEST:
+                return new InitialPositionInStreamExtended(InitialPositionInStream.LATEST, null);
+            case TRIM_HORIZON:
+                return new InitialPositionInStreamExtended(InitialPositionInStream.TRIM_HORIZON, null);
+            default:
+                throw new IllegalArgumentException("Invalid InitialPosition: " + position);
+        }
+    }
+
+    protected static InitialPositionInStreamExtended newInitialPositionAtTimestamp(final Date timestamp) {
+        if (timestamp == null) {
+            throw new IllegalArgumentException("Timestamp must be specified for InitialPosition AT_TIMESTAMP");
+        }
+        return new InitialPositionInStreamExtended(InitialPositionInStream.AT_TIMESTAMP, timestamp);
+    }
+}

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/InitializeTask.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/InitializeTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Amazon Software License (the "License").
  * You may not use this file except in compliance with the License.
@@ -41,6 +41,7 @@ class InitializeTask implements ITask {
     private final RecordProcessorCheckpointer recordProcessorCheckpointer;
     // Back off for this interval if we encounter a problem (exception)
     private final long backoffTimeMillis;
+    private final StreamConfig streamConfig;
 
     /**
      * Constructor.
@@ -50,13 +51,15 @@ class InitializeTask implements ITask {
             ICheckpoint checkpoint,
             RecordProcessorCheckpointer recordProcessorCheckpointer,
             KinesisDataFetcher dataFetcher,
-            long backoffTimeMillis) {
+            long backoffTimeMillis,
+            StreamConfig streamConfig) {
         this.shardInfo = shardInfo;
         this.recordProcessor = recordProcessor;
         this.checkpoint = checkpoint;
         this.recordProcessorCheckpointer = recordProcessorCheckpointer;
         this.dataFetcher = dataFetcher;
         this.backoffTimeMillis = backoffTimeMillis;
+        this.streamConfig = streamConfig;
     }
 
     /*
@@ -74,7 +77,7 @@ class InitializeTask implements ITask {
             LOG.debug("Initializing ShardId " + shardInfo.getShardId());
             ExtendedSequenceNumber initialCheckpoint = checkpoint.getCheckpoint(shardInfo.getShardId());
 
-            dataFetcher.initialize(initialCheckpoint.getSequenceNumber());
+            dataFetcher.initialize(initialCheckpoint.getSequenceNumber(), streamConfig.getInitialPositionInStream());
             recordProcessorCheckpointer.setLargestPermittedCheckpointValue(initialCheckpoint);
             recordProcessorCheckpointer.setInitialCheckpointValue(initialCheckpoint);
 

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/KinesisClientLibConfiguration.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/KinesisClientLibConfiguration.java
@@ -14,6 +14,7 @@
  */
 package com.amazonaws.services.kinesis.clientlibrary.lib.worker;
 
+import java.util.Date;
 import java.util.Set;
 
 import com.amazonaws.ClientConfiguration;
@@ -185,6 +186,7 @@ public class KinesisClientLibConfiguration {
     private int maxLeasesToStealAtOneTime;
     private int initialLeaseTableReadCapacity;
     private int initialLeaseTableWriteCapacity;
+    private InitialPositionInStreamExtended initialPositionInStreamExtended;
 
     /**
      * Constructor.
@@ -263,7 +265,6 @@ public class KinesisClientLibConfiguration {
      *        with a call to Amazon Kinesis before checkpointing for calls to
      *        {@link RecordProcessorCheckpointer#checkpoint(String)}
      * @param regionName The region name for the service
-     * 
      */
     // CHECKSTYLE:IGNORE HiddenFieldCheck FOR NEXT 26 LINES
     // CHECKSTYLE:IGNORE ParameterNumber FOR NEXT 26 LINES
@@ -330,6 +331,8 @@ public class KinesisClientLibConfiguration {
         this.maxLeasesToStealAtOneTime = DEFAULT_MAX_LEASES_TO_STEAL_AT_ONE_TIME;
         this.initialLeaseTableReadCapacity = DEFAULT_INITIAL_LEASE_TABLE_READ_CAPACITY;
         this.initialLeaseTableWriteCapacity = DEFAULT_INITIAL_LEASE_TABLE_WRITE_CAPACITY;
+        this.initialPositionInStreamExtended =
+                InitialPositionInStreamExtended.newInitialPosition(initialPositionInStream);
     }
 
     // Check if value is positive, otherwise throw an exception
@@ -580,6 +583,22 @@ public class KinesisClientLibConfiguration {
         return initialLeaseTableWriteCapacity;
     }
 
+    /**
+     * Keeping it protected to forbid outside callers from depending on this internal object.
+     * @return The initialPositionInStreamExtended object.
+     */
+    protected InitialPositionInStreamExtended getInitialPositionInStreamExtended() {
+        return initialPositionInStreamExtended;
+    }
+
+    /**
+     * @return The timestamp from where we need to start the application.
+     * Valid only for initial position of type AT_TIMESTAMP, returns null for other positions.
+     */
+    public Date getTimestampAtInitialPositionInStream() {
+        return initialPositionInStreamExtended.getTimestamp();
+    }
+
     // CHECKSTYLE:IGNORE HiddenFieldCheck FOR NEXT 190 LINES
     /**
      * @param tableName name of the lease table in DynamoDB
@@ -600,13 +619,25 @@ public class KinesisClientLibConfiguration {
     }
 
     /**
-     * @param initialPositionInStream One of LATEST or TRIM_HORIZON. The Amazon Kinesis Client Library will start
-     *        fetching records from this position when the application starts up if there are no checkpoints. If there
-     *        are checkpoints, we will process records from the checkpoint position.
+     * @param initialPositionInStream One of LATEST or TRIM_HORIZON. The Amazon Kinesis Client Library
+     *        will start fetching records from this position when the application starts up if there are no checkpoints.
+     *        If there are checkpoints, we will process records from the checkpoint position.
      * @return KinesisClientLibConfiguration
      */
     public KinesisClientLibConfiguration withInitialPositionInStream(InitialPositionInStream initialPositionInStream) {
         this.initialPositionInStream = initialPositionInStream;
+        this.initialPositionInStreamExtended =
+                InitialPositionInStreamExtended.newInitialPosition(initialPositionInStream);
+        return this;
+    }
+
+    /**
+     * @param timestamp The timestamp to use with the AT_TIMESTAMP value for initialPositionInStream.
+     * @return KinesisClientLibConfiguration
+     */
+    public KinesisClientLibConfiguration withTimestampAtInitialPositionInStream(Date timestamp) {
+        this.initialPositionInStream = InitialPositionInStream.AT_TIMESTAMP;
+        this.initialPositionInStreamExtended = InitialPositionInStreamExtended.newInitialPositionAtTimestamp(timestamp);
         return this;
     }
 

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ProcessTask.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ProcessTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Amazon Software License (the "License").
  * You may not use this file except in compliance with the License.
@@ -259,8 +259,8 @@ class ProcessTask implements ITask {
              * Advance the iterator to after the greatest processed sequence number (remembered by
              * recordProcessorCheckpointer).
              */
-            dataFetcher.advanceIteratorTo(
-                    recordProcessorCheckpointer.getLargestPermittedCheckpointValue().getSequenceNumber());
+            dataFetcher.advanceIteratorTo(recordProcessorCheckpointer.getLargestPermittedCheckpointValue()
+                    .getSequenceNumber(), streamConfig.getInitialPositionInStream());
 
             // Try a second time - if we fail this time, expose the failure.
             try {

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardConsumer.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardConsumer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Amazon Software License (the "License").
  * You may not use this file except in compliance with the License.
@@ -252,7 +252,8 @@ class ShardConsumer {
                                 checkpoint,
                                 recordProcessorCheckpointer,
                                 dataFetcher,
-                                taskBackoffTimeMillis);
+                                taskBackoffTimeMillis,
+                                streamConfig);
                 break;
             case PROCESSING:
                 nextTask =

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardSyncTask.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardSyncTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2013 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Amazon Software License (the "License").
  * You may not use this file except in compliance with the License.
@@ -33,7 +33,7 @@ class ShardSyncTask implements ITask {
 
     private final IKinesisProxy kinesisProxy;
     private final ILeaseManager<KinesisClientLease> leaseManager;
-    private InitialPositionInStream initialPosition;
+    private InitialPositionInStreamExtended initialPosition;
     private final boolean cleanupLeasesUponShardCompletion;
     private final long shardSyncTaskIdleTimeMillis;
     private final TaskType taskType = TaskType.SHARDSYNC;
@@ -41,13 +41,13 @@ class ShardSyncTask implements ITask {
     /**
      * @param kinesisProxy Used to fetch information about the stream (e.g. shard list)
      * @param leaseManager Used to fetch and create leases
-     * @param initialPosition One of LATEST or TRIM_HORIZON. Amazon Kinesis Client Library will start processing records
-     *        from this point in the stream (when an application starts up for the first time) except for shards that
-     *        already have a checkpoint (and their descendant shards).
+     * @param initialPositionInStream One of LATEST, TRIM_HORIZON or AT_TIMESTAMP. Amazon Kinesis Client Library will
+     *        start processing records from this point in the stream (when an application starts up for the first time)
+     *        except for shards that already have a checkpoint (and their descendant shards).
      */
     ShardSyncTask(IKinesisProxy kinesisProxy,
             ILeaseManager<KinesisClientLease> leaseManager,
-            InitialPositionInStream initialPositionInStream,
+            InitialPositionInStreamExtended initialPositionInStream,
             boolean cleanupLeasesUponShardCompletion,
             long shardSyncTaskIdleTimeMillis) {
         this.kinesisProxy = kinesisProxy;

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardSyncTaskManager.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardSyncTaskManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2013 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Amazon Software License (the "License").
  * You may not use this file except in compliance with the License.
@@ -42,7 +42,7 @@ class ShardSyncTaskManager {
     private final ILeaseManager<KinesisClientLease> leaseManager;
     private final IMetricsFactory metricsFactory;
     private final ExecutorService executorService;
-    private final InitialPositionInStream initialPositionInStream;
+    private final InitialPositionInStreamExtended initialPositionInStream;
     private boolean cleanupLeasesUponShardCompletion;
     private final long shardSyncIdleTimeMillis;
 
@@ -61,7 +61,7 @@ class ShardSyncTaskManager {
      */
     ShardSyncTaskManager(final IKinesisProxy kinesisProxy,
             final ILeaseManager<KinesisClientLease> leaseManager,
-            final InitialPositionInStream initialPositionInStream,
+            final InitialPositionInStreamExtended initialPositionInStream,
             final boolean cleanupLeasesUponShardCompletion,
             final long shardSyncIdleTimeMillis,
             final IMetricsFactory metricsFactory,

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShutdownTask.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShutdownTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Amazon Software License (the "License").
  * You may not use this file except in compliance with the License.
@@ -42,7 +42,7 @@ class ShutdownTask implements ITask {
     private final ShutdownReason reason;
     private final IKinesisProxy kinesisProxy;
     private final ILeaseManager<KinesisClientLease> leaseManager;
-    private final InitialPositionInStream initialPositionInStream;
+    private final InitialPositionInStreamExtended initialPositionInStream;
     private final boolean cleanupLeasesOfCompletedShards;
     private final TaskType taskType = TaskType.SHUTDOWN;
     private final long backoffTimeMillis;
@@ -56,7 +56,7 @@ class ShutdownTask implements ITask {
             RecordProcessorCheckpointer recordProcessorCheckpointer,
             ShutdownReason reason,
             IKinesisProxy kinesisProxy,
-            InitialPositionInStream initialPositionInStream,
+            InitialPositionInStreamExtended initialPositionInStream,
             boolean cleanupLeasesOfCompletedShards,
             ILeaseManager<KinesisClientLease> leaseManager,
             long backoffTimeMillis) {

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/StreamConfig.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/StreamConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2014 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Amazon Software License (the "License").
  * You may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@ class StreamConfig {
     private final int maxRecords;
     private final long idleTimeInMilliseconds;
     private final boolean callProcessRecordsEvenForEmptyRecordList;
-    private InitialPositionInStream initialPositionInStream;
+    private InitialPositionInStreamExtended initialPositionInStream;
     private final boolean validateSequenceNumberBeforeCheckpointing;
 
     /**
@@ -42,7 +42,7 @@ class StreamConfig {
             long idleTimeInMilliseconds,
             boolean callProcessRecordsEvenForEmptyRecordList,
             boolean validateSequenceNumberBeforeCheckpointing,
-            InitialPositionInStream initialPositionInStream) {
+            InitialPositionInStreamExtended initialPositionInStream) {
         this.streamProxy = proxy;
         this.maxRecords = maxRecords;
         this.idleTimeInMilliseconds = idleTimeInMilliseconds;
@@ -82,7 +82,7 @@ class StreamConfig {
     /**
      * @return the initialPositionInStream
      */
-    InitialPositionInStream getInitialPositionInStream() {
+    InitialPositionInStreamExtended getInitialPositionInStream() {
         return initialPositionInStream;
     }
 
@@ -92,5 +92,4 @@ class StreamConfig {
     boolean shouldValidateSequenceNumberBeforeCheckpointing() {
         return validateSequenceNumberBeforeCheckpointing;
     }
-
 }

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/Worker.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/Worker.java
@@ -64,7 +64,7 @@ public class Worker implements Runnable {
     private final String applicationName;
     private final IRecordProcessorFactory recordProcessorFactory;
     private final StreamConfig streamConfig;
-    private final InitialPositionInStream initialPosition;
+    private final InitialPositionInStreamExtended initialPosition;
     private final ICheckpoint checkpointTracker;
     private final long idleTimeInMilliseconds;
     // Backoff time when polling to check if application has finished processing
@@ -212,8 +212,8 @@ public class Worker implements Runnable {
                         config.getMaxRecords(), config.getIdleTimeBetweenReadsInMillis(),
                         config.shouldCallProcessRecordsEvenForEmptyRecordList(),
                         config.shouldValidateSequenceNumberBeforeCheckpointing(),
-                        config.getInitialPositionInStream()),
-                config.getInitialPositionInStream(),
+                        config.getInitialPositionInStreamExtended()),
+                config.getInitialPositionInStreamExtended(),
                 config.getParentShardPollIntervalMillis(),
                 config.getShardSyncIntervalMillis(),
                 config.shouldCleanupLeasesUponShardCompletion(),
@@ -258,9 +258,9 @@ public class Worker implements Runnable {
      * @param applicationName Name of the Kinesis application
      * @param recordProcessorFactory Used to get record processor instances for processing data from shards
      * @param streamConfig Stream configuration
-     * @param initialPositionInStream One of LATEST or TRIM_HORIZON. The KinesisClientLibrary will start fetching data
-     *        from this location in the stream when an application starts up for the first time and there are no
-     *        checkpoints. If there are checkpoints, we start from the checkpoint position.
+     * @param initialPositionInStream One of LATEST, TRIM_HORIZON, or AT_TIMESTAMP. The KinesisClientLibrary will start
+     *        fetching data from this location in the stream when an application starts up for the first time and
+     *        there are no checkpoints. If there are checkpoints, we start from the checkpoint position.
      * @param parentShardPollIntervalMillis Wait for this long between polls to check if parent shards are done
      * @param shardSyncIdleTimeMillis Time between tasks to sync leases and Kinesis shards
      * @param cleanupLeasesUponShardCompletion Clean up shards we've finished processing (don't wait till they expire in
@@ -277,7 +277,7 @@ public class Worker implements Runnable {
     Worker(String applicationName,
             IRecordProcessorFactory recordProcessorFactory,
             StreamConfig streamConfig,
-            InitialPositionInStream initialPositionInStream,
+            InitialPositionInStreamExtended initialPositionInStream,
             long parentShardPollIntervalMillis,
             long shardSyncIdleTimeMillis,
             boolean cleanupLeasesUponShardCompletion,
@@ -946,8 +946,8 @@ public class Worker implements Runnable {
                             config.getIdleTimeBetweenReadsInMillis(),
                             config.shouldCallProcessRecordsEvenForEmptyRecordList(),
                             config.shouldValidateSequenceNumberBeforeCheckpointing(),
-                            config.getInitialPositionInStream()),
-                    config.getInitialPositionInStream(),
+                            config.getInitialPositionInStreamExtended()),
+                    config.getInitialPositionInStreamExtended(),
                     config.getParentShardPollIntervalMillis(),
                     config.getShardSyncIntervalMillis(),
                     config.shouldCleanupLeasesUponShardCompletion(),

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/proxies/IKinesisProxy.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/proxies/IKinesisProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2013 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Amazon Software License (the "License").
  * You may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
 package com.amazonaws.services.kinesis.clientlibrary.proxies;
 
 import java.nio.ByteBuffer;
+import java.util.Date;
 import java.util.List;
 import java.util.Set;
 
@@ -72,7 +73,16 @@ public interface IKinesisProxy {
 
     /**
      * Fetch a shard iterator from the specified position in the shard.
-     * 
+     * This is to fetch a shard iterator for ShardIteratorType AT_SEQUENCE_NUMBER or AFTER_SEQUENCE_NUMBER which
+     * requires the starting sequence number.
+     *
+     * NOTE: Currently this method continues to fetch iterators for ShardIteratorTypes TRIM_HORIZON, LATEST,
+     * AT_SEQUENCE_NUMBER and AFTER_SEQUENCE_NUMBER.
+     * But this behavior will change in the next release, after which this method will only serve
+     * AT_SEQUENCE_NUMBER or AFTER_SEQUENCE_NUMBER ShardIteratorTypes.
+     * We recommend users who call this method directly to use the appropriate getIterator method based on the
+     * ShardIteratorType.
+     *
      * @param shardId Shard id
      * @param iteratorEnum one of: TRIM_HORIZON, LATEST, AT_SEQUENCE_NUMBER, AFTER_SEQUENCE_NUMBER
      * @param sequenceNumber the sequence number - must be null unless iteratorEnum is AT_SEQUENCE_NUMBER or
@@ -83,6 +93,31 @@ public interface IKinesisProxy {
      */
     String getIterator(String shardId, String iteratorEnum, String sequenceNumber)
         throws ResourceNotFoundException, InvalidArgumentException;
+
+    /**
+     * Fetch a shard iterator from the specified position in the shard.
+     * This is to fetch a shard iterator for ShardIteratorType LATEST or TRIM_HORIZON which doesn't require a starting
+     * sequence number.
+     *
+     * @param shardId Shard id
+     * @param iteratorEnum Either TRIM_HORIZON or LATEST.
+     * @return shard iterator which can be used to read data from Kinesis.
+     * @throws ResourceNotFoundException The Kinesis stream or shard was not found
+     * @throws InvalidArgumentException Invalid input parameters
+     */
+    String getIterator(String shardId, String iteratorEnum) throws ResourceNotFoundException, InvalidArgumentException;
+
+    /**
+     * Fetch a shard iterator from the specified position in the shard.
+     * This is to fetch a shard iterator for ShardIteratorType AT_TIMESTAMP which requires the timestamp field.
+     *
+     * @param shardId   Shard id
+     * @param timestamp The timestamp.
+     * @return shard iterator which can be used to read data from Kinesis.
+     * @throws ResourceNotFoundException The Kinesis stream or shard was not found
+     * @throws InvalidArgumentException  Invalid input parameters
+     */
+    String getIterator(String shardId, Date timestamp) throws ResourceNotFoundException, InvalidArgumentException;
 
     /**
      * @param sequenceNumberForOrdering (optional) used for record ordering

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/proxies/KinesisProxy.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/proxies/KinesisProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Amazon Software License (the "License").
  * You may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@ package com.amazonaws.services.kinesis.clientlibrary.proxies;
 
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -40,6 +41,7 @@ import com.amazonaws.services.kinesis.model.PutRecordRequest;
 import com.amazonaws.services.kinesis.model.PutRecordResult;
 import com.amazonaws.services.kinesis.model.ResourceNotFoundException;
 import com.amazonaws.services.kinesis.model.Shard;
+import com.amazonaws.services.kinesis.model.ShardIteratorType;
 import com.amazonaws.services.kinesis.model.StreamStatus;
 
 /**
@@ -263,12 +265,50 @@ public class KinesisProxy implements IKinesisProxyExtended {
      */
     @Override
     public String getIterator(String shardId, String iteratorType, String sequenceNumber) {
+        if (!iteratorType.equals(ShardIteratorType.AT_SEQUENCE_NUMBER.toString()) || !iteratorType.equals(
+                ShardIteratorType.AFTER_SEQUENCE_NUMBER.toString())) {
+            LOG.info("This method should only be used for AT_SEQUENCE_NUMBER and AFTER_SEQUENCE_NUMBER "
+                    + "ShardIteratorTypes. For methods to use with other ShardIteratorTypes, see IKinesisProxy.java");
+        }
         final GetShardIteratorRequest getShardIteratorRequest = new GetShardIteratorRequest();
         getShardIteratorRequest.setRequestCredentials(credentialsProvider.getCredentials());
         getShardIteratorRequest.setStreamName(streamName);
         getShardIteratorRequest.setShardId(shardId);
         getShardIteratorRequest.setShardIteratorType(iteratorType);
         getShardIteratorRequest.setStartingSequenceNumber(sequenceNumber);
+        getShardIteratorRequest.setTimestamp(null);
+        final GetShardIteratorResult response = client.getShardIterator(getShardIteratorRequest);
+        return response.getShardIterator();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getIterator(String shardId, String iteratorType) {
+        final GetShardIteratorRequest getShardIteratorRequest = new GetShardIteratorRequest();
+        getShardIteratorRequest.setRequestCredentials(credentialsProvider.getCredentials());
+        getShardIteratorRequest.setStreamName(streamName);
+        getShardIteratorRequest.setShardId(shardId);
+        getShardIteratorRequest.setShardIteratorType(iteratorType);
+        getShardIteratorRequest.setStartingSequenceNumber(null);
+        getShardIteratorRequest.setTimestamp(null);
+        final GetShardIteratorResult response = client.getShardIterator(getShardIteratorRequest);
+        return response.getShardIterator();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getIterator(String shardId, Date timestamp) {
+        final GetShardIteratorRequest getShardIteratorRequest = new GetShardIteratorRequest();
+        getShardIteratorRequest.setRequestCredentials(credentialsProvider.getCredentials());
+        getShardIteratorRequest.setStreamName(streamName);
+        getShardIteratorRequest.setShardId(shardId);
+        getShardIteratorRequest.setShardIteratorType(ShardIteratorType.AT_TIMESTAMP);
+        getShardIteratorRequest.setStartingSequenceNumber(null);
+        getShardIteratorRequest.setTimestamp(timestamp);
         final GetShardIteratorResult response = client.getShardIterator(getShardIteratorRequest);
         return response.getShardIterator();
     }

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/proxies/MetricsCollectingKinesisProxyDecorator.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/proxies/MetricsCollectingKinesisProxyDecorator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Amazon Software License (the "License").
  * You may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
 package com.amazonaws.services.kinesis.clientlibrary.proxies;
 
 import java.nio.ByteBuffer;
+import java.util.Date;
 import java.util.List;
 import java.util.Set;
 
@@ -121,6 +122,40 @@ public class MetricsCollectingKinesisProxyDecorator implements IKinesisProxy {
         boolean success = false;
         try {
             String response = other.getIterator(shardId, iteratorEnum, sequenceNumber);
+            success = true;
+            return response;
+        } finally {
+            MetricsHelper.addSuccessAndLatency(getIteratorMetric, startTime, success, MetricsLevel.DETAILED);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getIterator(String shardId, String iteratorEnum)
+        throws ResourceNotFoundException, InvalidArgumentException {
+        long startTime = System.currentTimeMillis();
+        boolean success = false;
+        try {
+            String response = other.getIterator(shardId, iteratorEnum);
+            success = true;
+            return response;
+        } finally {
+            MetricsHelper.addSuccessAndLatency(getIteratorMetric, startTime, success, MetricsLevel.DETAILED);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getIterator(String shardId, Date timestamp)
+        throws ResourceNotFoundException, InvalidArgumentException {
+        long startTime = System.currentTimeMillis();
+        boolean success = false;
+        try {
+            String response = other.getIterator(shardId, timestamp);
             success = true;
             return response;
         } finally {

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/types/ExtendedSequenceNumber.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/types/ExtendedSequenceNumber.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2014 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Amazon Software License (the "License").
  * You may not use this file except in compliance with the License.
@@ -36,9 +36,10 @@ public class ExtendedSequenceNumber implements Comparable<ExtendedSequenceNumber
     private final String sequenceNumber;
     private final long subSequenceNumber;
 
-    // Define TRIM_HORIZON and LATEST to be less than all sequence numbers
+    // Define TRIM_HORIZON, LATEST, and AT_TIMESTAMP to be less than all sequence numbers
     private static final BigInteger TRIM_HORIZON_BIG_INTEGER_VALUE = BigInteger.valueOf(-2);
     private static final BigInteger LATEST_BIG_INTEGER_VALUE = BigInteger.valueOf(-1);
+    private static final BigInteger AT_TIMESTAMP_BIG_INTEGER_VALUE = BigInteger.valueOf(-3);
 
     /**
      * Special value for LATEST.
@@ -57,6 +58,12 @@ public class ExtendedSequenceNumber implements Comparable<ExtendedSequenceNumber
      */
     public static final ExtendedSequenceNumber TRIM_HORIZON = 
             new ExtendedSequenceNumber(SentinelCheckpoint.TRIM_HORIZON.toString());
+
+    /**
+     * Special value for AT_TIMESTAMP.
+     */
+    public static final ExtendedSequenceNumber AT_TIMESTAMP =
+            new ExtendedSequenceNumber(SentinelCheckpoint.AT_TIMESTAMP.toString());
 
     /**
      * Construct an ExtendedSequenceNumber. The sub-sequence number defaults to
@@ -87,7 +94,7 @@ public class ExtendedSequenceNumber implements Comparable<ExtendedSequenceNumber
      * Compares this with another ExtendedSequenceNumber using these rules.
      * 
      * SHARD_END is considered greatest
-     * TRIM_HORIZON and LATEST are considered less than sequence numbers
+     * TRIM_HORIZON, LATEST and AT_TIMESTAMP are considered less than sequence numbers
      * sequence numbers are given their big integer value
      * 
      * @param extendedSequenceNumber The ExtendedSequenceNumber to compare against
@@ -183,8 +190,8 @@ public class ExtendedSequenceNumber implements Comparable<ExtendedSequenceNumber
     /**
      * Sequence numbers are converted, sentinels are given a value of -1. Note this method is only used after special
      * logic associated with SHARD_END and the case of comparing two sentinel values has already passed, so we map
-     * sentinel values LATEST and TRIM_HORIZON to negative numbers so that they are considered less than sequence
-     * numbers.
+     * sentinel values LATEST, TRIM_HORIZON and AT_TIMESTAMP to negative numbers so that they are considered less than
+     * sequence numbers.
      * 
      * @param sequenceNumber The string to convert to big integer value
      * @return a BigInteger value representation of the sequenceNumber
@@ -196,9 +203,11 @@ public class ExtendedSequenceNumber implements Comparable<ExtendedSequenceNumber
             return LATEST_BIG_INTEGER_VALUE;
         } else if (SentinelCheckpoint.TRIM_HORIZON.toString().equals(sequenceNumber)) {
             return TRIM_HORIZON_BIG_INTEGER_VALUE;
+        } else if (SentinelCheckpoint.AT_TIMESTAMP.toString().equals(sequenceNumber)) {
+            return AT_TIMESTAMP_BIG_INTEGER_VALUE;
         } else {
-            throw new IllegalArgumentException("Expected a string of digits, TRIM_HORIZON, or LATEST but received "
-                    + sequenceNumber);
+            throw new IllegalArgumentException("Expected a string of digits, TRIM_HORIZON, LATEST or AT_TIMESTAMP but "
+                    + "received " + sequenceNumber);
         }
     }
 

--- a/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/BlockOnParentShardTaskTest.java
+++ b/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/BlockOnParentShardTaskTest.java
@@ -30,7 +30,6 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import com.amazonaws.services.kinesis.clientlibrary.lib.checkpoint.SentinelCheckpoint;
 import com.amazonaws.services.kinesis.clientlibrary.types.ExtendedSequenceNumber;
 import com.amazonaws.services.kinesis.leases.exceptions.DependencyException;
 import com.amazonaws.services.kinesis.leases.exceptions.InvalidStateException;

--- a/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/KinesisClientLibConfigurationTest.java
+++ b/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/KinesisClientLibConfigurationTest.java
@@ -15,6 +15,10 @@
 package com.amazonaws.services.kinesis.clientlibrary.lib.worker;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import junit.framework.Assert;
 
 import org.junit.Test;
@@ -30,6 +34,8 @@ import com.amazonaws.services.kinesis.AmazonKinesisClient;
 import com.amazonaws.services.kinesis.clientlibrary.interfaces.IRecordProcessorFactory;
 import com.amazonaws.services.kinesis.metrics.interfaces.MetricsLevel;
 import com.google.common.collect.ImmutableSet;
+
+import java.util.Date;
 
 public class KinesisClientLibConfigurationTest {
     private static final long INVALID_LONG = 0L;
@@ -58,7 +64,7 @@ public class KinesisClientLibConfigurationTest {
                 new KinesisClientLibConfiguration(TEST_STRING,
                         TEST_STRING,
                         TEST_STRING,
-                        null,
+                        InitialPositionInStream.LATEST,
                         null,
                         null,
                         null,
@@ -95,7 +101,7 @@ public class KinesisClientLibConfigurationTest {
                         new KinesisClientLibConfiguration(TEST_STRING,
                                 TEST_STRING,
                                 TEST_STRING,
-                                null,
+                                InitialPositionInStream.LATEST,
                                 null,
                                 null,
                                 null,
@@ -128,7 +134,7 @@ public class KinesisClientLibConfigurationTest {
                         new KinesisClientLibConfiguration(TEST_STRING,
                                 TEST_STRING,
                                 TEST_STRING,
-                                null,
+                                InitialPositionInStream.LATEST,
                                 null,
                                 null,
                                 null,
@@ -345,5 +351,51 @@ public class KinesisClientLibConfigurationTest {
         config.withMetricsEnabledDimensions(ImmutableSet.of("WorkerIdentifier"));
         // Operation dimension should always be there.
         assertEquals(config.getMetricsEnabledDimensions(), ImmutableSet.of("Operation", "WorkerIdentifier"));
+    }
+
+    @Test
+    public void testKCLConfigurationWithInvalidInitialPositionInStream() {
+        KinesisClientLibConfiguration config;
+        try {
+            config = new KinesisClientLibConfiguration("TestApplication",
+                    "TestStream",
+                    null,
+                    "TestWorker").withInitialPositionInStream(InitialPositionInStream.AT_TIMESTAMP);
+            fail("Should have thrown");
+        } catch (Exception e) {
+            assertTrue(e instanceof IllegalArgumentException);
+        }
+
+        try {
+            config = new KinesisClientLibConfiguration("TestApplication",
+                    "TestStream",
+                    null, "TestWorker").withTimestampAtInitialPositionInStream(null);
+            fail("Should have thrown");
+        } catch (Exception e) {
+            assertTrue(e instanceof IllegalArgumentException);
+        }
+
+        try {
+            Date timestamp = new Date(1000L);
+            config = new KinesisClientLibConfiguration("TestApplication",
+                    "TestStream", null, "TestWorker").withTimestampAtInitialPositionInStream(timestamp);
+            assertEquals(config.getInitialPositionInStreamExtended().getInitialPositionInStream(),
+                    InitialPositionInStream.AT_TIMESTAMP);
+            assertEquals(config.getInitialPositionInStreamExtended().getTimestamp(), timestamp);
+        } catch (Exception e) {
+            fail("Should not have thrown");
+        }
+
+        try {
+            config = new KinesisClientLibConfiguration("TestApplication",
+                    "TestStream",
+                    null,
+                    "TestWorker").withInitialPositionInStream(InitialPositionInStream.LATEST);
+            assertEquals(config.getInitialPositionInStreamExtended().getInitialPositionInStream(),
+                    InitialPositionInStream.LATEST);
+            assertNull(config.getInitialPositionInStreamExtended().getTimestamp());
+        } catch (Exception e) {
+            fail("Should not have thrown");
+        }
     }
 }

--- a/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ProcessTaskTest.java
+++ b/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ProcessTaskTest.java
@@ -66,7 +66,8 @@ public class ProcessTaskTest {
     private final boolean callProcessRecordsForEmptyRecordList = true;
     // We don't want any of these tests to run checkpoint validation
     private final boolean skipCheckpointValidationValue = false;
-    private final InitialPositionInStream initialPositionInStream = InitialPositionInStream.LATEST;
+    private static final InitialPositionInStreamExtended INITIAL_POSITION_LATEST =
+            InitialPositionInStreamExtended.newInitialPosition(InitialPositionInStream.LATEST);
 
     private @Mock KinesisDataFetcher mockDataFetcher;
     private @Mock IRecordProcessor mockRecordProcessor;
@@ -84,7 +85,8 @@ public class ProcessTaskTest {
         // Set up process task
         final StreamConfig config =
                 new StreamConfig(null, maxRecords, idleTimeMillis, callProcessRecordsForEmptyRecordList,
-                        skipCheckpointValidationValue, initialPositionInStream);
+                        skipCheckpointValidationValue,
+                        INITIAL_POSITION_LATEST);
         final ShardInfo shardInfo = new ShardInfo(shardId, null, null);
         processTask = new ProcessTask(
                 shardInfo, config, mockRecordProcessor, mockCheckpointer, mockDataFetcher, taskBackoffTimeMillis);

--- a/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/SequenceNumberValidatorTest.java
+++ b/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/SequenceNumberValidatorTest.java
@@ -86,9 +86,9 @@ public class SequenceNumberValidatorTest {
             IKinesisProxy proxy,
             boolean validateWithGetIterator) {
 
-        String[] nonNumericStrings =
-        { null, "bogus-sequence-number", SentinelCheckpoint.LATEST.toString(),
-                SentinelCheckpoint.SHARD_END.toString(), SentinelCheckpoint.TRIM_HORIZON.toString() };
+        String[] nonNumericStrings = { null, "bogus-sequence-number", SentinelCheckpoint.LATEST.toString(),
+                SentinelCheckpoint.SHARD_END.toString(), SentinelCheckpoint.TRIM_HORIZON.toString(),
+                SentinelCheckpoint.AT_TIMESTAMP.toString() };
 
         for (String nonNumericString : nonNumericStrings) {
             try {

--- a/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardSyncTaskIntegrationTest.java
+++ b/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardSyncTaskIntegrationTest.java
@@ -120,8 +120,11 @@ public class ShardSyncTaskIntegrationTest {
         }
         leaseManager.deleteAll();
         Set<String> shardIds = kinesisProxy.getAllShardIds();
-        ShardSyncTask syncTask =
-                new ShardSyncTask(kinesisProxy, leaseManager, InitialPositionInStream.LATEST, false, 0L);
+        ShardSyncTask syncTask = new ShardSyncTask(kinesisProxy,
+                leaseManager,
+                InitialPositionInStreamExtended.newInitialPosition(InitialPositionInStream.LATEST),
+                false,
+                0L);
         syncTask.call();
         List<KinesisClientLease> leases = leaseManager.listLeases();
         Set<String> leaseKeys = new HashSet<String>();

--- a/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShutdownTaskTest.java
+++ b/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShutdownTaskTest.java
@@ -42,6 +42,9 @@ import com.amazonaws.services.kinesis.leases.interfaces.ILeaseManager;
  */
 public class ShutdownTaskTest {
     private static final long TASK_BACKOFF_TIME_MILLIS = 1L;
+    private static final InitialPositionInStreamExtended INITIAL_POSITION_TRIM_HORIZON =
+            InitialPositionInStreamExtended.newInitialPosition(InitialPositionInStream.TRIM_HORIZON);
+
     Set<String> defaultParentShardIds = new HashSet<>();
     String defaultConcurrencyToken = "testToken4398";
     String defaultShardId = "shardId-0000397840";
@@ -88,16 +91,15 @@ public class ShutdownTaskTest {
         IKinesisProxy kinesisProxy = mock(IKinesisProxy.class);
         ILeaseManager<KinesisClientLease> leaseManager = mock(KinesisClientLeaseManager.class);
         boolean cleanupLeasesOfCompletedShards = false;
-        ShutdownTask task =
-                new ShutdownTask(defaultShardInfo,
-                        defaultRecordProcessor,
-                        checkpointer,
-                        ShutdownReason.TERMINATE,
-                        kinesisProxy,
-                        InitialPositionInStream.TRIM_HORIZON,
-                        cleanupLeasesOfCompletedShards ,
-                        leaseManager,
-                        TASK_BACKOFF_TIME_MILLIS);
+        ShutdownTask task = new ShutdownTask(defaultShardInfo,
+                defaultRecordProcessor,
+                checkpointer,
+                ShutdownReason.TERMINATE,
+                kinesisProxy,
+                INITIAL_POSITION_TRIM_HORIZON,
+                cleanupLeasesOfCompletedShards,
+                leaseManager,
+                TASK_BACKOFF_TIME_MILLIS);
         TaskResult result = task.call();
         Assert.assertNotNull(result.getException());
         Assert.assertTrue(result.getException() instanceof IllegalArgumentException);
@@ -114,16 +116,15 @@ public class ShutdownTaskTest {
         when(kinesisProxy.getShardList()).thenReturn(null);
         ILeaseManager<KinesisClientLease> leaseManager = mock(KinesisClientLeaseManager.class);
         boolean cleanupLeasesOfCompletedShards = false;
-        ShutdownTask task =
-                new ShutdownTask(defaultShardInfo,
-                        defaultRecordProcessor,
-                        checkpointer,
-                        ShutdownReason.TERMINATE,
-                        kinesisProxy,
-                        InitialPositionInStream.TRIM_HORIZON,
-                        cleanupLeasesOfCompletedShards ,
-                        leaseManager,
-                        TASK_BACKOFF_TIME_MILLIS);
+        ShutdownTask task = new ShutdownTask(defaultShardInfo,
+                defaultRecordProcessor,
+                checkpointer,
+                ShutdownReason.TERMINATE,
+                kinesisProxy,
+                INITIAL_POSITION_TRIM_HORIZON,
+                cleanupLeasesOfCompletedShards,
+                leaseManager,
+                TASK_BACKOFF_TIME_MILLIS);
         TaskResult result = task.call();
         Assert.assertNotNull(result.getException());
         Assert.assertTrue(result.getException() instanceof KinesisClientLibIOException);

--- a/src/test/java/com/amazonaws/services/kinesis/clientlibrary/proxies/util/KinesisLocalFileDataCreator.java
+++ b/src/test/java/com/amazonaws/services/kinesis/clientlibrary/proxies/util/KinesisLocalFileDataCreator.java
@@ -51,6 +51,17 @@ public class KinesisLocalFileDataCreator {
     private static final int PARTITION_KEY_LENGTH = 10;
     private static final int DATA_LENGTH = 40;
 
+    /**
+     * Starting timestamp - also referenced in KinesisLocalFileProxyTest.
+     */
+    public static final long STARTING_TIMESTAMP = 1462345678910L;
+
+    /**
+     * This is used to allow few records to have the same timestamps (to mimic real life scenarios).
+     * Records 5n-1 and 5n will have the same timestamp (n > 0).
+     */
+    private static final int DIVISOR = 5;
+
     private KinesisLocalFileDataCreator() {
     }
 
@@ -96,6 +107,7 @@ public class KinesisLocalFileDataCreator {
             fileWriter.write(serializedShardList);
             fileWriter.newLine();
             BigInteger sequenceNumberIncrement = new BigInteger("0");
+            long timestamp = STARTING_TIMESTAMP;
             for (int i = 0; i < numRecordsPerShard; i++) {
                 for (Shard shard : shardList) {
                     BigInteger sequenceNumber =
@@ -112,7 +124,12 @@ public class KinesisLocalFileDataCreator {
                     String partitionKey =
                             PARTITION_KEY_PREFIX + shard.getShardId() + generateRandomString(PARTITION_KEY_LENGTH);
                     String data = generateRandomString(DATA_LENGTH);
-                    String line = shard.getShardId() + "," + sequenceNumber + "," + partitionKey + "," + data;
+
+                    // Allow few records to have the same timestamps (to mimic real life scenarios).
+                    timestamp = (i % DIVISOR == 0) ? timestamp : timestamp + 1;
+                    String line = shard.getShardId() + "," + sequenceNumber + "," + partitionKey + "," + data + ","
+                            + timestamp;
+
                     fileWriter.write(line);
                     fileWriter.newLine();
                     sequenceNumberIncrement = sequenceNumberIncrement.add(BigInteger.ONE);


### PR DESCRIPTION
### Preliminary Release Notes
* Add support for time based iterators ([See GetShardIterator Documentation](http://docs.aws.amazon.com/kinesis/latest/APIReference/API_GetShardIterator.html))  
  The `KinesisClientLibConfiguration` now supports providing an initial time stamp position.
  * This position is only used if there is no current checkpoint for the shard.
  * This setting cannot be used with DynamoDB Streams
  Resolves [Issue #88](https://github.com/awslabs/amazon-kinesis-client/issues/88)