### PR TITLE
Add a mismatched records check on the ShardConsumer side as well

### DIFF
--- a/amazon-kinesis-client-multilang/pom.xml
+++ b/amazon-kinesis-client-multilang/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <artifactId>amazon-kinesis-client-pom</artifactId>
     <groupId>software.amazon.kinesis</groupId>
-    <version>2.0.3-experimental</version>
+    <version>2.0.3-experimental-2</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/amazon-kinesis-client/pom.xml
+++ b/amazon-kinesis-client/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>software.amazon.kinesis</groupId>
     <artifactId>amazon-kinesis-client-pom</artifactId>
-    <version>2.0.3-experimental</version>
+    <version>2.0.3-experimental-2</version>
   </parent>
 
   <artifactId>amazon-kinesis-client</artifactId>

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/common/MismatchedRecordReporter.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/common/MismatchedRecordReporter.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Amazon Software License (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://aws.amazon.com/asl/
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package software.amazon.kinesis.common;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.apache.commons.lang3.StringUtils;
+
+import software.amazon.kinesis.annotations.KinesisClientExperimental;
+import software.amazon.kinesis.checkpoint.SequenceNumberValidator;
+
+@KinesisClientExperimental
+public class MismatchedRecordReporter {
+
+    private final SequenceNumberValidator sequenceNumberValidator = new SequenceNumberValidator();
+
+    public Map<String, Integer> recordsNotForShard(String shardId, Stream<String> sequenceNumbers) {
+        return sequenceNumbers.map(seq -> {
+            Optional<String> res = sequenceNumberValidator.shardIdFor(seq);
+            if (!res.isPresent()) {
+                throw new IllegalArgumentException("Unable to validate sequence number of " + seq);
+            }
+            return res.get();
+        }).filter(s -> !StringUtils.equalsIgnoreCase(s, shardId)).collect(Collectors.groupingBy(Function.identity()))
+                .entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().size()));
+    }
+
+    public String makeReport(Map<String, Integer> mismatchedRecords) {
+        return mismatchedRecords.entrySet().stream().map(e -> String.format("(%s -> %d)", e.getKey(), e.getValue()))
+                .collect(Collectors.joining(", "));
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
   <artifactId>amazon-kinesis-client-pom</artifactId>
   <packaging>pom</packaging>
   <name>Amazon Kinesis Client Library</name>
-  <version>2.0.3-experimental</version>
+  <version>2.0.3-experimental-2</version>
   <description>The Amazon Kinesis Client Library for Java enables Java developers to easily consume and process data
     from Amazon Kinesis.
   </description>


### PR DESCRIPTION
Added a check for mismatched records on the ShardConsumer as well as
the FanOutRecordsPublisher.

Changed version to 2.0.3-experimental-2

#391 



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
