### PR TITLE
Support Validating Records are From to the Expected Shard

### DIFF
--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/checkpoint/SequenceNumberValidator.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/checkpoint/SequenceNumberValidator.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Amazon Software License (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://aws.amazon.com/asl/
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.kinesis.checkpoint;
+
+import java.math.BigInteger;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import lombok.Data;
+import lombok.experimental.Accessors;
+import org.apache.commons.lang3.StringUtils;
+
+public class SequenceNumberValidator {
+
+    @Data
+    @Accessors(fluent = true)
+    private static class SequenceNumberComponents {
+        final int version;
+        final int shardId;
+    }
+
+    private interface SequenceNumberReader {
+        Optional<SequenceNumberComponents> read(String sequenceNumber);
+    }
+
+    private static class V2SequenceNumberReader implements SequenceNumberReader {
+
+        private static final int VERSION = 2;
+
+        private static final int VERSION_OFFSET = 184;
+        private static final long VERSION_MASK = (1 << 4) - 1;
+
+        private static final int SHARD_ID_OFFSET = 4;
+        private static final long SHARD_ID_MASK = (1L << 32) - 1;
+
+        @Override
+        public Optional<SequenceNumberComponents> read(String sequenceNumberString) {
+            BigInteger sequenceNumber = new BigInteger(sequenceNumberString, 10);
+            int version = readOffset(sequenceNumber, VERSION_OFFSET, VERSION_MASK);
+            if (version != VERSION) {
+                return Optional.empty();
+            }
+            int shardId = readOffset(sequenceNumber, SHARD_ID_OFFSET, SHARD_ID_MASK);
+            return Optional.of(new SequenceNumberComponents(version, shardId));
+        }
+
+        private int readOffset(BigInteger sequenceNumber, int offset, long mask) {
+            long value = sequenceNumber.shiftRight(offset).longValue() & mask;
+            return (int) value;
+        }
+    }
+
+    private static final List<SequenceNumberReader> SEQUENCE_NUMBER_READERS = Collections
+            .singletonList(new V2SequenceNumberReader());
+
+    private Optional<SequenceNumberComponents> retrieveComponentsFor(String sequenceNumber) {
+        return SEQUENCE_NUMBER_READERS.stream().map(r -> r.read(sequenceNumber)).filter(Optional::isPresent).map(Optional::get).findFirst();
+    }
+
+    public Optional<Integer> versionFor(String sequenceNumber) {
+        return retrieveComponentsFor(sequenceNumber).map(SequenceNumberComponents::version);
+    }
+
+    public Optional<String> shardIdFor(String sequenceNumber) {
+        return retrieveComponentsFor(sequenceNumber).map(s -> String.format("shardId-%012d", s.shardId()));
+    }
+
+    public Optional<Boolean> validateSequenceNumberForShard(String sequenceNumber, String shardId) {
+        return shardIdFor(sequenceNumber).map(s -> StringUtils.equalsIgnoreCase(s, shardId));
+    }
+
+}

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/fanout/FanOutConfig.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/fanout/FanOutConfig.java
@@ -80,9 +80,15 @@ public class FanOutConfig implements RetrievalSpecificConfig {
      */
     private long retryBackoffMillis = 1000;
 
+    /**
+     * Controls whether the {@link FanOutRecordsPublisher} will validate that all the records are from the shard it's
+     * processing.
+     */
+    private boolean validateRecordsAreForShard = false;
+
     @Override
     public RetrievalFactory retrievalFactory() {
-        return new FanOutRetrievalFactory(kinesisClient, getOrCreateConsumerArn());
+        return new FanOutRetrievalFactory(kinesisClient, getOrCreateConsumerArn()).validateRecordsAreForShard(validateRecordsAreForShard);
     }
 
     private String getOrCreateConsumerArn() {

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/fanout/FanOutRetrievalFactory.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/fanout/FanOutRetrievalFactory.java
@@ -15,8 +15,11 @@
 
 package software.amazon.kinesis.retrieval.fanout;
 
+import lombok.Getter;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.Accessors;
 import software.amazon.awssdk.services.kinesis.KinesisAsyncClient;
 import software.amazon.kinesis.annotations.KinesisClientInternalApi;
 import software.amazon.kinesis.leases.ShardInfo;
@@ -27,10 +30,14 @@ import software.amazon.kinesis.retrieval.RetrievalFactory;
 
 @RequiredArgsConstructor
 @KinesisClientInternalApi
+@Accessors(fluent = true)
 public class FanOutRetrievalFactory implements RetrievalFactory {
 
     private final KinesisAsyncClient kinesisClient;
     private final String consumerArn;
+    @Getter
+    @Setter
+    private boolean validateRecordsAreForShard = false;
 
     @Override
     public GetRecordsRetrievalStrategy createGetRecordsRetrievalStrategy(final ShardInfo shardInfo,
@@ -41,6 +48,6 @@ public class FanOutRetrievalFactory implements RetrievalFactory {
     @Override
     public RecordsPublisher createGetRecordsCache(@NonNull final ShardInfo shardInfo,
             final MetricsFactory metricsFactory) {
-        return new FanOutRecordsPublisher(kinesisClient, shardInfo.shardId(), consumerArn);
+        return new FanOutRecordsPublisher(kinesisClient, shardInfo.shardId(), consumerArn, validateRecordsAreForShard);
     }
 }

--- a/amazon-kinesis-client/src/test/java/software/amazon/kinesis/checkpoint/SequenceNumberValidatorTest.java
+++ b/amazon-kinesis-client/src/test/java/software/amazon/kinesis/checkpoint/SequenceNumberValidatorTest.java
@@ -74,4 +74,28 @@ public class SequenceNumberValidatorTest {
 
         assertThat(validator.validateSequenceNumberForShard(sequenceNumber, expectedShardId), equalTo(Optional.empty()));
     }
+
+    @Test
+    public void sequenceNumberToShortTest() {
+        String sequenceNumber = "4958538998331216244379665794487200811415489956897252969";
+        String expectedShardId = "shardId-000000000000";
+
+        assertThat(validator.versionFor(sequenceNumber), equalTo(Optional.empty()));
+        assertThat(validator.shardIdFor(sequenceNumber), equalTo(Optional.empty()));
+
+        assertThat(validator.validateSequenceNumberForShard(sequenceNumber, expectedShardId), equalTo(Optional.empty()));
+    }
+
+    @Test
+    public void sequenceNumberToLongTest() {
+        String sequenceNumber = "495874973112745339945748342527421442361071306360078991381";
+        String expectedShardId = "shardId-000000000000";
+
+        assertThat(validator.versionFor(sequenceNumber), equalTo(Optional.empty()));
+        assertThat(validator.shardIdFor(sequenceNumber), equalTo(Optional.empty()));
+
+        assertThat(validator.validateSequenceNumberForShard(sequenceNumber, expectedShardId), equalTo(Optional.empty()));
+    }
+
+
 }


### PR DESCRIPTION
Related to #391 

Adds a configuration option that enables validating the shardId from the sequence number of each received record.  This validation ensures that the given record originated from the shard that the `FanOutRecordsPublisher` subscribed to.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
