### PR TITLE
Fix JavaDoc for Java 8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -247,6 +247,15 @@
   </build>
   <profiles>
     <profile>
+      <id>disable-java8-doclint</id>
+      <activation>
+        <jdk>[1.8,)</jdk>
+      </activation>
+      <properties>
+        <additionalparam>-Xdoclint:none</additionalparam>
+      </properties>
+    </profile>
+    <profile>
       <id>publishing</id>
       <build>
         <plugins>


### PR DESCRIPTION
Disable the JavaDoc doclint when building with Java 8.  Java 8 became
much more pedantic on bad practices, and the documentation hasn't been
cleaned up.