### PR TITLE
Release 1.9.1 of the Amazon Kinesis Client Library for Java

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
   A custom `LeaseManager` can be provided to `Worker.Builder` that will be used to provide lease services. 
   This makes it possible to implement custom lease management systems in addition to the default DynamoDB system.  
   * [PR #297](https://github.com/awslabs/amazon-kinesis-client/pull/297)
+* Updated the version of the AWS Java SDK to 1.11.219
 
 ## Release 1.9.0 (February 6, 2018)
 * Introducing support for ListShards API. This API is used in place of DescribeStream API to provide more throughput during ShardSyncTask. Please consult the [AWS Documentation for ListShards](https://docs.aws.amazon.com/kinesis/latest/APIReference/API_ListShards.html) for more information.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Release 1.9.1 (April 30, 2018)
+* Added the ability to create a prepared checkpoint when at `SHARD_END`.
+  * [PR #301](https://github.com/awslabs/amazon-kinesis-client/pull/301)
+* Added the ability to subscribe to worker state change events.  
+  * [PR #291](https://github.com/awslabs/amazon-kinesis-client/pull/291)
+* Added support for custom lease managers.  
+  A custom `LeaseManager` can be provided to `Worker.Builder` that will be used to provide lease services. 
+  This makes it possible to implement custom lease management systems in addition to the default DynamoDB system.  
+  * [PR #297](https://github.com/awslabs/amazon-kinesis-client/pull/297)
+
 ## Release 1.9.0 (February 6, 2018)
 * Introducing support for ListShards API. This API is used in place of DescribeStream API to provide more throughput during ShardSyncTask. Please consult the [AWS Documentation for ListShards](https://docs.aws.amazon.com/kinesis/latest/APIReference/API_ListShards.html) for more information.
   * ListShards supports higher call rate, which should reduce instances of throttling when attempting to synchronize the shard list.

--- a/META-INF/MANIFEST.MF
+++ b/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Amazon Kinesis Client Library for Java
 Bundle-SymbolicName: com.amazonaws.kinesisclientlibrary;singleton:=true
-Bundle-Version: 1.9.0
+Bundle-Version: 1.9.1
 Bundle-Vendor: Amazon Technologies, Inc
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.apache.commons.codec;bundle-version="1.6",
@@ -12,7 +12,7 @@ Require-Bundle: org.apache.commons.codec;bundle-version="1.6",
  com.fasterxml.jackson.core.jackson-annotations;bundle-version="2.5.0",
  org.apache.httpcomponents.httpcore;bundle-version="4.3.3",
  org.apache.httpcomponents.httpclient;bundle-version="4.3.6"
- com.amazonaws.sdk;bundle-version="1.11.14",
+ com.amazonaws.sdk;bundle-version="1.11.319",
 Export-Package: com.amazonaws.services.kinesis,
  com.amazonaws.services.kinesis.clientlibrary,
  com.amazonaws.services.kinesis.clientlibrary.config,

--- a/README.md
+++ b/README.md
@@ -30,25 +30,15 @@ To make it easier for developers to write record processors in other languages, 
 
 ## Release Notes
 
-### Latest Release (1.9.0)
-* Introducing support for ListShards API. This API is used in place of DescribeStream API to provide more throughput during ShardSyncTask. Please consult the [AWS Documentation for ListShards](https://docs.aws.amazon.com/kinesis/latest/APIReference/API_ListShards.html) for more information.
-  * ListShards supports higher call rate, which should reduce instances of throttling when attempting to synchronize the shard list.
-  * __WARNING: `ListShards` is a new API, and may require updating any explicit IAM policies__
-  * Added configuration parameters for ListShards usage  
-  
-    | Name | Default | Description |
-    | ---- | ------- | ----------- |
-    | [listShardsBackoffTimeInMillis](https://github.com/awslabs/amazon-kinesis-client/blob/3ae916c5fcdccd6b835c86ba7f6f53dd5b4c8b04/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/KinesisClientLibConfiguration.java#L1412) | 1500 ms | This is the default backoff time between 2 ListShards calls when throttled. |
-    | [listShardsRetryAttempts](https://github.com/awslabs/amazon-kinesis-client/blob/3ae916c5fcdccd6b835c86ba7f6f53dd5b4c8b04/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/KinesisClientLibConfiguration.java#L1423) | 50 | This is the maximum number of times the KinesisProxy will retry to make ListShards calls on being throttled. |
-  
-* Updating the version of AWS Java SDK to 1.11.272.
-  * Version 1.11.272 is now the minimum support version of the SDK.
-* Deprecating the following methods, and classes. These methods, and classes will be removed in a future release.
-  * Deprecated [IKinesisProxy#getStreamInfo](https://github.com/awslabs/amazon-kinesis-client/blob/3ae916c5fcdccd6b835c86ba7f6f53dd5b4c8b04/src/main/java/com/amazonaws/services/kinesis/clientlibrary/proxies/IKinesisProxy.java#L48-L62).
-  * Deprecated [IKinesisProxyFactory](https://github.com/awslabs/amazon-kinesis-client/blob/3ae916c5fcdccd6b835c86ba7f6f53dd5b4c8b04/src/main/java/com/amazonaws/services/kinesis/clientlibrary/proxies/IKinesisProxyFactory.java).
-  * Deprecated [KinesisProxyFactory](https://github.com/awslabs/amazon-kinesis-client/blob/3ae916c5fcdccd6b835c86ba7f6f53dd5b4c8b04/src/main/java/com/amazonaws/services/kinesis/clientlibrary/proxies/KinesisProxyFactory.java).
-  * Deprecated certain [KinesisProxy](https://github.com/awslabs/amazon-kinesis-client/blob/3ae916c5fcdccd6b835c86ba7f6f53dd5b4c8b04/src/main/java/com/amazonaws/services/kinesis/clientlibrary/proxies/KinesisProxy.java) constructors.
-    * [PR #293](https://github.com/awslabs/amazon-kinesis-client/pull/293)
+### Latest Release (1.9.1)
+* Added the ability to create a prepared checkpoint when at `SHARD_END`.
+  * [PR #301](https://github.com/awslabs/amazon-kinesis-client/pull/301)
+* Added the ability to subscribe to worker state change events.  
+  * [PR #291](https://github.com/awslabs/amazon-kinesis-client/pull/291)
+* Added support for custom lease managers.  
+  A custom `LeaseManager` can be provided to `Worker.Builder` that will be used to provide lease services. 
+  This makes it possible to implement custom lease management systems in addition to the default DynamoDB system.  
+  * [PR #297](https://github.com/awslabs/amazon-kinesis-client/pull/297)
   
 ### For remaining release notes check **[CHANGELOG.md][changelog-md]**.
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ To make it easier for developers to write record processors in other languages, 
   A custom `LeaseManager` can be provided to `Worker.Builder` that will be used to provide lease services. 
   This makes it possible to implement custom lease management systems in addition to the default DynamoDB system.  
   * [PR #297](https://github.com/awslabs/amazon-kinesis-client/pull/297)
-  
+* Updated the version of the AWS Java SDK to 1.11.219
+
 ### For remaining release notes check **[CHANGELOG.md][changelog-md]**.
 
 [kinesis]: http://aws.amazon.com/kinesis

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <artifactId>amazon-kinesis-client</artifactId>
   <packaging>jar</packaging>
   <name>Amazon Kinesis Client Library for Java</name>
-  <version>1.9.1-SNAPSHOT</version>
+  <version>1.9.1</version>
   <description>The Amazon Kinesis Client Library for Java enables Java developers to easily consume and process data
     from Amazon Kinesis.
   </description>
@@ -25,7 +25,7 @@
   </licenses>
 
   <properties>
-    <aws-java-sdk.version>1.11.272</aws-java-sdk.version>
+    <aws-java-sdk.version>1.11.319</aws-java-sdk.version>
     <sqlite4java.version>1.0.392</sqlite4java.version>
     <sqlite4java.native>libsqlite4java</sqlite4java.native>
     <sqlite4java.libpath>${project.build.directory}/test-lib</sqlite4java.libpath>

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/KinesisClientLibConfiguration.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/KinesisClientLibConfiguration.java
@@ -126,7 +126,7 @@ public class KinesisClientLibConfiguration {
     /**
      * User agent set when Amazon Kinesis Client Library makes AWS requests.
      */
-    public static final String KINESIS_CLIENT_LIB_USER_AGENT = "amazon-kinesis-client-library-java-1.9.0";
+    public static final String KINESIS_CLIENT_LIB_USER_AGENT = "amazon-kinesis-client-library-java-1.9.1";
 
     /**
      * KCL will validate client provided sequence numbers with a call to Amazon Kinesis before checkpointing for calls


### PR DESCRIPTION
Updated versions, and release notes.

## Release 1.9.1 (April 30, 2018)
* Added the ability to create a prepared checkpoint when at `SHARD_END`.
  * [PR #301](https://github.com/awslabs/amazon-kinesis-client/pull/301)
* Added the ability to subscribe to worker state change events.  
  * [PR #291](https://github.com/awslabs/amazon-kinesis-client/pull/291)
* Added support for custom lease managers.  
  A custom `LeaseManager` can be provided to `Worker.Builder` that will be used to provide lease services. 
  This makes it possible to implement custom lease management systems in addition to the default DynamoDB system.  
  * [PR #297](https://github.com/awslabs/amazon-kinesis-client/pull/297)
* Updated the version of the AWS Java SDK to 1.11.219