### PR TITLE
Release notes for 1.9.2 and updated versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## Release 1.9.2 (September 4, 2018)
+* Allow use of Immutable Clients  
+  * [Issue #280](https://github.com/awslabs/amazon-kinesis-client/issues/280)
+  * [PR #305](https://github.com/awslabs/amazon-kinesis-client/pull/305)
+* Allow the use of `AT_TIMESTAMP` for MultiLang Daemon Clients.  
+  * [Issue #341)(https://github.com/awslabs/amazon-kinesis-client/issues/341)
+  * [PR #342](https://github.com/awslabs/amazon-kinesis-client/pull/342)
+* Update the cache for `KinesisProxy#getShard` on cache misses.  
+  * [PR #344](https://github.com/awslabs/amazon-kinesis-client/pull/344)
+* Changed release process to use a standard process.  
+  * [PR #389](https://github.com/awslabs/amazon-kinesis-client/pull/389)
+* Removed tests that expected a null region response for unknown regions.  
+  * [PR #346](https://github.com/awslabs/amazon-kinesis-client/pull/346)
+* Updated the version of the AWS Java SDK to 1.11.400  
+
 ## Release 1.9.1 (April 30, 2018)
 * Added the ability to create a prepared checkpoint when at `SHARD_END`.
   * [PR #301](https://github.com/awslabs/amazon-kinesis-client/pull/301)

--- a/README.md
+++ b/README.md
@@ -30,16 +30,15 @@ To make it easier for developers to write record processors in other languages, 
 
 ## Release Notes
 
-### Latest Release (1.9.1)
-* Added the ability to create a prepared checkpoint when at `SHARD_END`.
-  * [PR #301](https://github.com/awslabs/amazon-kinesis-client/pull/301)
-* Added the ability to subscribe to worker state change events.  
-  * [PR #291](https://github.com/awslabs/amazon-kinesis-client/pull/291)
-* Added support for custom lease managers.  
-  A custom `LeaseManager` can be provided to `Worker.Builder` that will be used to provide lease services. 
-  This makes it possible to implement custom lease management systems in addition to the default DynamoDB system.  
-  * [PR #297](https://github.com/awslabs/amazon-kinesis-client/pull/297)
-* Updated the version of the AWS Java SDK to 1.11.219
+### Latest Release (1.9.2)
+* Allow use of Immutable Clients  
+  * [PR #305](https://github.com/awslabs/amazon-kinesis-client/pull/305)
+* Allow the use of `AT_TIMESTAMP ` for MultiLang Daemon Clients
+  * [PR #342](https://github.com/awslabs/amazon-kinesis-client/pull/342)
+* Update the cache for `KinesisProxy#getShard` on cache misses.
+  * [PR #344](https://github.com/awslabs/amazon-kinesis-client/pull/344)
+* Updated the version of the AWS Java SDK to 1.11.219  
+  * [PR #]()
 
 ### For remaining release notes check **[CHANGELOG.md][changelog-md]**.
 

--- a/README.md
+++ b/README.md
@@ -30,15 +30,20 @@ To make it easier for developers to write record processors in other languages, 
 
 ## Release Notes
 
-### Latest Release (1.9.2)
+### Latest Release (1.9.2 - September 4, 2018)
 * Allow use of Immutable Clients  
+  * [Issue #280](https://github.com/awslabs/amazon-kinesis-client/issues/280)
   * [PR #305](https://github.com/awslabs/amazon-kinesis-client/pull/305)
-* Allow the use of `AT_TIMESTAMP ` for MultiLang Daemon Clients
+* Allow the use of `AT_TIMESTAMP` for MultiLang Daemon Clients.  
+  * [Issue #341)(https://github.com/awslabs/amazon-kinesis-client/issues/341)
   * [PR #342](https://github.com/awslabs/amazon-kinesis-client/pull/342)
-* Update the cache for `KinesisProxy#getShard` on cache misses.
+* Update the cache for `KinesisProxy#getShard` on cache misses.  
   * [PR #344](https://github.com/awslabs/amazon-kinesis-client/pull/344)
-* Updated the version of the AWS Java SDK to 1.11.219  
-  * [PR #]()
+* Changed release process to use a standard process.  
+  * [PR #389](https://github.com/awslabs/amazon-kinesis-client/pull/389)
+* Removed tests that expected a null region response for unknown regions.  
+  * [PR #346](https://github.com/awslabs/amazon-kinesis-client/pull/346)
+* Updated the version of the AWS Java SDK to 1.11.400  
 
 ### For remaining release notes check **[CHANGELOG.md][changelog-md]**.
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <artifactId>amazon-kinesis-client</artifactId>
   <packaging>jar</packaging>
   <name>Amazon Kinesis Client Library for Java</name>
-  <version>1.9.2-SNAPSHOT</version>
+  <version>1.9.2</version>
   <description>The Amazon Kinesis Client Library for Java enables Java developers to easily consume and process data
     from Amazon Kinesis.
   </description>
@@ -25,7 +25,7 @@
   </licenses>
 
   <properties>
-    <aws-java-sdk.version>1.11.344</aws-java-sdk.version>
+    <aws-java-sdk.version>1.11.400</aws-java-sdk.version>
     <sqlite4java.version>1.0.392</sqlite4java.version>
     <sqlite4java.native>libsqlite4java</sqlite4java.native>
     <sqlite4java.libpath>${project.build.directory}/test-lib</sqlite4java.libpath>

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/KinesisClientLibConfiguration.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/KinesisClientLibConfiguration.java
@@ -126,7 +126,7 @@ public class KinesisClientLibConfiguration {
     /**
      * User agent set when Amazon Kinesis Client Library makes AWS requests.
      */
-    public static final String KINESIS_CLIENT_LIB_USER_AGENT = "amazon-kinesis-client-library-java-1.9.1";
+    public static final String KINESIS_CLIENT_LIB_USER_AGENT = "amazon-kinesis-client-library-java-1.9.2";
 
     /**
      * KCL will validate client provided sequence numbers with a call to Amazon Kinesis before checkpointing for calls


### PR DESCRIPTION
Added release notes for 1.9.2 and updated the version of the client.

Updated to 1.11.400 of the AWS Java SDK.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
