### PR TITLE
Release 1.8.5 of the Amazon Kinesis Client for Java

### DIFF
--- a/META-INF/MANIFEST.MF
+++ b/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Amazon Kinesis Client Library for Java
 Bundle-SymbolicName: com.amazonaws.kinesisclientlibrary;singleton:=true
-Bundle-Version: 1.8.4
+Bundle-Version: 1.8.5
 Bundle-Vendor: Amazon Technologies, Inc
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Require-Bundle: org.apache.commons.codec;bundle-version="1.6",

--- a/README.md
+++ b/README.md
@@ -31,8 +31,9 @@ To make it easier for developers to write record processors in other languages, 
 ## Release Notes
 ### Release 1.8.5 (September 26, 2017)
 * Only advance the shard iterator for the accepted response.  
-  When using the asynchronous retriever multiple requests can be created.  As the requests can finish at different times it's possible for them to also have different next shard iterator.  The KinesisDataFetcher will now only use the next shard iterator of the request that is accepted by the caller.  Requests are accepted by calling `DataFetcherResult#accept()`, which both retrievers now call.
+  This fixes a race condition in the `KinesisDataFetcher` when it's being used to make asynchronous requests.  The shard iterator is now only advanced when the retriever calls `DataFetcherResult#accept()`.
   * [PR #230](https://github.com/awslabs/amazon-kinesis-client/pull/230)
+  * [Issue #231](https://github.com/awslabs/amazon-kinesis-client/issues/231)
 
 ### Release 1.8.4 (September 22, 2017)
 * Create a new completion service for each request.  

--- a/README.md
+++ b/README.md
@@ -29,6 +29,11 @@ For producer-side developers using the **[Kinesis Producer Library (KPL)][kinesi
 To make it easier for developers to write record processors in other languages, we have implemented a Java based daemon, called MultiLangDaemon that does all the heavy lifting. Our approach has the daemon spawn a sub-process, which in turn runs the record processor, which can be written in any language. The MultiLangDaemon process and the record processor sub-process communicate with each other over [STDIN and STDOUT using a defined protocol][multi-lang-protocol]. There will be a one to one correspondence amongst record processors, child processes, and shards. For Python developers specifically, we have abstracted these implementation details away and [expose an interface][kclpy] that enables you to focus on writing record processing logic in Python. This approach enables KCL to be language agnostic, while providing identical features and similar parallel processing model across all languages.
 
 ## Release Notes
+### Release 1.8.5 (September 26, 2017)
+* Only advance the shard iterator for the accepted response.  
+  This ensures that the shard iterator is only advanced when the response is accepted.  This fixes a race condition where additional request created by the asynchronous retriever could overwrite the shard iterator of the accepted response.
+  * [PR #230](https://github.com/awslabs/amazon-kinesis-client/pull/230)
+
 ### Release 1.8.4 (September 22, 2017)
 * Create a new completion service for each request.  
   This ensures that canceled tasks are discarded.  This will prevent a cancellation exception causing issues processing records.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ To make it easier for developers to write record processors in other languages, 
 ## Release Notes
 ### Release 1.8.5 (September 26, 2017)
 * Only advance the shard iterator for the accepted response.  
-  This ensures that the shard iterator is only advanced when the response is accepted.  This fixes a race condition where additional request created by the asynchronous retriever could overwrite the shard iterator of the accepted response.
+  When using the asynchronous retriever multiple requests can be created.  As the requests can finish at different times it's possible for them to also have different next shard iterator.  The KinesisDataFetcher will now only use the next shard iterator of the request that is accepted by the caller.  Requests are accepted by calling `DataFetcherResult#accept()`, which both retrievers now call.
   * [PR #230](https://github.com/awslabs/amazon-kinesis-client/pull/230)
 
 ### Release 1.8.4 (September 22, 2017)

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <artifactId>amazon-kinesis-client</artifactId>
   <packaging>jar</packaging>
   <name>Amazon Kinesis Client Library for Java</name>
-  <version>1.8.5-SNAPSHOT</version>
+  <version>1.8.5</version>
   <description>The Amazon Kinesis Client Library for Java enables Java developers to easily consume and process data
     from Amazon Kinesis.
   </description>

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/KinesisClientLibConfiguration.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/KinesisClientLibConfiguration.java
@@ -126,7 +126,7 @@ public class KinesisClientLibConfiguration {
     /**
      * User agent set when Amazon Kinesis Client Library makes AWS requests.
      */
-    public static final String KINESIS_CLIENT_LIB_USER_AGENT = "amazon-kinesis-client-library-java-1.8.4";
+    public static final String KINESIS_CLIENT_LIB_USER_AGENT = "amazon-kinesis-client-library-java-1.8.5";
 
     /**
      * KCL will validate client provided sequence numbers with a call to Amazon Kinesis before checkpointing for calls


### PR DESCRIPTION
### Release 1.8.5 (September 26, 2017)
* Only advance the shard iterator for the accepted response.  
  This fixes a race condition in the `KinesisDataFetcher` when it's being used to make asynchronous requests.  The shard iterator is now only advanced when the retriever calls `DataFetcherResult#accept()`.
  * [PR #230](https://github.com/awslabs/amazon-kinesis-client/pull/230)
  * [Issue #231](https://github.com/awslabs/amazon-kinesis-client/issues/231)