### PR TITLE
MultiLangDaemon: Make shutdown grace configurable

### DIFF
--- a/src/main/java/com/amazonaws/services/kinesis/multilang/MultiLangDaemon.java
+++ b/src/main/java/com/amazonaws/services/kinesis/multilang/MultiLangDaemon.java
@@ -148,13 +148,14 @@ public class MultiLangDaemon implements Callable<Integer> {
                 config.getRecordProcessorFactory(),
                 executorService);
 
+        final long shutdownGraceMillis = config.getKinesisClientLibConfiguration().getShutdownGraceMillis();
         Runtime.getRuntime().addShutdownHook(new Thread() {
             @Override
             public void run() {
                 LOG.info("Process terminanted, will initiate shutdown.");
                 try {
                     Future<Void> fut = daemon.worker.requestShutdown();
-                    fut.get(5000, TimeUnit.MILLISECONDS);
+                    fut.get(shutdownGraceMillis, TimeUnit.MILLISECONDS);
                     LOG.info("Process shutdown is complete.");
                 } catch (InterruptedException | ExecutionException | TimeoutException e) {
                     LOG.error("Encountered an error during shutdown.", e);

--- a/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/KinesisClientLibConfigurationTest.java
+++ b/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/KinesisClientLibConfigurationTest.java
@@ -84,7 +84,8 @@ public class KinesisClientLibConfigurationTest {
                         TEST_VALUE_LONG,
                         TEST_VALUE_INT,
                         skipCheckpointValidationValue,
-                        null);
+                        null,
+                        TEST_VALUE_LONG);
     }
 
     @Test
@@ -94,7 +95,7 @@ public class KinesisClientLibConfigurationTest {
         // Try each argument at one time.
         KinesisClientLibConfiguration config = null;
         long[] longValues =
-        { TEST_VALUE_LONG, TEST_VALUE_LONG, TEST_VALUE_LONG, TEST_VALUE_LONG, TEST_VALUE_LONG, TEST_VALUE_LONG };
+        { TEST_VALUE_LONG, TEST_VALUE_LONG, TEST_VALUE_LONG, TEST_VALUE_LONG, TEST_VALUE_LONG, TEST_VALUE_LONG, TEST_VALUE_LONG };
         for (int i = 0; i < PARAMETER_COUNT; i++) {
             longValues[i] = INVALID_LONG;
             try {
@@ -122,7 +123,8 @@ public class KinesisClientLibConfigurationTest {
                                 longValues[5],
                                 TEST_VALUE_INT,
                                 skipCheckpointValidationValue,
-                                null);
+                                null,
+                                longValues[6]);
             } catch (IllegalArgumentException e) {
                 System.out.println(e.getMessage());
             }
@@ -156,7 +158,8 @@ public class KinesisClientLibConfigurationTest {
                                 TEST_VALUE_LONG,
                                 intValues[1],
                                 skipCheckpointValidationValue,
-                                null);
+                                null,
+                                TEST_VALUE_LONG);
             } catch (IllegalArgumentException e) {
                 System.out.println(e.getMessage());
             }
@@ -319,7 +322,8 @@ public class KinesisClientLibConfigurationTest {
                         TEST_VALUE_LONG,
                         1,
                         skipCheckpointValidationValue,
-                        "abcd");
+                        "abcd",
+                        TEST_VALUE_LONG);
             Assert.fail("No expected Exception is thrown.");
         } catch(IllegalArgumentException e) {
             System.out.println(e.getMessage());


### PR DESCRIPTION
The shutdown grace added to the MultiLangDaemon in 1.7.6 proved to be essential for my application, but the hard-coded 5 second grace is too harsh for my needs. This adds a configuration parameter for the grace period.