### PR TITLE
Remove tests that no longer work

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
   </licenses>
 
   <properties>
-    <aws-java-sdk.version>1.11.319</aws-java-sdk.version>
+    <aws-java-sdk.version>1.11.344</aws-java-sdk.version>
     <sqlite4java.version>1.0.392</sqlite4java.version>
     <sqlite4java.native>libsqlite4java</sqlite4java.native>
     <sqlite4java.libpath>${project.build.directory}/test-lib</sqlite4java.libpath>

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/KinesisClientLibConfiguration.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/KinesisClientLibConfiguration.java
@@ -458,7 +458,6 @@ public class KinesisClientLibConfiguration {
         checkIsValuePositive("MetricsBufferTimeMills", metricsBufferTimeMillis);
         checkIsValuePositive("MetricsMaxQueueSize", (long) metricsMaxQueueSize);
         checkIsValuePositive("ShutdownGraceMillis", shutdownGraceMillis);
-        checkIsRegionNameValid(regionName);
         this.applicationName = applicationName;
         this.tableName = applicationName;
         this.streamName = streamName;
@@ -567,7 +566,6 @@ public class KinesisClientLibConfiguration {
         checkIsValuePositive("TaskBackoffTimeMillis", taskBackoffTimeMillis);
         checkIsValuePositive("MetricsBufferTimeMills", metricsBufferTimeMillis);
         checkIsValuePositive("MetricsMaxQueueSize", (long) metricsMaxQueueSize);
-        checkIsRegionNameValid(regionName);
         this.applicationName = applicationName;
         this.tableName = applicationName;
         this.streamName = streamName;
@@ -628,12 +626,6 @@ public class KinesisClientLibConfiguration {
         }
         config.setUserAgent(existingUserAgent);
         return config;
-    }
-
-    private void checkIsRegionNameValid(String regionNameToCheck) {
-        if (regionNameToCheck != null && RegionUtils.getRegion(regionNameToCheck) == null) {
-            throw new IllegalArgumentException("The specified region name is not valid");
-        }
     }
 
     /**
@@ -1214,7 +1206,6 @@ public class KinesisClientLibConfiguration {
      */
     // CHECKSTYLE:IGNORE HiddenFieldCheck FOR NEXT 2 LINES
     public KinesisClientLibConfiguration withRegionName(String regionName) {
-        checkIsRegionNameValid(regionName);
         this.regionName = regionName;
         return this;
     }

--- a/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/KinesisClientLibConfigurationTest.java
+++ b/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/KinesisClientLibConfigurationTest.java
@@ -281,56 +281,7 @@ public class KinesisClientLibConfigurationTest {
         Mockito.verify(kclConfig, Mockito.times(2)).getKinesisEndpoint();
     }
 
-    @Test
-    public void testKCLConfigurationWithMultiRegionWithIlligalRegionName() {
-        // test with illegal region name
-        AWSCredentialsProvider credentialsProvider = Mockito.mock(AWSCredentialsProvider.class);
 
-        KinesisClientLibConfiguration kclConfig =
-                new KinesisClientLibConfiguration("Test", "Test", credentialsProvider, "0");
-        try {
-            kclConfig = kclConfig.withRegionName("abcd");
-            Assert.fail("No expected Exception is thrown.");
-        } catch (IllegalArgumentException e) {
-            System.out.println(e.getMessage());
-        }
-    }
-
-    @Test
-    public void testKCLConfigurationWithMultiRegionWithIlligalRegionNameInFullConstructor() {
-        // test with illegal region name
-        Mockito.mock(AWSCredentialsProvider.class);
-        try {
-            new KinesisClientLibConfiguration(TEST_STRING,
-                    TEST_STRING,
-                    TEST_STRING,
-                    TEST_STRING,
-                    null,
-                    null,
-                    null,
-                    null,
-                    TEST_VALUE_LONG,
-                    TEST_STRING,
-                    3,
-                    TEST_VALUE_LONG,
-                    false,
-                    TEST_VALUE_LONG,
-                    TEST_VALUE_LONG,
-                    true,
-                    new ClientConfiguration(),
-                    new ClientConfiguration(),
-                    new ClientConfiguration(),
-                    TEST_VALUE_LONG,
-                    TEST_VALUE_LONG,
-                    1,
-                    skipCheckpointValidationValue,
-                    "abcd",
-                    TEST_VALUE_LONG);
-            Assert.fail("No expected Exception is thrown.");
-        } catch(IllegalArgumentException e) {
-            System.out.println(e.getMessage());
-        }
-    }
 
     @Test
     public void testKCLConfigurationMetricsDefaults() {


### PR DESCRIPTION
The new version of the SDK no longer returns null on an unknown
region.  There's not much we can do but run with whatever region is configured.
