### PR TITLE
Update the lastRequestTime to prevent overlapping restarts.

### DIFF
--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/lifecycle/ShardConsumer.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/lifecycle/ShardConsumer.java
@@ -265,6 +265,11 @@ public class ShardConsumer {
                     if (subscriber != null) {
                         subscriber.cancel();
                     }
+                    //
+                    // Set the last request time to now, we specifically don't null it out since we want it to trigger a
+                    // restart if the subscription still doesn't start producing.
+                    //
+                    lastRequestTime = Instant.now();
                     startSubscriptions();
                 }
             }


### PR DESCRIPTION
When a restart occurs due to no activity set the lastRequestTime to
now to prevent ti from overlapping itself.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
