### PR TITLE
Allow Prioritization of Parent Shard Tasks

### DIFF
--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/KinesisClientLibConfiguration.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/KinesisClientLibConfiguration.java
@@ -154,6 +154,10 @@ public class KinesisClientLibConfiguration {
      */
     public static final int DEFAULT_INITIAL_LEASE_TABLE_WRITE_CAPACITY = 10;
 
+    /**
+     * Default Shard prioritization strategy.
+     */
+    public static final ShardPrioritization DEFAULT_SHARD_PRIORITIZATION = new NoOpShardPrioritization();
 
     private String applicationName;
     private String tableName;
@@ -187,6 +191,7 @@ public class KinesisClientLibConfiguration {
     private int initialLeaseTableReadCapacity;
     private int initialLeaseTableWriteCapacity;
     private InitialPositionInStreamExtended initialPositionInStreamExtended;
+    private ShardPrioritization shardPrioritization;
 
     /**
      * Constructor.
@@ -333,6 +338,7 @@ public class KinesisClientLibConfiguration {
         this.initialLeaseTableWriteCapacity = DEFAULT_INITIAL_LEASE_TABLE_WRITE_CAPACITY;
         this.initialPositionInStreamExtended =
                 InitialPositionInStreamExtended.newInitialPosition(initialPositionInStream);
+        this.shardPrioritization = DEFAULT_SHARD_PRIORITIZATION;
     }
 
     // Check if value is positive, otherwise throw an exception
@@ -597,6 +603,13 @@ public class KinesisClientLibConfiguration {
      */
     public Date getTimestampAtInitialPositionInStream() {
         return initialPositionInStreamExtended.getTimestamp();
+    }
+
+    /**
+     * @return Shard prioritization strategy.
+     */
+    public ShardPrioritization getShardPrioritizationStrategy() {
+        return shardPrioritization;
     }
 
     // CHECKSTYLE:IGNORE HiddenFieldCheck FOR NEXT 190 LINES
@@ -911,6 +924,18 @@ public class KinesisClientLibConfiguration {
     public KinesisClientLibConfiguration withInitialLeaseTableWriteCapacity(int initialLeaseTableWriteCapacity) {
         checkIsValuePositive("initialLeaseTableWriteCapacity", initialLeaseTableWriteCapacity);
         this.initialLeaseTableWriteCapacity = initialLeaseTableWriteCapacity;
+        return this;
+    }
+
+    /**
+     * @param shardPrioritization Implementation of ShardPrioritization interface that should be used during processing.
+     * @return KinesisClientLibConfiguration
+     */
+    public KinesisClientLibConfiguration withShardPrioritizationStrategy(ShardPrioritization shardPrioritization) {
+        if (shardPrioritization == null) {
+            throw new IllegalArgumentException("shardPrioritization cannot be null");
+        }
+        this.shardPrioritization = shardPrioritization;
         return this;
     }
 }

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/KinesisClientLibLeaseCoordinator.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/KinesisClientLibLeaseCoordinator.java
@@ -209,7 +209,8 @@ class KinesisClientLibLeaseCoordinator extends LeaseCoordinator<KinesisClientLea
                         new ShardInfo(
                                 lease.getLeaseKey(), 
                                 lease.getConcurrencyToken().toString(), 
-                                parentShardIds);
+                                parentShardIds,
+                                lease.getCheckpoint());
                 assignments.add(assignment);
             }
         }

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/NoOpShardPrioritization.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/NoOpShardPrioritization.java
@@ -1,0 +1,21 @@
+package com.amazonaws.services.kinesis.clientlibrary.lib.worker;
+
+import java.util.List;
+
+/**
+ * Shard Prioritization that returns the same original list of shards without any modifications.
+ */
+public class NoOpShardPrioritization implements
+        ShardPrioritization {
+
+    /**
+     * Empty constructor for NoOp Shard Prioritization.
+     */
+    public NoOpShardPrioritization() {
+    }
+
+    @Override
+    public List<ShardInfo> prioritize(List<ShardInfo> original) {
+        return original;
+    }
+}

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ParentsFirstShardPrioritization.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ParentsFirstShardPrioritization.java
@@ -1,0 +1,135 @@
+package com.amazonaws.services.kinesis.clientlibrary.lib.worker;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Shard Prioritization that prioritizes parent shards first.
+ * It also limits number of shards that will be available for initialization based on their depth.
+ * It doesn't make a lot of sense to work on a shard that has too many unfinished parents.
+ */
+public class ParentsFirstShardPrioritization implements
+        ShardPrioritization {
+    private static final SortingNode PROCESSING_NODE = new SortingNode(null, Integer.MIN_VALUE);
+
+    private final int maxDepth;
+
+    /**
+     * Creates ParentFirst prioritization with filtering based on depth of the shard.
+     * Shards that have depth > maxDepth will be ignored and will not be returned by this prioritization.
+     * 
+     * @param maxDepth any shard that is deeper than max depth, will be excluded from processing
+     */
+    public ParentsFirstShardPrioritization(int maxDepth) {
+        /* Depth 0 means that shard is completed or cannot be found,
+        * it is impossible to process such shards.
+        */
+        if (maxDepth <= 0) {
+            throw new IllegalArgumentException("Max depth cannot be negative or zero. Provided value: " + maxDepth);
+        }
+        this.maxDepth = maxDepth;
+    }
+
+    @Override
+    public List<ShardInfo> prioritize(List<ShardInfo> original) {
+        Map<String, ShardInfo> shards = new HashMap<>();
+        for (ShardInfo shardInfo : original) {
+            shards.put(shardInfo.getShardId(),
+                    shardInfo);
+        }
+
+        Map<String, SortingNode> processedNodes = new HashMap<>();
+
+        for (ShardInfo shardInfo : original) {
+            populateDepth(shardInfo.getShardId(),
+                    shards,
+                    processedNodes);
+        }
+
+        List<ShardInfo> orderedInfos = new ArrayList<>(original.size());
+
+        List<SortingNode> orderedNodes = new ArrayList<>(processedNodes.values());
+        Collections.sort(orderedNodes);
+
+        for (SortingNode sortingTreeNode : orderedNodes) {
+            // don't process shards with depth > maxDepth
+            if (sortingTreeNode.getDepth() <= maxDepth) {
+                orderedInfos.add(sortingTreeNode.shardInfo);
+            }
+        }
+        return orderedInfos;
+    }
+
+    private int populateDepth(String shardId,
+            Map<String, ShardInfo> shards,
+            Map<String, SortingNode> processedNodes) {
+        SortingNode processed = processedNodes.get(shardId);
+        if (processed != null) {
+            if (processed == PROCESSING_NODE) {
+                throw new IllegalArgumentException("Circular dependency detected. Shard Id "
+                    + shardId + " is processed twice");
+            }
+            return processed.getDepth();
+        }
+
+        ShardInfo shardInfo = shards.get(shardId);
+        if (shardInfo == null) {
+            // parent doesn't exist in our list, so this shard is root-level node
+            return 0;
+        }
+
+        if (shardInfo.isCompleted()) {
+            // we treat completed shards as 0-level
+            return 0;
+        }
+
+        // storing processing node to make sure we track progress and avoid circular dependencies
+        processedNodes.put(shardId, PROCESSING_NODE);
+
+        int maxParentDepth = 0;
+        for (String parentId : shardInfo.getParentShardIds()) {
+            maxParentDepth = Math.max(maxParentDepth,
+                    populateDepth(parentId,
+                            shards,
+                            processedNodes));
+        }
+
+        int currentNodeLevel = maxParentDepth + 1;
+        SortingNode previousValue = processedNodes.put(shardId,
+                new SortingNode(shardInfo,
+                        currentNodeLevel));
+        if (previousValue != PROCESSING_NODE) {
+            throw new IllegalStateException("Validation failed. Depth for shardId " + shardId + " was populated twice");
+        }
+
+        return currentNodeLevel;
+    }
+
+    /**
+     * Class to store depth of shards during prioritization.
+     */
+    private static class SortingNode implements
+            Comparable<SortingNode> {
+        private final ShardInfo shardInfo;
+        private final int depth;
+
+        public SortingNode(ShardInfo shardInfo,
+                int depth) {
+            this.shardInfo = shardInfo;
+            this.depth = depth;
+        }
+
+        public int getDepth() {
+            return depth;
+        }
+
+        @Override
+        public int compareTo(SortingNode o) {
+            return Integer.compare(depth,
+                    o.depth);
+        }
+    }
+}

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardPrioritization.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardPrioritization.java
@@ -1,0 +1,19 @@
+package com.amazonaws.services.kinesis.clientlibrary.lib.worker;
+
+import java.util.List;
+
+/**
+ * Provides logic to prioritize or filter shards before their execution.
+ */
+public interface ShardPrioritization {
+
+    /**
+     * Returns new list of shards ordered based on their priority.
+     * Resulted list may have fewer shards compared to original list
+     * 
+     * @param original
+     *            list of shards needed to be prioritized
+     * @return new list that contains only shards that should be processed
+     */
+    List<ShardInfo> prioritize(List<ShardInfo> original);
+}

--- a/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/BlockOnParentShardTaskTest.java
+++ b/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/BlockOnParentShardTaskTest.java
@@ -20,12 +20,11 @@ import static org.mockito.Mockito.when;
 import java.util.ArrayList;
 import java.util.List;
 
-import junit.framework.Assert;
-
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.junit.After;
 import org.junit.AfterClass;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -47,7 +46,7 @@ public class BlockOnParentShardTaskTest {
     private final String shardId = "shardId-97";
     private final String concurrencyToken = "testToken";
     private final List<String> emptyParentShardIds = new ArrayList<String>();
-    ShardInfo defaultShardInfo = new ShardInfo(shardId, concurrencyToken, emptyParentShardIds);
+    ShardInfo defaultShardInfo = new ShardInfo(shardId, concurrencyToken, emptyParentShardIds, ExtendedSequenceNumber.TRIM_HORIZON);
 
     /**
      * @throws java.lang.Exception
@@ -122,14 +121,14 @@ public class BlockOnParentShardTaskTest {
 
         // test single parent
         parentShardIds.add(parent1ShardId);
-        shardInfo = new ShardInfo(shardId, concurrencyToken, parentShardIds);
+        shardInfo = new ShardInfo(shardId, concurrencyToken, parentShardIds, ExtendedSequenceNumber.TRIM_HORIZON);
         task = new BlockOnParentShardTask(shardInfo, leaseManager, backoffTimeInMillis);
         result = task.call();
         Assert.assertNull(result.getException());
 
         // test two parents
         parentShardIds.add(parent2ShardId);
-        shardInfo = new ShardInfo(shardId, concurrencyToken, parentShardIds);
+        shardInfo = new ShardInfo(shardId, concurrencyToken, parentShardIds, ExtendedSequenceNumber.TRIM_HORIZON);
         task = new BlockOnParentShardTask(shardInfo, leaseManager, backoffTimeInMillis);
         result = task.call();
         Assert.assertNull(result.getException());
@@ -164,14 +163,14 @@ public class BlockOnParentShardTaskTest {
 
         // test single parent
         parentShardIds.add(parent1ShardId);
-        shardInfo = new ShardInfo(shardId, concurrencyToken, parentShardIds);
+        shardInfo = new ShardInfo(shardId, concurrencyToken, parentShardIds, ExtendedSequenceNumber.TRIM_HORIZON);
         task = new BlockOnParentShardTask(shardInfo, leaseManager, backoffTimeInMillis);
         result = task.call();
         Assert.assertNotNull(result.getException());
 
         // test two parents
         parentShardIds.add(parent2ShardId);
-        shardInfo = new ShardInfo(shardId, concurrencyToken, parentShardIds);
+        shardInfo = new ShardInfo(shardId, concurrencyToken, parentShardIds, ExtendedSequenceNumber.TRIM_HORIZON);
         task = new BlockOnParentShardTask(shardInfo, leaseManager, backoffTimeInMillis);
         result = task.call();
         Assert.assertNotNull(result.getException());
@@ -191,7 +190,7 @@ public class BlockOnParentShardTaskTest {
         String parentShardId = "shardId-1";
         List<String> parentShardIds = new ArrayList<>();
         parentShardIds.add(parentShardId);
-        ShardInfo shardInfo = new ShardInfo(shardId, concurrencyToken, parentShardIds);
+        ShardInfo shardInfo = new ShardInfo(shardId, concurrencyToken, parentShardIds, ExtendedSequenceNumber.TRIM_HORIZON);
         TaskResult result = null;
         KinesisClientLease parentLease = new KinesisClientLease();
         ILeaseManager<KinesisClientLease> leaseManager = mock(ILeaseManager.class);

--- a/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/KinesisDataFetcherTest.java
+++ b/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/KinesisDataFetcherTest.java
@@ -48,7 +48,7 @@ public class KinesisDataFetcherTest {
     private static final int MAX_RECORDS = 1;
     private static final String SHARD_ID = "shardId-1";
     private static final String AT_SEQUENCE_NUMBER = ShardIteratorType.AT_SEQUENCE_NUMBER.toString();
-    private static final ShardInfo SHARD_INFO = new ShardInfo(SHARD_ID, null, null);
+    private static final ShardInfo SHARD_INFO = new ShardInfo(SHARD_ID, null, null, null);
     private static final InitialPositionInStreamExtended INITIAL_POSITION_LATEST =
             InitialPositionInStreamExtended.newInitialPosition(InitialPositionInStream.LATEST);
     private static final InitialPositionInStreamExtended INITIAL_POSITION_TRIM_HORIZON =

--- a/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ParentsFirstShardPrioritizationUnitTest.java
+++ b/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ParentsFirstShardPrioritizationUnitTest.java
@@ -1,0 +1,162 @@
+package com.amazonaws.services.kinesis.clientlibrary.lib.worker;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
+
+import org.junit.Test;
+
+public class ParentsFirstShardPrioritizationUnitTest {
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testMaxDepthNegativeShouldFail() {
+        new ParentsFirstShardPrioritization(-1);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testMaxDepthZeroShouldFail() {
+        new ParentsFirstShardPrioritization(0);
+    }
+
+    @Test
+    public void testMaxDepthPositiveShouldNotFail() {
+        new ParentsFirstShardPrioritization(1);
+    }
+
+    @Test
+    public void testSorting() {
+        Random random = new Random(987654);
+        int numberOfShards = 7;
+
+        List<String> shardIdsDependencies = new ArrayList<>();
+        shardIdsDependencies.add("unknown");
+        List<ShardInfo> original = new ArrayList<>();
+        for (int shardNumber = 0; shardNumber < numberOfShards; shardNumber++) {
+            String shardId = shardId(shardNumber);
+            original.add(shardInfo(shardId, shardIdsDependencies));
+            shardIdsDependencies.add(shardId);
+        }
+
+        ParentsFirstShardPrioritization ordering = new ParentsFirstShardPrioritization(Integer.MAX_VALUE);
+
+        // shuffle original list as it is already ordered in right way
+        Collections.shuffle(original, random);
+        List<ShardInfo> ordered = ordering.prioritize(original);
+
+        assertEquals(numberOfShards, ordered.size());
+        for (int shardNumber = 0; shardNumber < numberOfShards; shardNumber++) {
+            String shardId = shardId(shardNumber);
+            assertEquals(shardId, ordered.get(shardNumber).getShardId());
+        }
+    }
+
+    @Test
+    public void testSortingAndFiltering() {
+        Random random = new Random(45677);
+        int numberOfShards = 10;
+
+        List<String> shardIdsDependencies = new ArrayList<>();
+        shardIdsDependencies.add("unknown");
+        List<ShardInfo> original = new ArrayList<>();
+        for (int shardNumber = 0; shardNumber < numberOfShards; shardNumber++) {
+            String shardId = shardId(shardNumber);
+            original.add(shardInfo(shardId, shardIdsDependencies));
+            shardIdsDependencies.add(shardId);
+        }
+
+        int maxDepth = 3;
+        ParentsFirstShardPrioritization ordering = new ParentsFirstShardPrioritization(maxDepth);
+
+        // shuffle original list as it is already ordered in right way
+        Collections.shuffle(original, random);
+        List<ShardInfo> ordered = ordering.prioritize(original);
+        // in this case every shard has its own level, so we don't expect to
+        // have more shards than max depth
+        assertEquals(maxDepth, ordered.size());
+
+        for (int shardNumber = 0; shardNumber < maxDepth; shardNumber++) {
+            String shardId = shardId(shardNumber);
+            assertEquals(shardId, ordered.get(shardNumber).getShardId());
+        }
+    }
+
+    @Test
+    public void testSimpleOrdering() {
+        Random random = new Random(1234);
+        int numberOfShards = 10;
+
+        String parentId = "unknown";
+        List<ShardInfo> original = new ArrayList<>();
+        for (int shardNumber = 0; shardNumber < numberOfShards; shardNumber++) {
+            String shardId = shardId(shardNumber);
+            original.add(shardInfo(shardId, parentId));
+            parentId = shardId;
+        }
+
+        ParentsFirstShardPrioritization ordering = new ParentsFirstShardPrioritization(Integer.MAX_VALUE);
+
+        // shuffle original list as it is already ordered in right way
+        Collections.shuffle(original, random);
+        List<ShardInfo> ordered = ordering.prioritize(original);
+        assertEquals(numberOfShards, ordered.size());
+        for (int shardNumber = 0; shardNumber < numberOfShards; shardNumber++) {
+            String shardId = shardId(shardNumber);
+            assertEquals(shardId, ordered.get(shardNumber).getShardId());
+        }
+    }
+
+    /**
+     * This should be impossible as shards don't have circular dependencies,
+     * but this code should handle it properly and fail
+     */
+    @Test
+    public void testCircularDependencyBetweenShards() {
+        Random random = new Random(13468798);
+        int numberOfShards = 10;
+
+        // shard-0 will point in middle shard (shard-5) in current test
+        String parentId = shardId(numberOfShards / 2);
+        List<ShardInfo> original = new ArrayList<>();
+        for (int shardNumber = 0; shardNumber < numberOfShards; shardNumber++) {
+            String shardId = shardId(shardNumber);
+            original.add(shardInfo(shardId, parentId));
+            parentId = shardId;
+        }
+
+        ParentsFirstShardPrioritization ordering = new ParentsFirstShardPrioritization(Integer.MAX_VALUE);
+
+        // shuffle original list as it is already ordered in right way
+        Collections.shuffle(original, random);
+        try {
+            ordering.prioritize(original);
+            fail("Processing should fail in case we have circular dependency");
+        } catch (IllegalArgumentException expected) {
+
+        }
+    }
+
+    private String shardId(int shardNumber) {
+        return "shardId-" + shardNumber;
+    }
+
+    private static ShardInfo shardInfo(String shardId, List<String> parentShardIds) {
+        // copy into new list just in case ShardInfo will stop doing it
+        List<String> newParentShardIds = new ArrayList<>(parentShardIds);
+        return new ShardInfo.Builder()
+                .withShardId(shardId)
+                .withParentShards(newParentShardIds)
+                .build();
+    }
+
+    private static ShardInfo shardInfo(String shardId, String... parentShardIds) {
+        return new ShardInfo.Builder()
+                .withShardId(shardId)
+                .withParentShards(Arrays.asList(parentShardIds))
+                .build();
+    }
+}

--- a/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ProcessTaskTest.java
+++ b/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ProcessTaskTest.java
@@ -87,7 +87,7 @@ public class ProcessTaskTest {
                 new StreamConfig(null, maxRecords, idleTimeMillis, callProcessRecordsForEmptyRecordList,
                         skipCheckpointValidationValue,
                         INITIAL_POSITION_LATEST);
-        final ShardInfo shardInfo = new ShardInfo(shardId, null, null);
+        final ShardInfo shardInfo = new ShardInfo(shardId, null, null, null);
         processTask = new ProcessTask(
                 shardInfo, config, mockRecordProcessor, mockCheckpointer, mockDataFetcher, taskBackoffTimeMillis);
     }

--- a/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/RecordProcessorCheckpointerTest.java
+++ b/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/RecordProcessorCheckpointerTest.java
@@ -75,7 +75,7 @@ public class RecordProcessorCheckpointerTest {
      */
     @Test
     public final void testCheckpoint() throws Exception {
-        ShardInfo shardInfo = new ShardInfo(shardId, testConcurrencyToken, null);
+        ShardInfo shardInfo = new ShardInfo(shardId, testConcurrencyToken, null, ExtendedSequenceNumber.TRIM_HORIZON);
 
         // First call to checkpoint
         RecordProcessorCheckpointer processingCheckpointer =
@@ -98,7 +98,7 @@ public class RecordProcessorCheckpointerTest {
      */    
     @Test
     public final void testCheckpointRecord() throws Exception {
-        ShardInfo shardInfo = new ShardInfo(shardId, testConcurrencyToken, null);
+        ShardInfo shardInfo = new ShardInfo(shardId, testConcurrencyToken, null, ExtendedSequenceNumber.TRIM_HORIZON);
         SequenceNumberValidator sequenceNumberValidator = 
                 new SequenceNumberValidator(null, shardId, false); 
     	RecordProcessorCheckpointer processingCheckpointer =
@@ -117,7 +117,7 @@ public class RecordProcessorCheckpointerTest {
      */
     @Test
     public final void testCheckpointSubRecord() throws Exception {
-        ShardInfo shardInfo = new ShardInfo(shardId, testConcurrencyToken, null);
+        ShardInfo shardInfo = new ShardInfo(shardId, testConcurrencyToken, null, ExtendedSequenceNumber.TRIM_HORIZON);
         SequenceNumberValidator sequenceNumberValidator = 
                 new SequenceNumberValidator(null, shardId, false); 
     	RecordProcessorCheckpointer processingCheckpointer =
@@ -137,7 +137,7 @@ public class RecordProcessorCheckpointerTest {
      */
     @Test
     public final void testCheckpointSequenceNumber() throws Exception {
-        ShardInfo shardInfo = new ShardInfo(shardId, testConcurrencyToken, null);
+        ShardInfo shardInfo = new ShardInfo(shardId, testConcurrencyToken, null, ExtendedSequenceNumber.TRIM_HORIZON);
         SequenceNumberValidator sequenceNumberValidator = 
                 new SequenceNumberValidator(null, shardId, false); 
     	RecordProcessorCheckpointer processingCheckpointer =
@@ -155,7 +155,7 @@ public class RecordProcessorCheckpointerTest {
      */
     @Test
     public final void testCheckpointExtendedSequenceNumber() throws Exception {
-        ShardInfo shardInfo = new ShardInfo(shardId, testConcurrencyToken, null);
+        ShardInfo shardInfo = new ShardInfo(shardId, testConcurrencyToken, null, ExtendedSequenceNumber.TRIM_HORIZON);
         SequenceNumberValidator sequenceNumberValidator = 
                 new SequenceNumberValidator(null, shardId, false); 
     	RecordProcessorCheckpointer processingCheckpointer =
@@ -173,7 +173,7 @@ public class RecordProcessorCheckpointerTest {
      */
     @Test
     public final void testUpdate() throws Exception {
-        ShardInfo shardInfo = new ShardInfo(shardId, testConcurrencyToken, null);
+        ShardInfo shardInfo = new ShardInfo(shardId, testConcurrencyToken, null, ExtendedSequenceNumber.TRIM_HORIZON);
 
         RecordProcessorCheckpointer checkpointer = new RecordProcessorCheckpointer(shardInfo, checkpoint, null);
 
@@ -193,7 +193,7 @@ public class RecordProcessorCheckpointerTest {
      */
     @Test
     public final void testClientSpecifiedCheckpoint() throws Exception {
-        ShardInfo shardInfo = new ShardInfo(shardId, testConcurrencyToken, null);
+        ShardInfo shardInfo = new ShardInfo(shardId, testConcurrencyToken, null, ExtendedSequenceNumber.TRIM_HORIZON);
 
         SequenceNumberValidator validator = mock(SequenceNumberValidator.class);
         Mockito.doNothing().when(validator).validateSequenceNumber(anyString());
@@ -290,7 +290,7 @@ public class RecordProcessorCheckpointerTest {
     @SuppressWarnings("serial")
     @Test
     public final void testMixedCheckpointCalls() throws Exception {
-        ShardInfo shardInfo = new ShardInfo(shardId, testConcurrencyToken, null);
+        ShardInfo shardInfo = new ShardInfo(shardId, testConcurrencyToken, null, ExtendedSequenceNumber.TRIM_HORIZON);
 
         SequenceNumberValidator validator = mock(SequenceNumberValidator.class);
         Mockito.doNothing().when(validator).validateSequenceNumber(anyString());

--- a/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardConsumerTest.java
+++ b/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardConsumerTest.java
@@ -92,7 +92,7 @@ public class ShardConsumerTest {
     @SuppressWarnings("unchecked")
     @Test
     public final void testInitializationStateUponFailure() throws Exception {
-        ShardInfo shardInfo = new ShardInfo("s-0-0", "testToken", null);
+        ShardInfo shardInfo = new ShardInfo("s-0-0", "testToken", null, ExtendedSequenceNumber.TRIM_HORIZON);
         ICheckpoint checkpoint = mock(ICheckpoint.class);
 
         when(checkpoint.getCheckpoint(anyString())).thenThrow(NullPointerException.class);
@@ -141,7 +141,7 @@ public class ShardConsumerTest {
     @SuppressWarnings("unchecked")
     @Test
     public final void testInitializationStateUponSubmissionFailure() throws Exception {
-        ShardInfo shardInfo = new ShardInfo("s-0-0", "testToken", null);
+        ShardInfo shardInfo = new ShardInfo("s-0-0", "testToken", null, ExtendedSequenceNumber.TRIM_HORIZON);
         ICheckpoint checkpoint = mock(ICheckpoint.class);
         ExecutorService spyExecutorService = spy(executorService);
 
@@ -189,7 +189,7 @@ public class ShardConsumerTest {
     @SuppressWarnings("unchecked")
     @Test
     public final void testRecordProcessorThrowable() throws Exception {
-        ShardInfo shardInfo = new ShardInfo("s-0-0", "testToken", null);
+        ShardInfo shardInfo = new ShardInfo("s-0-0", "testToken", null, ExtendedSequenceNumber.TRIM_HORIZON);
         ICheckpoint checkpoint = mock(ICheckpoint.class);
         IRecordProcessor processor = mock(IRecordProcessor.class);
         IKinesisProxy streamProxy = mock(IKinesisProxy.class);
@@ -289,7 +289,7 @@ public class ShardConsumerTest {
                         callProcessRecordsForEmptyRecordList,
                         skipCheckpointValidationValue, INITIAL_POSITION_LATEST);
 
-        ShardInfo shardInfo = new ShardInfo(streamShardId, testConcurrencyToken, null);
+        ShardInfo shardInfo = new ShardInfo(streamShardId, testConcurrencyToken, null, null);
         ShardConsumer consumer =
                 new ShardConsumer(shardInfo,
                         streamConfig,
@@ -379,7 +379,7 @@ public class ShardConsumerTest {
                         skipCheckpointValidationValue,
                         atTimestamp);
 
-        ShardInfo shardInfo = new ShardInfo(streamShardId, testConcurrencyToken, null);
+        ShardInfo shardInfo = new ShardInfo(streamShardId, testConcurrencyToken, null, ExtendedSequenceNumber.TRIM_HORIZON);
         ShardConsumer consumer =
                 new ShardConsumer(shardInfo,
                         streamConfig,

--- a/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardInfoTest.java
+++ b/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardInfoTest.java
@@ -20,10 +20,11 @@ import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 
-import junit.framework.Assert;
-
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+
+import com.amazonaws.services.kinesis.clientlibrary.types.ExtendedSequenceNumber;
 
 public class ShardInfoTest {
     private static final String CONCURRENCY_TOKEN = UUID.randomUUID().toString();
@@ -37,12 +38,12 @@ public class ShardInfoTest {
         parentShardIds.add("shard-1");
         parentShardIds.add("shard-2");
 
-        testShardInfo = new ShardInfo(SHARD_ID, CONCURRENCY_TOKEN, parentShardIds);
+        testShardInfo = new ShardInfo(SHARD_ID, CONCURRENCY_TOKEN, parentShardIds, ExtendedSequenceNumber.LATEST);
     }
 
     @Test
     public void testPacboyShardInfoEqualsWithSameArgs() {
-        ShardInfo equalShardInfo = new ShardInfo(SHARD_ID, CONCURRENCY_TOKEN, parentShardIds);
+        ShardInfo equalShardInfo = new ShardInfo(SHARD_ID, CONCURRENCY_TOKEN, parentShardIds, ExtendedSequenceNumber.LATEST);
         Assert.assertTrue("Equal should return true for arguments all the same", testShardInfo.equals(equalShardInfo));
     }
 
@@ -53,18 +54,18 @@ public class ShardInfoTest {
 
     @Test
     public void testPacboyShardInfoEqualsForShardId() {
-        ShardInfo diffShardInfo = new ShardInfo("shardId-diff", CONCURRENCY_TOKEN, parentShardIds);
+        ShardInfo diffShardInfo = new ShardInfo("shardId-diff", CONCURRENCY_TOKEN, parentShardIds, ExtendedSequenceNumber.LATEST);
         Assert.assertFalse("Equal should return false with different shard id", diffShardInfo.equals(testShardInfo));
-        diffShardInfo = new ShardInfo(null, CONCURRENCY_TOKEN, parentShardIds);
+        diffShardInfo = new ShardInfo(null, CONCURRENCY_TOKEN, parentShardIds, ExtendedSequenceNumber.LATEST);
         Assert.assertFalse("Equal should return false with null shard id", diffShardInfo.equals(testShardInfo));
     }
 
     @Test
     public void testPacboyShardInfoEqualsForfToken() {
-        ShardInfo diffShardInfo = new ShardInfo(SHARD_ID, UUID.randomUUID().toString(), parentShardIds);
+        ShardInfo diffShardInfo = new ShardInfo(SHARD_ID, UUID.randomUUID().toString(), parentShardIds, ExtendedSequenceNumber.LATEST);
         Assert.assertFalse("Equal should return false with different concurrency token",
                 diffShardInfo.equals(testShardInfo));
-        diffShardInfo = new ShardInfo(SHARD_ID, null, parentShardIds);
+        diffShardInfo = new ShardInfo(SHARD_ID, null, parentShardIds, ExtendedSequenceNumber.LATEST);
         Assert.assertFalse("Equal should return false for null concurrency token", diffShardInfo.equals(testShardInfo));
     }
 
@@ -74,7 +75,7 @@ public class ShardInfoTest {
         differentlyOrderedParentShardIds.add("shard-2");
         differentlyOrderedParentShardIds.add("shard-1");
         ShardInfo shardInfoWithDifferentlyOrderedParentShardIds =
-                new ShardInfo(SHARD_ID, CONCURRENCY_TOKEN, differentlyOrderedParentShardIds);
+                new ShardInfo(SHARD_ID, CONCURRENCY_TOKEN, differentlyOrderedParentShardIds, ExtendedSequenceNumber.LATEST);
         Assert.assertTrue("Equal should return true even with parent shard Ids reordered",
                 shardInfoWithDifferentlyOrderedParentShardIds.equals(testShardInfo));
     }
@@ -84,16 +85,24 @@ public class ShardInfoTest {
         Set<String> diffParentIds = new HashSet<>();
         diffParentIds.add("shard-3");
         diffParentIds.add("shard-4");
-        ShardInfo diffShardInfo = new ShardInfo(SHARD_ID, CONCURRENCY_TOKEN, diffParentIds);
+        ShardInfo diffShardInfo = new ShardInfo(SHARD_ID, CONCURRENCY_TOKEN, diffParentIds, ExtendedSequenceNumber.LATEST);
         Assert.assertFalse("Equal should return false with different parent shard Ids",
                 diffShardInfo.equals(testShardInfo));
-        diffShardInfo = new ShardInfo(SHARD_ID, CONCURRENCY_TOKEN, null);
+        diffShardInfo = new ShardInfo(SHARD_ID, CONCURRENCY_TOKEN, null, ExtendedSequenceNumber.LATEST);
         Assert.assertFalse("Equal should return false with null parent shard Ids", diffShardInfo.equals(testShardInfo));
     }
 
     @Test
+    public void testPacboyShardInfoEqualsForCheckpoint() {
+        ShardInfo diffShardInfo = new ShardInfo(SHARD_ID, CONCURRENCY_TOKEN, parentShardIds, ExtendedSequenceNumber.SHARD_END);
+        Assert.assertFalse("Equal should return false with different checkpoint", diffShardInfo.equals(testShardInfo));
+        diffShardInfo = new ShardInfo(SHARD_ID, CONCURRENCY_TOKEN, parentShardIds, null);
+        Assert.assertFalse("Equal should return false with null checkpoint", diffShardInfo.equals(testShardInfo));
+    }
+
+    @Test
     public void testPacboyShardInfoSameHashCode() {
-        ShardInfo equalShardInfo = new ShardInfo(SHARD_ID, CONCURRENCY_TOKEN, parentShardIds);
+        ShardInfo equalShardInfo = new ShardInfo(SHARD_ID, CONCURRENCY_TOKEN, parentShardIds, ExtendedSequenceNumber.LATEST);
         Assert.assertTrue("Shard info objects should have same hashCode for the same arguments",
                 equalShardInfo.hashCode() == testShardInfo.hashCode());
     }

--- a/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShutdownTaskTest.java
+++ b/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShutdownTaskTest.java
@@ -20,10 +20,9 @@ import static org.mockito.Mockito.when;
 import java.util.HashSet;
 import java.util.Set;
 
-import junit.framework.Assert;
-
 import org.junit.After;
 import org.junit.AfterClass;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -50,7 +49,8 @@ public class ShutdownTaskTest {
     String defaultShardId = "shardId-0000397840";
     ShardInfo defaultShardInfo = new ShardInfo(defaultShardId,
             defaultConcurrencyToken,
-            defaultParentShardIds);
+            defaultParentShardIds,
+            ExtendedSequenceNumber.LATEST);
     IRecordProcessor defaultRecordProcessor = new TestStreamlet();
 
     /**

--- a/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/WorkerTest.java
+++ b/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/WorkerTest.java
@@ -105,6 +105,7 @@ public class WorkerTest {
             InitialPositionInStreamExtended.newInitialPosition(InitialPositionInStream.LATEST);
     private static final InitialPositionInStreamExtended INITIAL_POSITION_TRIM_HORIZON =
             InitialPositionInStreamExtended.newInitialPosition(InitialPositionInStream.TRIM_HORIZON);
+    private final ShardPrioritization shardPrioritization = new NoOpShardPrioritization();
 
     // CHECKSTYLE:IGNORE AnonInnerLengthCheck FOR NEXT 50 LINES
     private static final com.amazonaws.services.kinesis.clientlibrary.interfaces.IRecordProcessorFactory SAMPLE_RECORD_PROCESSOR_FACTORY = 
@@ -192,14 +193,15 @@ public class WorkerTest {
                         execService,
                         nullMetricsFactory,
                         taskBackoffTimeMillis,
-                        failoverTimeMillis);
-        ShardInfo shardInfo = new ShardInfo(dummyKinesisShardId, testConcurrencyToken, null);
+                        failoverTimeMillis,
+                        shardPrioritization);
+        ShardInfo shardInfo = new ShardInfo(dummyKinesisShardId, testConcurrencyToken, null, ExtendedSequenceNumber.TRIM_HORIZON);
         ShardConsumer consumer = worker.createOrGetShardConsumer(shardInfo, streamletFactory);
         Assert.assertNotNull(consumer);
         ShardConsumer consumer2 = worker.createOrGetShardConsumer(shardInfo, streamletFactory);
         Assert.assertSame(consumer, consumer2);
         ShardInfo shardInfoWithSameShardIdButDifferentConcurrencyToken =
-                new ShardInfo(dummyKinesisShardId, anotherConcurrencyToken, null);
+                new ShardInfo(dummyKinesisShardId, anotherConcurrencyToken, null, ExtendedSequenceNumber.TRIM_HORIZON);
         ShardConsumer consumer3 =
                 worker.createOrGetShardConsumer(shardInfoWithSameShardIdButDifferentConcurrencyToken, streamletFactory);
         Assert.assertNotNull(consumer3);
@@ -241,12 +243,13 @@ public class WorkerTest {
                         execService,
                         nullMetricsFactory,
                         taskBackoffTimeMillis,
-                        failoverTimeMillis);
+                        failoverTimeMillis,
+                        shardPrioritization);
 
-        ShardInfo shardInfo1 = new ShardInfo(dummyKinesisShardId, concurrencyToken, null);
+        ShardInfo shardInfo1 = new ShardInfo(dummyKinesisShardId, concurrencyToken, null, ExtendedSequenceNumber.TRIM_HORIZON);
         ShardInfo duplicateOfShardInfo1ButWithAnotherConcurrencyToken =
-                new ShardInfo(dummyKinesisShardId, anotherConcurrencyToken, null);
-        ShardInfo shardInfo2 = new ShardInfo(anotherDummyKinesisShardId, concurrencyToken, null);
+                new ShardInfo(dummyKinesisShardId, anotherConcurrencyToken, null, ExtendedSequenceNumber.TRIM_HORIZON);
+        ShardInfo shardInfo2 = new ShardInfo(anotherDummyKinesisShardId, concurrencyToken, null, ExtendedSequenceNumber.TRIM_HORIZON);
 
         ShardConsumer consumerOfShardInfo1 = worker.createOrGetShardConsumer(shardInfo1, streamletFactory);
         ShardConsumer consumerOfDuplicateOfShardInfo1ButWithAnotherConcurrencyToken =
@@ -297,7 +300,8 @@ public class WorkerTest {
                         execService,
                         nullMetricsFactory,
                         taskBackoffTimeMillis,
-                        failoverTimeMillis);
+                        failoverTimeMillis,
+                        shardPrioritization);
         worker.run();
         Assert.assertTrue(count > 0);
     }
@@ -745,7 +749,8 @@ public class WorkerTest {
                         executorService,
                         metricsFactory,
                         taskBackoffTimeMillis,
-                        failoverTimeMillis);
+                        failoverTimeMillis,
+                        shardPrioritization);
 
         WorkerThread workerThread = new WorkerThread(worker);
         workerThread.start();


### PR DESCRIPTION
Added a new interface that allows the worker to prioritize which lease
assignment it will work on next.  When using the
ParentsFirstshardprioritization the worker will select parents for
processing before selecting children.  This will prevent ShardConsumers
from spending time sleeping in the WAITING_ON_PARENT_SHARDS state.