### PR TITLE
Allow for credential providers with basic arg types(updated, no conflicts)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,11 @@
   <dependencies>
     <dependency>
       <groupId>com.amazonaws</groupId>
+      <artifactId>aws-java-sdk-sts</artifactId>
+      <version>${aws-java-sdk.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk-dynamodb</artifactId>
       <version>${aws-java-sdk.version}</version>
     </dependency>

--- a/src/test/java/com/amazonaws/services/kinesis/clientlibrary/config/AWSCredentialsProviderPropertyValueDecoderTest.java
+++ b/src/test/java/com/amazonaws/services/kinesis/clientlibrary/config/AWSCredentialsProviderPropertyValueDecoderTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Amazon Software License (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://aws.amazon.com/asl/
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.services.kinesis.clientlibrary.config;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.util.Set;
+import java.io.File;
+import java.io.IOException;
+
+import org.apache.commons.lang.StringUtils;
+import org.junit.Test;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.AWSCredentialsProviderChain;
+import com.amazonaws.auth.profile.ProfileCredentialsProvider;
+import com.amazonaws.services.kinesis.clientlibrary.config.AWSCredentialsProviderPropertyValueDecoder;
+
+public class AWSCredentialsProviderPropertyValueDecoderTest {
+
+    private String credentialName1 =
+            "com.amazonaws.services.kinesis.clientlibrary.config.KinesisClientLibConfiguratorTest$AlwaysSucceedCredentialsProvider";
+    private String credentialName2 =
+            "com.amazonaws.services.kinesis.clientlibrary.config.KinesisClientLibConfiguratorTest$AlwaysFailCredentialsProvider";
+    private AWSCredentialsProviderPropertyValueDecoder decoder = new AWSCredentialsProviderPropertyValueDecoder();
+
+    @Test
+    public void testSingleProvider() {
+        AWSCredentialsProvider provider = decoder.decodeValue(credentialName1);
+        assertEquals(provider.getClass(), AWSCredentialsProviderChain.class);
+    }
+
+    @Test
+    public void testTwoProviders() {
+        AWSCredentialsProvider provider = decoder.decodeValue(credentialName1 + "," + credentialName2);
+        assertEquals(provider.getClass(), AWSCredentialsProviderChain.class);
+    }
+
+    @Test
+    public void testProfileProviderWithOneArg() {
+        AWSCredentialsProvider provider = decoder.decodeValue(ProfileCredentialsProvider.class.getName() + "|profileName");
+        assertEquals(provider.getClass(), AWSCredentialsProviderChain.class);
+    }
+
+    @Test
+    public void testProfileProviderWithTwoArgs() throws IOException {
+        File temp = File.createTempFile("test-profiles-file", ".tmp");
+        temp.deleteOnExit();
+        AWSCredentialsProvider provider = decoder.decodeValue(ProfileCredentialsProvider.class.getName() +
+                "|" + temp.getAbsolutePath() + "|profileName");
+        assertEquals(provider.getClass(), AWSCredentialsProviderChain.class);
+    }
+
+    /**
+     * This credentials provider will always succeed
+     */
+    public static class AlwaysSucceedCredentialsProvider implements AWSCredentialsProvider {
+
+        @Override
+        public AWSCredentials getCredentials() {
+            return null;
+        }
+
+        @Override
+        public void refresh() {
+        }
+
+    }
+
+    /**
+     * This credentials provider will always fail
+     */
+    public static class AlwaysFailCredentialsProvider implements AWSCredentialsProvider {
+
+        @Override
+        public AWSCredentials getCredentials() {
+            throw new IllegalArgumentException();
+        }
+
+        @Override
+        public void refresh() {
+        }
+
+    }
+}


### PR DESCRIPTION
This is the same pull request as https://github.com/awslabs/amazon-kinesis-client/pull/99 except it doesn't have the dynamo db endpoint changes.  This is a straight copy and paste from that pull request.  This pull request is off master so it shouldn't have any conflicts like the other one.  

All credits should go to @joshuamorris3.  
