### PR TITLE
Application didn't checkpoint at end of shard

### DIFF
--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/RecordProcessorCheckpointer.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/RecordProcessorCheckpointer.java
@@ -298,7 +298,7 @@ class RecordProcessorCheckpointer implements IRecordProcessorCheckpointer {
                 MetricsHelper.setMetricsScope(new ThreadSafeMetricsDelegatingScope(metricsFactory.createMetrics()));
                 unsetMetrics = true;
             }
-            if (extendedSequenceNumber != null && !extendedSequenceNumber.equals(lastCheckpointValue)) {
+            if (checkpointToRecord != null && !checkpointToRecord.equals(lastCheckpointValue)) {
                 try {
                     if (LOG.isDebugEnabled()) {
                         LOG.debug("Setting " + shardInfo.getShardId() + ", token " + shardInfo.getConcurrencyToken()

--- a/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/RecordProcessorCheckpointerTest.java
+++ b/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/RecordProcessorCheckpointerTest.java
@@ -881,4 +881,17 @@ public class RecordProcessorCheckpointerTest {
             MetricsHelper.unsetMetricsScope();
         }
     }
+
+    @Test
+    public final void testCheckpointingAtShardEnd() throws Exception {
+        RecordProcessorCheckpointer processingCheckpointer =
+                new RecordProcessorCheckpointer(shardInfo, checkpoint, sequenceNumberValidator, metricsFactory);
+        String sequenceNumber = "5019";
+        ExtendedSequenceNumber extendedSequenceNumber = new ExtendedSequenceNumber(sequenceNumber);
+        processingCheckpointer.setLargestPermittedCheckpointValue(extendedSequenceNumber);
+        processingCheckpointer.checkpoint(sequenceNumber);
+        processingCheckpointer.setSequenceNumberAtShardEnd(extendedSequenceNumber);
+        processingCheckpointer.checkpoint(sequenceNumber);
+        assertEquals(ExtendedSequenceNumber.SHARD_END, processingCheckpointer.getLastCheckpointValue());
+    }
 }


### PR DESCRIPTION
Issue #211 Application didn't checkpoint at end of shard

*Description of changes:*

Decide whether to checkpoint based on whether `checkpointToRecord` is equal to `lastCheckPointValue`.
- If a shard is open, this makes no difference because `checkpointToRecord` is always equal to `extendedSequenceNumber` .
- If a shard is closed, `sequenceNumberAtShardEnd`  is set, and we are not trying to checkpoint at the last record, this doesn't make a difference, either becuase `checkpointToRecord` is equal to `extendedSequenceNumber`
- When a shard is closed, `sequenceNumberAtShardEnd`  is set, and we are trying to checkpoint at the last record, then  `extendedSequenceNumber` is different from `checkpointToRecord`. If `lastCheckpointValue` it not at the last record, then we could checkpoint value of `checkpointToRecord` because `extendedSequenceNumber` is not equal to `lastCheckpointValue` ; but if `lastCheckpointValue` is at the last reocrd, we couldn't checkpoint becuase it is equal to `extendedSequenceNumber` now.

This patch fixes the issue and this unit test shows a case where the patch helps.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
