### PR TITLE
Allow systems to track consumer initialization error

### DIFF
--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/Worker.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/Worker.java
@@ -358,6 +358,7 @@ public class Worker implements Runnable {
         } catch (RuntimeException e1) {
             LOG.error("Unable to initialize after " + MAX_INITIALIZATION_ATTEMPTS + " attempts. Shutting down.", e1);
             shutdown();
+            throw e1;
         }
 
         while (!shouldShutdown()) {


### PR DESCRIPTION
When some problem occours on initialization of DynamoDB or simple credentials validation, the exception is logged but the calling system won't never get notified. It's interesting that the exception is throwed so that some action may be taked at application level.