### PR TITLE
Don't allow activities if the subscriber is current, or the connection to Kinesis is broken

### DIFF
--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/fanout/FanOutRecordsPublisher.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/fanout/FanOutRecordsPublisher.java
@@ -319,12 +319,7 @@ public class FanOutRecordsPublisher implements RecordsPublisher {
                             log.debug(
                                     "{}: (FanOutRecordsPublisher/Subscription#request) - Request called for a null flow.",
                                     shardId);
-                            if (subscriber == s) {
-                                log.debug(
-                                        "{}: (FanOutRecordsPublisher/Subscription#request) - The active subscriber still matches triggering exception report",
-                                        shardId);
-                                errorOccurred(flow, new IllegalStateException("Attempted to request on a null flow."));
-                            }
+                            errorOccurred(flow, new IllegalStateException("Attempted to request on a null flow."));
                             return;
                         }
                         long previous = outstandingRequests;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
There is a possibility that the flow can become null while a request is inflight.  This would cause an NPE.  The KCL will recover in this case, but the recovery would be delayed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
