### PR TITLE
Adding initialized boolean to record worker state

### DIFF
--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/Worker.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/Worker.java
@@ -93,6 +93,8 @@ public class Worker implements Runnable {
     private volatile boolean shutdown;
     private volatile long shutdownStartTimeMillis;
     private volatile boolean shutdownComplete = false;
+    
+    private volatile boolean initialized = false;
 
     // Holds consumers for shards the worker is currently tracking. Key is shard
     // info, value is ShardConsumer.
@@ -457,6 +459,7 @@ public class Worker implements Runnable {
         if (!isDone) {
             throw new RuntimeException(lastException);
         }
+        initialized = true;
     }
 
     /**
@@ -579,6 +582,10 @@ public class Worker implements Runnable {
     boolean isShutdownComplete() {
         return shutdownComplete;
     }
+    
+    public boolean isInitialized() {
+        return initialized;
+    }
 
     ConcurrentMap<ShardInfo, ShardConsumer> getShardInfoShardConsumerMap() {
         return shardInfoShardConsumerMap;
@@ -629,8 +636,9 @@ public class Worker implements Runnable {
         }
         if (metricsFactory instanceof WorkerCWMetricsFactory) {
             ((CWMetricsFactory) metricsFactory).shutdown();
-        }
-        shutdownComplete = true;
+        }        
+        initialized = false;
+        shutdownComplete = true;        
     }
 
     /**


### PR DESCRIPTION
Due to the long startup time of workers it's helpful to find out when they are ready for work.

A small change, but one that could have a positive impact on our use of the library.

The initialized flag is set to true at the end of the initialize method and is set to false in finalShutdown.