### PR TITLE
Upgrade to the newest SDK, and fix requestId header name

### DIFF
--- a/amazon-kinesis-client-multilang/pom.xml
+++ b/amazon-kinesis-client-multilang/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <artifactId>amazon-kinesis-client-pom</artifactId>
     <groupId>software.amazon.kinesis</groupId>
-    <version>2.0.3-experimental-2</version>
+    <version>2.0.3-experimental-3</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/amazon-kinesis-client/pom.xml
+++ b/amazon-kinesis-client/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>software.amazon.kinesis</groupId>
     <artifactId>amazon-kinesis-client-pom</artifactId>
-    <version>2.0.3-experimental-2</version>
+    <version>2.0.3-experimental-3</version>
   </parent>
 
   <artifactId>amazon-kinesis-client</artifactId>
@@ -46,7 +46,7 @@
 
   <properties>
     <aws-java-sdk.version>1.11.272</aws-java-sdk.version>
-    <awssdk.version>2.0.1</awssdk.version>
+    <awssdk.version>2.0.2</awssdk.version>
     <sqlite4java.version>1.0.392</sqlite4java.version>
     <sqlite4java.native>libsqlite4java</sqlite4java.native>
     <sqlite4java.libpath>${project.build.directory}/test-lib</sqlite4java.libpath>

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/fanout/FanOutRecordsPublisher.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/fanout/FanOutRecordsPublisher.java
@@ -528,7 +528,7 @@ public class FanOutRecordsPublisher implements RecordsPublisher {
         public void responseReceived(SubscribeToShardResponse response) {
             Optional<SdkHttpResponse> sdkHttpResponse = Optional.ofNullable(response)
                     .flatMap(r -> Optional.ofNullable(r.sdkHttpResponse()));
-            Optional<String> requestId = sdkHttpResponse.flatMap(s -> s.firstMatchingHeader("x-amz-requestid"));
+            Optional<String> requestId = sdkHttpResponse.flatMap(s -> s.firstMatchingHeader("x-amzn-requestid"));
             Optional<String> requestId2 = sdkHttpResponse.flatMap(s -> s.firstMatchingHeader("x-amz-id-2"));
 
             log.debug(

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
   <artifactId>amazon-kinesis-client-pom</artifactId>
   <packaging>pom</packaging>
   <name>Amazon Kinesis Client Library</name>
-  <version>2.0.3-experimental-2</version>
+  <version>2.0.3-experimental-3</version>
   <description>The Amazon Kinesis Client Library for Java enables Java developers to easily consume and process data
     from Amazon Kinesis.
   </description>


### PR DESCRIPTION
*Issue #, if available:*
#391 
*Description of changes:*

* Upgraded to AWS SDK 2.0.2 which allows for reporting the requestId on received requests.
* Fixed the header name for the default requestId
* Changed version to 2.0.3-experimental-3

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
