### PR TITLE
Adding logging for long running tasks

### DIFF
--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/KinesisClientLibConfiguration.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/KinesisClientLibConfiguration.java
@@ -234,6 +234,9 @@ public class KinesisClientLibConfiguration {
 
     @Getter
     private RecordsFetcherFactory recordsFetcherFactory;
+    
+    @Getter
+    private Optional<Long> logWarningForTaskAfterMillis = Optional.empty();
 
     /**
      * Constructor.
@@ -1353,6 +1356,17 @@ public class KinesisClientLibConfiguration {
     public KinesisClientLibConfiguration withIdleMillisBetweenCalls(long idleMillisBetweenCalls) {
         checkIsValuePositive("IdleMillisBetweenCalls", idleMillisBetweenCalls);
         this.recordsFetcherFactory.setIdleMillisBetweenCalls(idleMillisBetweenCalls);
+        return this;
+    }
+
+    /**
+     * @param logWarningForTaskAfterMillis Logs warn message if as task is held in  a task for more than the set
+     *                                          time.
+     * @return KinesisClientLibConfiguration
+     */
+    public KinesisClientLibConfiguration withLogWarningForTaskAfterMillis(long logWarningForTaskAfterMillis) {
+        checkIsValuePositive("LogProcessTaskStatusAfterInMillis", logWarningForTaskAfterMillis);
+        this.logWarningForTaskAfterMillis = Optional.of(logWarningForTaskAfterMillis);
         return this;
     }
 }

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardConsumer.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardConsumer.java
@@ -283,11 +283,17 @@ class ShardConsumer {
                 }
             }
         } else {
+            final long timeElapsed = System.currentTimeMillis() - currentTaskSubmitTime;
+            final String commonMessage = String.format("Previous %s task still pending for shard %s since %d ms ago. ",
+                    currentTask.getTaskType(), shardInfo.getShardId(), timeElapsed);
             if (LOG.isDebugEnabled()) {
-                LOG.debug("Previous " + currentTask.getTaskType() + " task still pending for shard "
-                        + shardInfo.getShardId() + " since " + (System.currentTimeMillis() - currentTaskSubmitTime)
-                        + " ms ago" + ".  Not submitting new task.");
+                LOG.debug(commonMessage + "Not submitting new task.");
             }
+            config.getLogWarningForTaskAfterMillis().ifPresent(value -> {
+                if (timeElapsed > value) {
+                    LOG.warn(commonMessage);
+                }
+            });
         }
 
         return submittedNewTask;


### PR DESCRIPTION
* This commit contains the feature for logging long running tasks.
* This feature can be enabled by setting the value for `logWarningForTaskAfterMillis`, this value is to be set in milliseconds.
* The default value for `logWarningForTaskAfterMillis` is not set.
* The test case doesn't test the log message, it makes sure that the path to the log message is reached.