### PR TITLE
Enables property for setting AT_TIMESTAMP shard iterator initial time…

### DIFF
--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/config/DatePropertyValueDecorder.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/config/DatePropertyValueDecorder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Amazon Software License (the "License").
  * You may not use this file except in compliance with the License.
@@ -35,7 +35,11 @@ class DatePropertyValueDecoder implements IPropertyValueDecoder<Date> {
      */
     @Override
     public Date decodeValue(String value) {
-        return new Date(Long.parseLong(value) * 1000L);
+        try {
+            return new Date(Long.parseLong(value) * 1000L);
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("Date property value must be numeric.");
+        }
     }
 
     /**

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/config/DatePropertyValueDecorder.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/config/DatePropertyValueDecorder.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2014 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Amazon Software License (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://aws.amazon.com/asl/
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.services.kinesis.clientlibrary.config;
+
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+
+/**
+ * Provide Date property.
+ */
+class DatePropertyValueDecoder implements IPropertyValueDecoder<Date> {
+
+    /**
+     * Constructor.
+     */
+    DatePropertyValueDecoder() {
+    }
+
+    /**
+     * @param value property value as String
+     * @return corresponding variable in correct type
+     */
+    @Override
+    public Date decodeValue(String value) {
+        return new Date(Long.parseLong(value) * 1000L);
+    }
+
+    /**
+     * @return list of supported types
+     */
+    @Override
+    public List<Class<Date>> getSupportedTypes() {
+        return Arrays.asList(Date.class);
+    }
+
+}

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/config/KinesisClientLibConfigurator.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/config/KinesisClientLibConfigurator.java
@@ -66,6 +66,7 @@ public class KinesisClientLibConfigurator {
                 Arrays.asList(new IntegerPropertyValueDecoder(),
                         new LongPropertyValueDecoder(),
                         new BooleanPropertyValueDecoder(),
+                        new DatePropertyValueDecoder(),
                         new AWSCredentialsProviderPropertyValueDecoder(),
                         new StringPropertyValueDecoder(),
                         new InitialPositionInStreamPropertyValueDecoder(),

--- a/src/test/java/com/amazonaws/services/kinesis/clientlibrary/config/DatePropertyValueDecoderTest.java
+++ b/src/test/java/com/amazonaws/services/kinesis/clientlibrary/config/DatePropertyValueDecoderTest.java
@@ -36,33 +36,18 @@ public class DatePropertyValueDecoderTest {
         assertEquals(timestamp, new Date(Long.parseLong(TEST_VALUE) * 1000L));
     }
 
-    @Test
+    @Test(expected = IllegalArgumentException.class)
     public void testEmptyValue() {
-        try {
-          Date timestamp = decoder.decodeValue("");
-          fail("Expect IllegalArgumentException on empty value");
-        } catch (IllegalArgumentException e) {
-          // success
-        }
+        Date timestamp = decoder.decodeValue("");
     }
 
-    @Test
+    @Test(expected = IllegalArgumentException.class)
     public void testNullValue() {
-        try {
-          Date timestamp = decoder.decodeValue(null);
-          fail("Expect IllegalArgumentException on null value");
-        } catch (IllegalArgumentException e) {
-          // success
-        }
+        Date timestamp = decoder.decodeValue(null);
     }
 
-    @Test
+    @Test(expected = IllegalArgumentException.class)
     public void testNonNumericValue() {
-        try {
-          Date timestamp = decoder.decodeValue("123abc");
-          fail("Expect IllegalArgumentException on non numeric value");
-        } catch (IllegalArgumentException e) {
-          // success
-        }
+        Date timestamp = decoder.decodeValue("123abc");
     }
 }

--- a/src/test/java/com/amazonaws/services/kinesis/clientlibrary/config/DatePropertyValueDecoderTest.java
+++ b/src/test/java/com/amazonaws/services/kinesis/clientlibrary/config/DatePropertyValueDecoderTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Amazon Software License (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://aws.amazon.com/asl/
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.services.kinesis.clientlibrary.config;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import java.util.Date;
+
+import org.junit.Test;
+
+import com.amazonaws.services.kinesis.clientlibrary.config.DatePropertyValueDecoder;
+
+public class DatePropertyValueDecoderTest {
+
+    private DatePropertyValueDecoder decoder = new DatePropertyValueDecoder();
+
+    private static final String TEST_VALUE = "1527267472";
+
+    @Test
+    public void testNumericValue() {
+        Date timestamp = decoder.decodeValue(TEST_VALUE);
+        assertEquals(timestamp.getClass(), Date.class);
+        assertEquals(timestamp, new Date(Long.parseLong(TEST_VALUE) * 1000L));
+    }
+
+    @Test
+    public void testEmptyValue() {
+        try {
+          Date timestamp = decoder.decodeValue("");
+          fail("Expect IllegalArgumentException on empty value");
+        } catch (IllegalArgumentException e) {
+          // success
+        }
+    }
+
+    @Test
+    public void testNullValue() {
+        try {
+          Date timestamp = decoder.decodeValue(null);
+          fail("Expect IllegalArgumentException on null value");
+        } catch (IllegalArgumentException e) {
+          // success
+        }
+    }
+
+    @Test
+    public void testNonNumericValue() {
+        try {
+          Date timestamp = decoder.decodeValue("123abc");
+          fail("Expect IllegalArgumentException on non numeric value");
+        } catch (IllegalArgumentException e) {
+          // success
+        }
+    }
+}

--- a/src/test/java/com/amazonaws/services/kinesis/clientlibrary/config/KinesisClientLibConfiguratorTest.java
+++ b/src/test/java/com/amazonaws/services/kinesis/clientlibrary/config/KinesisClientLibConfiguratorTest.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.fail;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
+import java.util.Date;
 import java.util.Optional;
 import java.util.Set;
 
@@ -144,6 +145,20 @@ public class KinesisClientLibConfiguratorTest {
     }
 
     @Test
+    public void testWithDateVariables() {
+        KinesisClientLibConfiguration config =
+                getConfiguration(StringUtils.join(new String[] {
+                        "streamName = a",
+                        "applicationName = b",
+                        "AWSCredentialsProvider = ABCD, " + credentialName1,
+                        "timestampAtInitialPositionInStream = 1527267472"
+                }, '\n'));
+
+        assertEquals(config.getTimestampAtInitialPositionInStream(), 
+                new Date(1527267472 * 1000L));
+    }
+
+    @Test
     public void testWithStringVariables() {
         KinesisClientLibConfiguration config =
                 getConfiguration(StringUtils.join(new String[] {
@@ -189,6 +204,49 @@ public class KinesisClientLibConfiguratorTest {
                 }, '\n'));
 
         assertEquals(config.getInitialPositionInStream(), InitialPositionInStream.TRIM_HORIZON);
+    }    
+
+    @Test
+    public void testWithTimestampAtInitialPositionInStreamVariables() {
+        KinesisClientLibConfiguration config =
+                getConfiguration(StringUtils.join(new String[] {
+                        "streamName = a",
+                        "applicationName = b",
+                        "AWSCredentialsProvider = ABCD," + credentialName1,
+                        "timestampAtInitialPositionInStream = 1527267472"
+                }, '\n'));
+
+        assertEquals(config.getInitialPositionInStream(), InitialPositionInStream.AT_TIMESTAMP);
+        assertEquals(config.getTimestampAtInitialPositionInStream(), 
+                new Date(1527267472 * 1000L));
+    }
+
+    @Test
+    public void testWithEmptyTimestampAtInitialPositionInStreamVariables() {
+        KinesisClientLibConfiguration config =
+                getConfiguration(StringUtils.join(new String[] {
+                        "streamName = a",
+                        "applicationName = b",
+                        "AWSCredentialsProvider = ABCD," + credentialName1,
+                        "timestampAtInitialPositionInStream = "
+                }, '\n'));
+
+        assertEquals(config.getInitialPositionInStream(), InitialPositionInStream.LATEST);
+        assertEquals(config.getTimestampAtInitialPositionInStream(), null);
+    }
+
+    @Test
+    public void testWithNonNumericTimestampAtInitialPositionInStreamVariables() {
+        KinesisClientLibConfiguration config =
+                getConfiguration(StringUtils.join(new String[] {
+                        "streamName = a",
+                        "applicationName = b",
+                        "AWSCredentialsProvider = ABCD," + credentialName1,
+                        "timestampAtInitialPositionInStream = 123abc"
+                }, '\n'));
+
+        assertEquals(config.getInitialPositionInStream(), InitialPositionInStream.LATEST);
+        assertEquals(config.getTimestampAtInitialPositionInStream(), null);
     }
 
     @Test


### PR DESCRIPTION
…stamp (#341)

*Issue #341*

*Description of changes:*

Added `DatePropertyValueDecoder` for use in `KinesisClientLibConfigurator` which enables `timestampAtInitialPositionInStream` property for setting initial timestamp for `AT_TIMESTAMP` shard iterator.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
