### PR TITLE
Make lastException from initialize() available

### DIFF
--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/Worker.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/Worker.java
@@ -104,6 +104,7 @@ public class Worker implements Runnable {
     private volatile boolean shutdown;
     private volatile long shutdownStartTimeMillis;
     private volatile boolean shutdownComplete = false;
+    private volatile Exception lastException = null;
 
     // Holds consumers for shards the worker is currently tracking. Key is shard
     // info, value is ShardConsumer.
@@ -617,7 +618,6 @@ public class Worker implements Runnable {
     private void initialize() {
         workerStateChangeListener.onWorkerStateChange(WorkerStateChangeListener.WorkerState.INITIALIZING);
         boolean isDone = false;
-        Exception lastException = null;
 
         for (int i = 0; (!isDone) && (i < MAX_INITIALIZATION_ATTEMPTS); i++) {
             try {
@@ -880,6 +880,14 @@ public class Worker implements Runnable {
 
     WorkerStateChangeListener getWorkerStateChangeListener() {
         return workerStateChangeListener;
+    }
+    
+    /**
+     * The last of any exception encountered during initialize() will be available here
+     */
+    public Exception getLastException()
+    {
+    	return lastException;
     }
 
     /**


### PR DESCRIPTION
Issue #312

During each run of initialize() an exception could be encountered, this makes that exception available via a getter to whatever created the thread to be able to take further action with it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.