### PR TITLE
Fixed typo in terminate log message

### DIFF
--- a/amazon-kinesis-client-multilang/src/main/java/com/amazonaws/services/kinesis/multilang/MultiLangDaemon.java
+++ b/amazon-kinesis-client-multilang/src/main/java/com/amazonaws/services/kinesis/multilang/MultiLangDaemon.java
@@ -146,7 +146,7 @@ public class MultiLangDaemon implements Callable<Integer> {
         Runtime.getRuntime().addShutdownHook(new Thread() {
             @Override
             public void run() {
-                log.info("Process terminanted, will initiate shutdown.");
+                log.info("Process terminated, will initiate shutdown.");
                 try {
                     Future<Void> fut = daemon.scheduler.requestShutdown();
                     fut.get(shutdownGraceMillis, TimeUnit.MILLISECONDS);


### PR DESCRIPTION
Typo in terminate log message "terminanted" -> "terminated"


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
