### PR TITLE
Allow specifying a custom LeaseManager in Worker.Builder with tests

### DIFF
--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/Worker.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/Worker.java
@@ -33,6 +33,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 import com.amazonaws.services.kinesis.clientlibrary.proxies.IKinesisProxy;
+import com.amazonaws.services.kinesis.leases.interfaces.ILeaseManager;
+
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -1076,6 +1078,7 @@ public class Worker implements Runnable {
         private AmazonDynamoDB dynamoDBClient;
         private AmazonCloudWatch cloudWatchClient;
         private IMetricsFactory metricsFactory;
+        private ILeaseManager<KinesisClientLease> leaseManager;
         private ExecutorService execService;
         private ShardPrioritization shardPrioritization;
         private IKinesisProxy kinesisProxy;
@@ -1170,6 +1173,18 @@ public class Worker implements Runnable {
          */
         public Builder metricsFactory(IMetricsFactory metricsFactory) {
             this.metricsFactory = metricsFactory;
+            return this;
+        }
+
+        /**
+         * Set the lease manager.
+         *
+         * @param leaseManager
+         *            Lease manager used to manage shard leases
+         * @return A reference to this updated object so that method calls can be chained together.
+         */
+        public Builder leaseManager(ILeaseManager<KinesisClientLease> leaseManager) {
+            this.leaseManager = leaseManager;
             return this;
         }
 
@@ -1273,6 +1288,9 @@ public class Worker implements Runnable {
             if (metricsFactory == null) {
                 metricsFactory = getMetricsFactory(cloudWatchClient, config);
             }
+            if (leaseManager == null) {
+                leaseManager = new KinesisClientLeaseManager(config.getTableName(), dynamoDBClient);
+            }
             if (shardPrioritization == null) {
                 shardPrioritization = new ParentsFirstShardPrioritization(1);
             }
@@ -1294,8 +1312,7 @@ public class Worker implements Runnable {
                     config.getShardSyncIntervalMillis(),
                     config.shouldCleanupLeasesUponShardCompletion(),
                     null,
-                    new KinesisClientLibLeaseCoordinator(new KinesisClientLeaseManager(config.getTableName(),
-                            dynamoDBClient),
+                    new KinesisClientLibLeaseCoordinator(leaseManager,
                             config.getWorkerIdentifier(),
                             config.getFailoverTimeMillis(),
                             config.getEpsilonMillis(),

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/Worker.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/Worker.java
@@ -427,6 +427,13 @@ public class Worker implements Runnable {
     }
 
     /**
+     * @return the leaseCoordinator
+     */
+    KinesisClientLibLeaseCoordinator getLeaseCoordinator(){
+        return leaseCoordinator;
+    }
+
+    /**
      * Start consuming data from the stream, and pass it to the application record processors.
      */
     public void run() {

--- a/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/WorkerTest.java
+++ b/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/WorkerTest.java
@@ -1500,6 +1500,33 @@ public class WorkerTest {
         Assert.assertTrue(worker.getStreamConfig().getStreamProxy() instanceof KinesisLocalFileProxy);
     }
 
+    @Test
+    public void testBuilderWithDefaultLeaseManager()  {
+        IRecordProcessorFactory recordProcessorFactory = mock(IRecordProcessorFactory.class);
+
+        Worker worker = new Worker.Builder()
+                .recordProcessorFactory(recordProcessorFactory)
+                .config(config)
+                .build();
+
+        Assert.assertNotNull(worker.getLeaseCoordinator().getLeaseManager());
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testBuilderWhenLeaseManagerIsSet()  {
+        IRecordProcessorFactory recordProcessorFactory = mock(IRecordProcessorFactory.class);
+        // Create an instance of ILeaseManager for injection and validation
+        ILeaseManager<KinesisClientLease> leaseManager = (ILeaseManager<KinesisClientLease>) mock(ILeaseManager.class);
+        Worker worker = new Worker.Builder()
+                .recordProcessorFactory(recordProcessorFactory)
+                .config(config)
+                .leaseManager(leaseManager)
+                .build();
+
+        Assert.assertSame(leaseManager, worker.getLeaseCoordinator().getLeaseManager());
+    }
+
     private abstract class InjectableWorker extends Worker {
         InjectableWorker(String applicationName, IRecordProcessorFactory recordProcessorFactory,
                 KinesisClientLibConfiguration config, StreamConfig streamConfig,


### PR DESCRIPTION
Continuing the work started on PR: 
https://github.com/awslabs/amazon-kinesis-client/pull/255

(sorry for creating a new PR)

Added tests as requested.