### PR TITLE
Release 1.8.9 of the Amazon Kinesis Client for Java

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,15 @@ For producer-side developers using the **[Kinesis Producer Library (KPL)][kinesi
 To make it easier for developers to write record processors in other languages, we have implemented a Java based daemon, called MultiLangDaemon that does all the heavy lifting. Our approach has the daemon spawn a sub-process, which in turn runs the record processor, which can be written in any language. The MultiLangDaemon process and the record processor sub-process communicate with each other over [STDIN and STDOUT using a defined protocol][multi-lang-protocol]. There will be a one to one correspondence amongst record processors, child processes, and shards. For Python developers specifically, we have abstracted these implementation details away and [expose an interface][kclpy] that enables you to focus on writing record processing logic in Python. This approach enables KCL to be language agnostic, while providing identical features and similar parallel processing model across all languages.
 
 ## Release Notes
+
+### Release 1.8.9
+* Allow disabling check for the case where a child shard has an open parent shard.  
+  There is a race condition where it's possible for the a parent shard to appear open, while having child shards. This check can now be disabled by setting [`ignoreUnexpectedChildShards`](https://github.com/awslabs/amazon-kinesis-client/blob/master/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/KinesisClientLibConfiguration.java#L1037) to true.
+  * [PR #240](https://github.com/awslabs/amazon-kinesis-client/pull/240)
+  * [Issue #210](https://github.com/awslabs/amazon-kinesis-client/issues/210)
+* Upgraded the AWS SDK for Java to 1.11.261
+  * [PR #281](https://github.com/awslabs/amazon-kinesis-client/pull/281)
+
 ### Release 1.8.8
 * Fixed issues with leases losses due to `ExpiredIteratorException` in `PrefetchGetRecordsCache` and `AsynchronousFetchingStrategy`.  
   PrefetchGetRecordsCache will request for a new iterator and start fetching data again.  

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <artifactId>amazon-kinesis-client</artifactId>
   <packaging>jar</packaging>
   <name>Amazon Kinesis Client Library for Java</name>
-  <version>1.8.9-SNAPSHOT</version>
+  <version>1.8.9</version>
   <description>The Amazon Kinesis Client Library for Java enables Java developers to easily consume and process data
     from Amazon Kinesis.
   </description>


### PR DESCRIPTION
* Allow disabling check for the case where a child shard has an open parent shard.
  There is a race condition where it's possible for the a parent shard
  to appear open, while having child shards. This check can now be
  disabled by setting ignoreUnexpectedChildShards in the
  KinesisClientLibConfiguration to true.
  * PR #240
  * Issue #210
* Upgraded the AWS SDK for Java to 1.11.261
  * PR #281