### PR TITLE
Adding test classes for the Blocking and Prefetch getRecords cache.

### DIFF
--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/BlockingGetRecordsCache.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/BlockingGetRecordsCache.java
@@ -1,5 +1,6 @@
 package com.amazonaws.services.kinesis.clientlibrary.lib.worker;
 
+import com.amazonaws.services.kinesis.clientlibrary.types.ProcessRecordsInput;
 import com.amazonaws.services.kinesis.model.GetRecordsResult;
 
 import lombok.extern.apachecommons.CommonsLog;
@@ -17,10 +18,14 @@ public class BlockingGetRecordsCache implements GetRecordsCache {
         this.maxRecordsPerCall = maxRecordsPerCall;
         this.getRecordsRetrievalStrategy = getRecordsRetrievalStrategy;
     }
-    
+
     @Override
-    public GetRecordsResult getNextResult() {
-        return getRecordsRetrievalStrategy.getRecords(maxRecordsPerCall);
+    public ProcessRecordsInput getNextResult() {
+        GetRecordsResult getRecordsResult = getRecordsRetrievalStrategy.getRecords(maxRecordsPerCall);
+        ProcessRecordsInput processRecordsInput = new ProcessRecordsInput()
+                .withRecords(getRecordsResult.getRecords())
+                .withMillisBehindLatest(getRecordsResult.getMillisBehindLatest());
+        return processRecordsInput;
     }
 
     @Override

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/BlockingGetRecordsCache.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/BlockingGetRecordsCache.java
@@ -1,3 +1,18 @@
+/*
+ *  Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Amazon Software License (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *  http://aws.amazon.com/asl/
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License. 
+ */
+
 package com.amazonaws.services.kinesis.clientlibrary.lib.worker;
 
 import com.amazonaws.services.kinesis.clientlibrary.types.ProcessRecordsInput;
@@ -17,6 +32,11 @@ public class BlockingGetRecordsCache implements GetRecordsCache {
     public BlockingGetRecordsCache(final int maxRecordsPerCall, final GetRecordsRetrievalStrategy getRecordsRetrievalStrategy) {
         this.maxRecordsPerCall = maxRecordsPerCall;
         this.getRecordsRetrievalStrategy = getRecordsRetrievalStrategy;
+    }
+
+    @Override
+    public void start() {
+        // Do nothing, this behavior is not supported by this cache.
     }
 
     @Override

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/BlockingGetRecordsCache.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/BlockingGetRecordsCache.java
@@ -36,7 +36,9 @@ public class BlockingGetRecordsCache implements GetRecordsCache {
 
     @Override
     public void start() {
-        // Do nothing, this behavior is not supported by this cache.
+        //
+        // Nothing to do here
+        //
     }
 
     @Override
@@ -50,6 +52,8 @@ public class BlockingGetRecordsCache implements GetRecordsCache {
 
     @Override
     public void shutdown() {
+        //
         // Nothing to do here.
+        //
     }
 }

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/GetRecordsCache.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/GetRecordsCache.java
@@ -1,8 +1,6 @@
 package com.amazonaws.services.kinesis.clientlibrary.lib.worker;
 
-import com.amazonaws.services.kinesis.model.GetRecordsResult;
-
-import java.util.Collections;
+import com.amazonaws.services.kinesis.clientlibrary.types.ProcessRecordsInput;
 
 /**
  * This class is used as a cache for Prefetching data from Kinesis.
@@ -14,7 +12,7 @@ public interface GetRecordsCache {
      * 
      * @return The next set of records.
      */
-    GetRecordsResult getNextResult();
+    ProcessRecordsInput getNextResult();
     
     void shutdown();
 }

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/GetRecordsCache.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/GetRecordsCache.java
@@ -1,3 +1,18 @@
+/*
+ *  Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Amazon Software License (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *  http://aws.amazon.com/asl/
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License. 
+ */
+
 package com.amazonaws.services.kinesis.clientlibrary.lib.worker;
 
 import com.amazonaws.services.kinesis.clientlibrary.types.ProcessRecordsInput;
@@ -7,12 +22,20 @@ import com.amazonaws.services.kinesis.clientlibrary.types.ProcessRecordsInput;
  */
 public interface GetRecordsCache {
     /**
+     * This method calls the start behavior on the cache, if available.
+     */
+    void start();
+    
+    /**
      * This method returns the next set of records from the Cache if present, or blocks the request till it gets the
      * next set of records back from Kinesis.
      * 
      * @return The next set of records.
      */
     ProcessRecordsInput getNextResult();
-    
+
+    /**
+     * This method calls the shutdown behavior on the cache, if available.
+     */
     void shutdown();
 }

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/PrefetchGetRecordsCache.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/PrefetchGetRecordsCache.java
@@ -137,7 +137,7 @@ public class PrefetchGetRecordsCache implements GetRecordsCache {
             return result.getRecords().stream().mapToLong(record -> record.getData().array().length).sum();
         }
         
-        public boolean shouldGetNewRecords() {
+        public synchronized boolean shouldGetNewRecords() {
             return size < maxRecordsCount && byteSize < maxByteSize;
         }
     }

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/PrefetchGetRecordsCache.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/PrefetchGetRecordsCache.java
@@ -1,8 +1,10 @@
 package com.amazonaws.services.kinesis.clientlibrary.lib.worker;
 
+import java.time.Instant;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.LinkedBlockingQueue;
 
+import com.amazonaws.services.kinesis.clientlibrary.types.ProcessRecordsInput;
 import com.amazonaws.services.kinesis.model.GetRecordsResult;
 
 import lombok.NonNull;
@@ -18,20 +20,20 @@ import lombok.extern.apachecommons.CommonsLog;
  */
 @CommonsLog
 public class PrefetchGetRecordsCache implements GetRecordsCache {
-    private LinkedBlockingQueue<GetRecordsResult> getRecordsResultQueue;
+    LinkedBlockingQueue<ProcessRecordsInput> getRecordsResultQueue;
     private int maxSize;
     private int maxByteSize;
     private int maxRecordsCount;
     private final int maxRecordsPerCall;
     private final GetRecordsRetrievalStrategy getRecordsRetrievalStrategy;
     private final ExecutorService executorService;
-    
+
     private PrefetchCounters prefetchCounters;
-    
+
     private boolean started = false;
 
     public PrefetchGetRecordsCache(final int maxSize, final int maxByteSize, final int maxRecordsCount,
-                                   final int maxRecordsPerCall, @NonNull final DataFetchingStrategy dataFetchingStrategy,
+                                   final int maxRecordsPerCall,
                                    @NonNull final GetRecordsRetrievalStrategy getRecordsRetrievalStrategy,
                                    @NonNull final ExecutorService executorService) {
         this.getRecordsRetrievalStrategy = getRecordsRetrievalStrategy;
@@ -40,11 +42,11 @@ public class PrefetchGetRecordsCache implements GetRecordsCache {
         this.maxByteSize = maxByteSize;
         this.maxRecordsCount = maxRecordsCount;
         this.getRecordsResultQueue = new LinkedBlockingQueue<>(this.maxSize);
-        prefetchCounters = new PrefetchCounters();
+        this.prefetchCounters = new PrefetchCounters();
         this.executorService = executorService;
     }
-    
-    private void start() {
+
+    void start() {
         if (!started) {
             log.info("Starting prefetching thread.");
             executorService.execute(new DefaultGetRecordsCacheDaemon());
@@ -53,13 +55,14 @@ public class PrefetchGetRecordsCache implements GetRecordsCache {
     }
 
     @Override
-    public GetRecordsResult getNextResult() {
+    public ProcessRecordsInput getNextResult() {
         if (!started) {
             start();
         }
-        GetRecordsResult result = null;
+        ProcessRecordsInput result = null;
         try {
             result = getRecordsResultQueue.take();
+            result.withCacheExitTime(Instant.now());
             prefetchCounters.removed(result);
         } catch (InterruptedException e) {
             log.error("Interrupted while getting records from the cache", e);
@@ -69,18 +72,26 @@ public class PrefetchGetRecordsCache implements GetRecordsCache {
 
     @Override
     public void shutdown() {
-        executorService.shutdown();
+        executorService.shutdownNow();
     }
-    
+
     private class DefaultGetRecordsCacheDaemon implements Runnable {
         @Override
         public void run() {
             while (true) {
+                if (Thread.interrupted()) {
+                    log.warn("Prefetch thread was interrupted.");
+                    break;
+                }
                 if (prefetchCounters.byteSize < maxByteSize && prefetchCounters.size < maxRecordsCount) {
                     try {
                         GetRecordsResult getRecordsResult = getRecordsRetrievalStrategy.getRecords(maxRecordsPerCall);
-                        getRecordsResultQueue.put(getRecordsResult);
-                        prefetchCounters.added(getRecordsResult);
+                        ProcessRecordsInput processRecordsInput = new ProcessRecordsInput()
+                                .withRecords(getRecordsResult.getRecords())
+                                .withMillisBehindLatest(getRecordsResult.getMillisBehindLatest())
+                                .withCacheEntryTime(Instant.now());
+                        getRecordsResultQueue.put(processRecordsInput);
+                        prefetchCounters.added(processRecordsInput);
                     } catch (InterruptedException e) {
                         log.error("Interrupted while adding records to the cache", e);
                     }
@@ -88,28 +99,28 @@ public class PrefetchGetRecordsCache implements GetRecordsCache {
             }
         }
     }
-    
+
     private class PrefetchCounters {
         private volatile long size = 0;
         private volatile long byteSize = 0;
-        
-        public void added(final GetRecordsResult result) {
+
+        public void added(final ProcessRecordsInput result) {
             size += getSize(result);
             byteSize += getByteSize(result);
         }
-        
-        public void removed(final GetRecordsResult result) {
+
+        public void removed(final ProcessRecordsInput result) {
             size -= getSize(result);
             byteSize -= getByteSize(result);
         }
-        
-        private long getSize(final GetRecordsResult result) {
+
+        private long getSize(final ProcessRecordsInput result) {
             return result.getRecords().size();
         }
-        
-        private long getByteSize(final GetRecordsResult result) {
+
+        private long getByteSize(final ProcessRecordsInput result) {
             return result.getRecords().stream().mapToLong(record -> record.getData().array().length).sum();
         }
     }
-    
+
 }

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/PrefetchGetRecordsCache.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/PrefetchGetRecordsCache.java
@@ -116,15 +116,15 @@ public class PrefetchGetRecordsCache implements GetRecordsCache {
     }
 
     private class PrefetchCounters {
-        private volatile long size = 0;
-        private volatile long byteSize = 0;
+        private long size = 0;
+        private long byteSize = 0;
 
-        public void added(final ProcessRecordsInput result) {
+        public synchronized void added(final ProcessRecordsInput result) {
             size += getSize(result);
             byteSize += getByteSize(result);
         }
 
-        public void removed(final ProcessRecordsInput result) {
+        public synchronized void removed(final ProcessRecordsInput result) {
             size -= getSize(result);
             byteSize -= getByteSize(result);
         }

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/types/ProcessRecordsInput.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/types/ProcessRecordsInput.java
@@ -29,7 +29,6 @@ import lombok.Getter;
  * ProcessRecordsInput processRecordsInput) processRecords} method.
  */
 public class ProcessRecordsInput {
-
     @Getter
     private Instant cacheEntryTime;
     @Getter

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/types/ProcessRecordsInput.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/types/ProcessRecordsInput.java
@@ -14,9 +14,14 @@
  */
 package com.amazonaws.services.kinesis.clientlibrary.types;
 
+import java.time.Duration;
+import java.time.Instant;
 import java.util.List;
+
 import com.amazonaws.services.kinesis.clientlibrary.interfaces.IRecordProcessorCheckpointer;
 import com.amazonaws.services.kinesis.model.Record;
+
+import lombok.Getter;
 
 /**
  * Container for the parameters to the IRecordProcessor's
@@ -25,6 +30,10 @@ import com.amazonaws.services.kinesis.model.Record;
  */
 public class ProcessRecordsInput {
 
+    @Getter
+    private Instant cacheEntryTime;
+    @Getter
+    private Instant cacheExitTime;
     private List<Record> records;
     private IRecordProcessorCheckpointer checkpointer;
     private Long millisBehindLatest;
@@ -95,5 +104,22 @@ public class ProcessRecordsInput {
     public ProcessRecordsInput withMillisBehindLatest(Long millisBehindLatest) {
         this.millisBehindLatest = millisBehindLatest;
         return this;
+    }
+    
+    public ProcessRecordsInput withCacheEntryTime(Instant cacheEntryTime) {
+        this.cacheEntryTime = cacheEntryTime;
+        return this;
+    }
+    
+    public ProcessRecordsInput withCacheExitTime(Instant cacheExitTime) {
+        this.cacheExitTime = cacheExitTime;
+        return this;
+    }
+    
+    public Duration getTimeSpentInCache() {
+        if (cacheEntryTime == null || cacheExitTime == null) {
+            return Duration.ZERO;
+        }
+        return Duration.between(cacheEntryTime, cacheExitTime);
     }
 }

--- a/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/BlockingGetRecordsCacheTest.java
+++ b/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/BlockingGetRecordsCacheTest.java
@@ -51,11 +51,11 @@ public class BlockingGetRecordsCacheTest {
 
     @Before
     public void setup() {
-        when(getRecordsRetrievalStrategy.getRecords(eq(MAX_RECORDS_PER_COUNT))).thenReturn(getRecordsResult);
-        when(getRecordsResult.getRecords()).thenReturn(records);
-
         records = new ArrayList<>();
         blockingGetRecordsCache = new BlockingGetRecordsCache(MAX_RECORDS_PER_COUNT, getRecordsRetrievalStrategy);
+
+        when(getRecordsRetrievalStrategy.getRecords(eq(MAX_RECORDS_PER_COUNT))).thenReturn(getRecordsResult);
+        when(getRecordsResult.getRecords()).thenReturn(records);
     }
 
     @Test

--- a/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/BlockingGetRecordsCacheTest.java
+++ b/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/BlockingGetRecordsCacheTest.java
@@ -1,0 +1,69 @@
+/*
+ *  Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Amazon Software License (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *  http://aws.amazon.com/asl/
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License. 
+ */
+
+package com.amazonaws.services.kinesis.clientlibrary.lib.worker;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.when;
+
+import java.time.Duration;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import com.amazonaws.services.kinesis.clientlibrary.types.ProcessRecordsInput;
+import com.amazonaws.services.kinesis.model.GetRecordsResult;
+import com.amazonaws.services.kinesis.model.Record;
+
+/**
+ * Test class for the BlockingGetRecordsCache class.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class BlockingGetRecordsCacheTest {
+    private static final int MAX_RECORDS_PER_COUNT = 10_000;
+
+    @Mock
+    private GetRecordsRetrievalStrategy getRecordsRetrievalStrategy;
+    @Mock
+    private GetRecordsResult getRecordsResult;
+    @Mock
+    private List<Record> records;
+
+    private BlockingGetRecordsCache blockingGetRecordsCache;
+
+    @Before
+    public void setup() {
+        when(getRecordsRetrievalStrategy.getRecords(eq(MAX_RECORDS_PER_COUNT))).thenReturn(getRecordsResult);
+        when(getRecordsResult.getRecords()).thenReturn(records);
+
+        blockingGetRecordsCache = new BlockingGetRecordsCache(MAX_RECORDS_PER_COUNT, getRecordsRetrievalStrategy);
+    }
+
+    @Test
+    public void testGetNextRecords() {
+        ProcessRecordsInput result = blockingGetRecordsCache.getNextResult();
+
+        assertEquals(result.getRecords(), records);
+        assertNull(result.getCacheEntryTime());
+        assertNull(result.getCacheExitTime());
+        assertEquals(result.getTimeSpentInCache(), Duration.ZERO);
+    }
+}

--- a/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/BlockingGetRecordsCacheTest.java
+++ b/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/BlockingGetRecordsCacheTest.java
@@ -21,6 +21,7 @@ import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.when;
 
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.List;
 
 import org.junit.Before;
@@ -44,9 +45,8 @@ public class BlockingGetRecordsCacheTest {
     private GetRecordsRetrievalStrategy getRecordsRetrievalStrategy;
     @Mock
     private GetRecordsResult getRecordsResult;
-    @Mock
-    private List<Record> records;
-
+    
+    private List<Record> records = new ArrayList<>();
     private BlockingGetRecordsCache blockingGetRecordsCache;
 
     @Before
@@ -58,12 +58,25 @@ public class BlockingGetRecordsCacheTest {
     }
 
     @Test
-    public void testGetNextRecords() {
+    public void testGetNextRecordsWithNoRecords() {
         ProcessRecordsInput result = blockingGetRecordsCache.getNextResult();
 
         assertEquals(result.getRecords(), records);
         assertNull(result.getCacheEntryTime());
         assertNull(result.getCacheExitTime());
         assertEquals(result.getTimeSpentInCache(), Duration.ZERO);
+    }
+    
+    @Test
+    public void testGetNextRecordsWithRecords() {
+        Record record = new Record();
+        records.add(record);
+        records.add(record);
+        records.add(record);
+        records.add(record);
+        
+        ProcessRecordsInput result = blockingGetRecordsCache.getNextResult();
+        
+        assertEquals(result.getRecords(), records);
     }
 }

--- a/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/BlockingGetRecordsCacheTest.java
+++ b/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/BlockingGetRecordsCacheTest.java
@@ -46,7 +46,7 @@ public class BlockingGetRecordsCacheTest {
     @Mock
     private GetRecordsResult getRecordsResult;
     
-    private List<Record> records = new ArrayList<>();
+    private List<Record> records;
     private BlockingGetRecordsCache blockingGetRecordsCache;
 
     @Before
@@ -54,6 +54,7 @@ public class BlockingGetRecordsCacheTest {
         when(getRecordsRetrievalStrategy.getRecords(eq(MAX_RECORDS_PER_COUNT))).thenReturn(getRecordsResult);
         when(getRecordsResult.getRecords()).thenReturn(records);
 
+        records = new ArrayList<>();
         blockingGetRecordsCache = new BlockingGetRecordsCache(MAX_RECORDS_PER_COUNT, getRecordsRetrievalStrategy);
     }
 

--- a/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/PrefetchGetRecordsCacheTest.java
+++ b/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/PrefetchGetRecordsCacheTest.java
@@ -1,0 +1,195 @@
+/*
+ *  Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Amazon Software License (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *  http://aws.amazon.com/asl/
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License. 
+ */
+
+package com.amazonaws.services.kinesis.clientlibrary.lib.worker;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.nio.ByteBuffer;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.stream.IntStream;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import com.amazonaws.services.kinesis.clientlibrary.types.ProcessRecordsInput;
+import com.amazonaws.services.kinesis.model.GetRecordsResult;
+import com.amazonaws.services.kinesis.model.Record;
+
+/**
+ * Test class for the PrefetchGetRecordsCache class.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class PrefetchGetRecordsCacheTest {
+    private static final int SIZE_512_KB = 512 * 1024;
+    private static final int SIZE_1_MB = 2 * SIZE_512_KB;
+    private static final int MAX_RECORDS_PER_CALL = 10000;
+    private static final int MAX_SIZE = 5;
+    private static final int MAX_RECORDS_COUNT = 15000;
+
+    @Mock
+    private GetRecordsRetrievalStrategy getRecordsRetrievalStrategy;
+    @Mock
+    private GetRecordsResult getRecordsResult;
+    @Mock
+    private Record record;
+
+    private List<Record> records;
+    private ExecutorService executorService;
+    private LinkedBlockingQueue<ProcessRecordsInput> spyQueue;
+    private PrefetchGetRecordsCache getRecordsCache;
+
+    @Before
+    public void setup() {
+        executorService = spy(Executors.newFixedThreadPool(1));
+        getRecordsCache = new PrefetchGetRecordsCache(
+                MAX_SIZE,
+                3 * SIZE_1_MB,
+                MAX_RECORDS_COUNT,
+                MAX_RECORDS_PER_CALL,
+                getRecordsRetrievalStrategy,
+                executorService);
+        spyQueue = spy(getRecordsCache.getRecordsResultQueue);
+        records = spy(new ArrayList<>());
+
+        when(getRecordsRetrievalStrategy.getRecords(eq(MAX_RECORDS_PER_CALL))).thenReturn(getRecordsResult);
+        when(getRecordsResult.getRecords()).thenReturn(records);
+    }
+
+    @Test
+    public void testGetRecords() {
+        when(records.size()).thenReturn(1000);
+        when(record.getData()).thenReturn(createByteBufferWithSize(SIZE_512_KB));
+
+        records.add(record);
+        records.add(record);
+        records.add(record);
+        records.add(record);
+        records.add(record);
+
+        ProcessRecordsInput result = getRecordsCache.getNextResult();
+
+        assertEquals(result.getRecords(), records);
+
+        verify(executorService).execute(any());
+        verify(getRecordsRetrievalStrategy, atLeast(1)).getRecords(eq(MAX_RECORDS_PER_CALL));
+    }
+
+    @Test
+    public void testFullCacheByteSize() {
+        when(records.size()).thenReturn(500);
+        when(record.getData()).thenReturn(createByteBufferWithSize(SIZE_1_MB));
+
+        records.add(record);
+
+        getRecordsCache.start();
+
+        // Sleep for a few seconds for the cache to fill up.
+        sleep(2000);
+
+        verify(getRecordsRetrievalStrategy, times(3)).getRecords(eq(MAX_RECORDS_PER_CALL));
+        assertEquals(spyQueue.size(), 3);
+    }
+
+    @Test
+    public void testFullCacheRecordsCount() {
+        int recordsSize = 4500;
+        when(records.size()).thenReturn(recordsSize);
+
+        getRecordsCache.start();
+
+        sleep(2000);
+
+        int callRate = (int) Math.ceil((double) MAX_RECORDS_COUNT/recordsSize);
+        verify(getRecordsRetrievalStrategy, times(callRate)).getRecords(MAX_RECORDS_PER_CALL);
+        assertEquals(spyQueue.size(), callRate);
+        assertTrue(callRate < MAX_SIZE);
+    }
+
+    @Test
+    public void testFullCacheSize() {
+        int recordsSize = 200;
+        when(records.size()).thenReturn(recordsSize);
+
+        getRecordsCache.start();
+
+        // Sleep for a few seconds for the cache to fill up.
+        sleep(2000);
+
+        verify(getRecordsRetrievalStrategy, times(MAX_SIZE + 1)).getRecords(eq(MAX_RECORDS_PER_CALL));
+        assertEquals(spyQueue.size(), MAX_SIZE);
+    }
+
+    @Test
+    public void testMultipleCacheCalls() {
+        int recordsSize = 20;
+        when(record.getData()).thenReturn(createByteBufferWithSize(1024));
+
+        IntStream.range(0, recordsSize).forEach(i -> records.add(record));
+
+        ProcessRecordsInput processRecordsInput = getRecordsCache.getNextResult();
+
+        verify(executorService).execute(any());
+        assertEquals(processRecordsInput.getRecords(), records);
+        assertNotNull(processRecordsInput.getCacheEntryTime());
+        assertNotNull(processRecordsInput.getCacheExitTime());
+
+        sleep(2000);
+
+        ProcessRecordsInput processRecordsInput2 = getRecordsCache.getNextResult();
+        assertNotEquals(processRecordsInput, processRecordsInput2);
+        assertEquals(processRecordsInput2.getRecords(), records);
+        assertNotEquals(processRecordsInput2.getTimeSpentInCache(), Duration.ZERO);
+
+        assertTrue(spyQueue.size() <= MAX_SIZE);
+    }
+
+    @After
+    public void shutdown() {
+        getRecordsCache.shutdown();
+        verify(executorService).shutdownNow();
+    }
+
+    private void sleep(long millis) {
+        try {
+            Thread.sleep(millis);
+        } catch (InterruptedException e) {}
+    }
+
+    private ByteBuffer createByteBufferWithSize(int size) {
+        ByteBuffer byteBuffer = ByteBuffer.allocate(size);
+        byteBuffer.put(new byte[size]);
+        return byteBuffer;
+    }
+}

--- a/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/PrefetchGetRecordsCacheTest.java
+++ b/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/PrefetchGetRecordsCacheTest.java
@@ -98,6 +98,7 @@ public class PrefetchGetRecordsCacheTest {
         records.add(record);
         records.add(record);
 
+        getRecordsCache.start();
         ProcessRecordsInput result = getRecordsCache.getNextResult();
 
         assertEquals(result.getRecords(), records);
@@ -158,6 +159,7 @@ public class PrefetchGetRecordsCacheTest {
 
         IntStream.range(0, recordsSize).forEach(i -> records.add(record));
 
+        getRecordsCache.start();
         ProcessRecordsInput processRecordsInput = getRecordsCache.getNextResult();
 
         verify(executorService).execute(any());
@@ -173,6 +175,12 @@ public class PrefetchGetRecordsCacheTest {
         assertNotEquals(processRecordsInput2.getTimeSpentInCache(), Duration.ZERO);
 
         assertTrue(spyQueue.size() <= MAX_SIZE);
+    }
+    
+    @Test(expected = IllegalStateException.class)
+    public void testGetNextRecordsWithoutStarting() {
+        verify(executorService, times(0)).execute(any());
+        getRecordsCache.getNextResult();
     }
 
     @After


### PR DESCRIPTION
Changes included in the PR

* Added test classes for Blocking and Prefetch GetRecordsCache.
* KinesisDataFetcher no longer can return a null object.
* The cache now returns a ProcessRecordsInput object instead of the GetRecordsResult.
* The ProcessRecordsInput class has a new method to provide time spent in the cache.
* Calling shutdownNow instead of shutdown to shutdown the ExecutorService.