### PR TITLE
Get consumer running again

### DIFF
--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/checkpoint/CheckpointFactory.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/checkpoint/CheckpointFactory.java
@@ -15,12 +15,12 @@
 
 package software.amazon.kinesis.checkpoint;
 
-import software.amazon.kinesis.leases.ILeaseManager;
+import software.amazon.kinesis.leases.KinesisClientLibLeaseCoordinator;
 import software.amazon.kinesis.processor.ICheckpoint;
 
 /**
  *
  */
 public interface CheckpointFactory {
-    ICheckpoint createCheckpoint();
+    ICheckpoint createCheckpoint(KinesisClientLibLeaseCoordinator leaseCoordinator);
 }

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/checkpoint/DynamoDBCheckpointFactory.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/checkpoint/DynamoDBCheckpointFactory.java
@@ -40,14 +40,7 @@ public class DynamoDBCheckpointFactory implements CheckpointFactory {
     private final IMetricsFactory metricsFactory;
 
     @Override
-    public ICheckpoint createCheckpoint() {
-        return new KinesisClientLibLeaseCoordinator(leaseManager,
-                workerIdentifier,
-                failoverTimeMillis,
-                epsilonMillis,
-                maxLeasesForWorker,
-                maxLeasesToStealAtOneTime,
-                maxLeaseRenewalThreads,
-                metricsFactory);
+    public ICheckpoint createCheckpoint(KinesisClientLibLeaseCoordinator leaseCoordinator) {
+        return leaseCoordinator;
     }
 }

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/leases/LeaseRenewer.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/leases/LeaseRenewer.java
@@ -168,7 +168,8 @@ public class LeaseRenewer<T extends Lease> implements ILeaseRenewer<T> {
                         // Don't renew expired lease during regular renewals. getCopyOfHeldLease may have returned null
                         // triggering the application processing to treat this as a lost lease (fail checkpoint with
                         // ShutdownException).
-                        if (renewEvenIfExpired || (!lease.isExpired(leaseDurationNanos, System.nanoTime()))) {
+                        boolean isLeaseExpired = lease.isExpired(leaseDurationNanos, System.nanoTime());
+                        if (renewEvenIfExpired || !isLeaseExpired) {
                             renewedLease = leaseManager.renewLease(lease);
                         }
                         if (renewedLease) {

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/lifecycle/ConsumerStates.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/lifecycle/ConsumerStates.java
@@ -257,7 +257,8 @@ class ConsumerStates {
             return new InitializeTask(consumer.shardInfo(),
                     consumer.recordProcessor(),
                     consumer.checkpoint(),
-                    consumer.recordProcessorCheckpointer(),
+                    consumer.recordProcessorCheckpointer(), consumer.initialPositionInStream(),
+                    consumer.getRecordsCache(),
                     consumer.taskBackoffTimeMillis());
         }
 

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/BlockingGetRecordsCache.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/BlockingGetRecordsCache.java
@@ -15,8 +15,11 @@
 
 package software.amazon.kinesis.retrieval;
 
-import software.amazon.kinesis.lifecycle.ProcessRecordsInput;
+import com.amazonaws.services.kinesis.clientlibrary.lib.worker.InitialPositionInStreamExtended;
 import com.amazonaws.services.kinesis.model.GetRecordsResult;
+
+import software.amazon.kinesis.lifecycle.ProcessRecordsInput;
+import software.amazon.kinesis.retrieval.kpl.ExtendedSequenceNumber;
 
 /**
  * This is the BlockingGetRecordsCache class. This class blocks any calls to the getRecords on the
@@ -33,7 +36,8 @@ public class BlockingGetRecordsCache implements GetRecordsCache {
     }
 
     @Override
-    public void start() {
+    public void start(ExtendedSequenceNumber extendedSequenceNumber,
+            InitialPositionInStreamExtended initialPositionInStreamExtended) {
         //
         // Nothing to do here
         //

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/GetRecordsCache.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/GetRecordsCache.java
@@ -15,7 +15,9 @@
 
 package software.amazon.kinesis.retrieval;
 
+import com.amazonaws.services.kinesis.clientlibrary.lib.worker.InitialPositionInStreamExtended;
 import software.amazon.kinesis.lifecycle.ProcessRecordsInput;
+import software.amazon.kinesis.retrieval.kpl.ExtendedSequenceNumber;
 
 /**
  * This class is used as a cache for Prefetching data from Kinesis.
@@ -24,7 +26,7 @@ public interface GetRecordsCache {
     /**
      * This method calls the start behavior on the cache, if available.
      */
-    void start();
+    void start(ExtendedSequenceNumber extendedSequenceNumber, InitialPositionInStreamExtended initialPositionInStreamExtended);
     
     /**
      * This method returns the next set of records from the Cache if present, or blocks the request till it gets the

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/RecordsFetcherFactory.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/RecordsFetcherFactory.java
@@ -39,7 +39,7 @@ public interface RecordsFetcherFactory {
     /**
      * Sets the maximum number of ProcessRecordsInput objects the GetRecordsCache can hold, before further requests are
      * blocked.
-     * 
+     *
      * @param maxPendingProcessRecordsInput The maximum number of ProcessRecordsInput objects that the cache will accept
      *                                     before blocking.
      */
@@ -48,7 +48,7 @@ public interface RecordsFetcherFactory {
     /**
      * Sets the max byte size for the GetRecordsCache, before further requests are blocked. The byte size of the cache
      * is the sum of byte size of all the ProcessRecordsInput objects in the cache at any point of time.
-     * 
+     *
      * @param maxByteSize The maximum byte size for the cache before blocking.
      */
     void setMaxByteSize(int maxByteSize);
@@ -57,21 +57,21 @@ public interface RecordsFetcherFactory {
      * Sets the max number of records for the GetRecordsCache can hold, before further requests are blocked. The records
      * count is the sum of all records present in across all the ProcessRecordsInput objects in the cache at any point
      * of time.
-     * 
+     *
      * @param maxRecordsCount The mximum number of records in the cache before blocking.
      */
     void setMaxRecordsCount(int maxRecordsCount);
 
     /**
      * Sets the dataFetchingStrategy to determine the type of GetRecordsCache to be used.
-     * 
+     *
      * @param dataFetchingStrategy Fetching strategy to be used
      */
     void setDataFetchingStrategy(DataFetchingStrategy dataFetchingStrategy);
 
     /**
      * Sets the maximum idle time between two get calls.
-     * 
+     *
      * @param idleMillisBetweenCalls Sleep millis between calls.
      */
     void setIdleMillisBetweenCalls(long idleMillisBetweenCalls);

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/RetrievalConfig.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/RetrievalConfig.java
@@ -19,8 +19,8 @@ import java.util.Optional;
 
 import com.amazonaws.services.kinesis.AmazonKinesis;
 import com.amazonaws.services.kinesis.clientlibrary.lib.worker.InitialPositionInStream;
-
 import com.amazonaws.services.kinesis.clientlibrary.lib.worker.InitialPositionInStreamExtended;
+
 import lombok.Data;
 import lombok.NonNull;
 import lombok.experimental.Accessors;
@@ -119,6 +119,7 @@ public class RetrievalConfig {
     public RetrievalFactory retrievalFactory() {
         if (retrievalFactory == null) {
             retrievalFactory = new SynchronousBlockingRetrievalFactory(streamName(), amazonKinesis(),
+                    recordsFetcherFactory,
                     listShardsBackoffTimeInMillis(), maxListShardsRetryAttempts(), maxRecords());
         }
         return retrievalFactory;

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/RetrievalFactory.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/RetrievalFactory.java
@@ -16,6 +16,7 @@
 package software.amazon.kinesis.retrieval;
 
 import software.amazon.kinesis.leases.ShardInfo;
+import software.amazon.kinesis.metrics.IMetricsFactory;
 
 /**
  *
@@ -23,5 +24,5 @@ import software.amazon.kinesis.leases.ShardInfo;
 public interface RetrievalFactory {
     GetRecordsRetrievalStrategy createGetRecordsRetrievalStrategy(ShardInfo shardInfo);
 
-    GetRecordsCache createGetRecordsCache(ShardInfo shardInfo);
+    GetRecordsCache createGetRecordsCache(ShardInfo shardInfo, IMetricsFactory metricsFactory);
 }

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/SynchronousBlockingRetrievalFactory.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/SynchronousBlockingRetrievalFactory.java
@@ -19,6 +19,7 @@ import com.amazonaws.services.kinesis.AmazonKinesis;
 import lombok.Data;
 import lombok.NonNull;
 import software.amazon.kinesis.leases.ShardInfo;
+import software.amazon.kinesis.metrics.IMetricsFactory;
 
 /**
  *
@@ -34,6 +35,8 @@ public class SynchronousBlockingRetrievalFactory implements RetrievalFactory {
     private final String streamName;
     @NonNull
     private final AmazonKinesis amazonKinesis;
+    private final RecordsFetcherFactory recordsFetcherFactory;
+
     private final long listShardsBackoffTimeInMillis;
     private final int maxListShardsRetryAttempts;
     private final int maxRecords;
@@ -45,7 +48,7 @@ public class SynchronousBlockingRetrievalFactory implements RetrievalFactory {
     }
 
     @Override
-    public GetRecordsCache createGetRecordsCache(@NonNull final ShardInfo shardInfo) {
-        throw new UnsupportedOperationException();
+    public GetRecordsCache createGetRecordsCache(@NonNull final ShardInfo shardInfo, IMetricsFactory metricsFactory) {
+        return recordsFetcherFactory.createRecordsFetcher(createGetRecordsRetrievalStrategy(shardInfo), shardInfo.shardId(), metricsFactory, maxRecords);
     }
 }

--- a/amazon-kinesis-client/src/test/java/software/amazon/kinesis/coordinator/SchedulerTest.java
+++ b/amazon-kinesis-client/src/test/java/software/amazon/kinesis/coordinator/SchedulerTest.java
@@ -65,6 +65,7 @@ import software.amazon.kinesis.lifecycle.ProcessRecordsInput;
 import software.amazon.kinesis.lifecycle.ShardConsumer;
 import software.amazon.kinesis.lifecycle.ShutdownInput;
 import software.amazon.kinesis.lifecycle.ShutdownReason;
+import software.amazon.kinesis.metrics.IMetricsFactory;
 import software.amazon.kinesis.metrics.MetricsConfig;
 import software.amazon.kinesis.processor.ICheckpoint;
 import software.amazon.kinesis.processor.IRecordProcessor;
@@ -131,7 +132,7 @@ public class SchedulerTest {
 
         when(leaseCoordinator.leaseManager()).thenReturn(leaseManager);
         when(shardSyncTaskManager.leaseManagerProxy()).thenReturn(leaseManagerProxy);
-        when(retrievalFactory.createGetRecordsCache(any(ShardInfo.class))).thenReturn(getRecordsCache);
+        when(retrievalFactory.createGetRecordsCache(any(ShardInfo.class), any(IMetricsFactory.class))).thenReturn(getRecordsCache);
 
         scheduler = new Scheduler(checkpointConfig, coordinatorConfig, leaseManagementConfig, lifecycleConfig,
                 metricsConfig, processorConfig, retrievalConfig);
@@ -457,7 +458,7 @@ public class SchedulerTest {
 
     private class TestKinesisCheckpointFactory implements CheckpointFactory {
         @Override
-        public ICheckpoint createCheckpoint() {
+        public ICheckpoint createCheckpoint(KinesisClientLibLeaseCoordinator leaseCoordinator) {
             return checkpoint;
         }
     }

--- a/amazon-kinesis-client/src/test/java/software/amazon/kinesis/lifecycle/ShardConsumerTest.java
+++ b/amazon-kinesis-client/src/test/java/software/amazon/kinesis/lifecycle/ShardConsumerTest.java
@@ -308,7 +308,7 @@ public class ShardConsumerTest {
         assertThat(consumer.getCurrentState(), is(equalTo(ConsumerStates.ShardConsumerState.INITIALIZING)));
         consumer.consumeShard(); // initialize
         processor.getInitializeLatch().await(5, TimeUnit.SECONDS);
-        verify(getRecordsCache).start();
+        verify(getRecordsCache).start(any(ExtendedSequenceNumber.class), any(InitialPositionInStreamExtended.class));
 
         // We expect to process all records in numRecs calls
         for (int i = 0; i < numRecs;) {
@@ -410,7 +410,7 @@ public class ShardConsumerTest {
         assertThat(consumer.getCurrentState(), is(equalTo(ConsumerStates.ShardConsumerState.INITIALIZING)));
         consumer.consumeShard(); // initialize
         processor.getInitializeLatch().await(5, TimeUnit.SECONDS);
-        verify(getRecordsCache).start();
+        verify(getRecordsCache).start(any(ExtendedSequenceNumber.class), any(InitialPositionInStreamExtended.class));
 
         // We expect to process all records in numRecs calls
         for (int i = 0; i < numRecs;) {

--- a/amazon-kinesis-client/src/test/java/software/amazon/kinesis/retrieval/PrefetchGetRecordsCacheIntegrationTest.java
+++ b/amazon-kinesis-client/src/test/java/software/amazon/kinesis/retrieval/PrefetchGetRecordsCacheIntegrationTest.java
@@ -32,6 +32,7 @@ import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
+import com.amazonaws.services.kinesis.clientlibrary.lib.worker.InitialPositionInStreamExtended;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Ignore;
@@ -50,6 +51,7 @@ import com.amazonaws.services.kinesis.model.Record;
 import lombok.extern.slf4j.Slf4j;
 import software.amazon.kinesis.lifecycle.ProcessRecordsInput;
 import software.amazon.kinesis.metrics.NullMetricsFactory;
+import software.amazon.kinesis.retrieval.kpl.ExtendedSequenceNumber;
 
 /**
  * These are the integration tests for the PrefetchGetRecordsCache class. 
@@ -74,6 +76,10 @@ public class PrefetchGetRecordsCacheIntegrationTest {
 
     @Mock
     private AmazonKinesis amazonKinesis;
+    @Mock
+    private ExtendedSequenceNumber extendedSequenceNumber;
+    @Mock
+    private InitialPositionInStreamExtended initialPosition;
 
     @Before
     public void setup() {
@@ -95,7 +101,7 @@ public class PrefetchGetRecordsCacheIntegrationTest {
 
     @Test
     public void testRollingCache() {
-        getRecordsCache.start();
+        getRecordsCache.start(extendedSequenceNumber, initialPosition);
         sleep(IDLE_MILLIS_BETWEEN_CALLS);
 
         ProcessRecordsInput processRecordsInput1 = getRecordsCache.getNextResult();
@@ -111,7 +117,7 @@ public class PrefetchGetRecordsCacheIntegrationTest {
 
     @Test
     public void testFullCache() {
-        getRecordsCache.start();
+        getRecordsCache.start(extendedSequenceNumber, initialPosition);
         sleep(MAX_SIZE * IDLE_MILLIS_BETWEEN_CALLS);
 
         assertEquals(getRecordsCache.getRecordsResultQueue.size(), MAX_SIZE);
@@ -141,7 +147,7 @@ public class PrefetchGetRecordsCacheIntegrationTest {
                 operation,
                 "test-shard-2");
 
-        getRecordsCache.start();
+        getRecordsCache.start(extendedSequenceNumber, initialPosition);
         sleep(IDLE_MILLIS_BETWEEN_CALLS);
 
         final Record record = mock(Record.class);
@@ -152,7 +158,7 @@ public class PrefetchGetRecordsCacheIntegrationTest {
         records.add(record);
         records.add(record);
         records.add(record);
-        getRecordsCache2.start();
+        getRecordsCache2.start(extendedSequenceNumber, initialPosition);
 
         sleep(IDLE_MILLIS_BETWEEN_CALLS);
 
@@ -181,7 +187,7 @@ public class PrefetchGetRecordsCacheIntegrationTest {
         }).thenCallRealMethod();
         doNothing().when(dataFetcher).restartIterator();
 
-        getRecordsCache.start();
+        getRecordsCache.start(extendedSequenceNumber, initialPosition);
         sleep(IDLE_MILLIS_BETWEEN_CALLS);
 
         ProcessRecordsInput processRecordsInput = getRecordsCache.getNextResult();


### PR DESCRIPTION
Temporary fix for lease management <=> checkpoint issue

Initialize the get records cache with the shard position, and pass
that configuration to the data fetcher.