### PR TITLE
Added an API on LeaseCoordinator and LeaseTaker to get all leases for…

### DIFF
--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/leases/LeaseCoordinator.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/leases/LeaseCoordinator.java
@@ -16,6 +16,7 @@
 package software.amazon.kinesis.leases;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 
@@ -125,9 +126,15 @@ public interface LeaseCoordinator {
     List<ShardInfo> getCurrentAssignments();
 
     /**
-     * @return All leases
+     * Default implementation returns an empty list and concrete implementation is expected to return all leases
+     * for the application that are in the lease table. This enables application managing Kcl Scheduler to take care of
+     * horizontal scaling for example.
+     *
+     * @return all leases for the application that are in the lease table
      */
-    Collection<Lease> getAllAssignments();
+    default List<Lease> allLeases() {
+       return Collections.emptyList();
+    }
 
     /**
      * @param writeCapacity The DynamoDB table used for tracking leases will be provisioned with the specified initial

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/leases/LeaseCoordinator.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/leases/LeaseCoordinator.java
@@ -125,6 +125,11 @@ public interface LeaseCoordinator {
     List<ShardInfo> getCurrentAssignments();
 
     /**
+     * @return All leases
+     */
+    Collection<Lease> getAllAssignments();
+
+    /**
      * @param writeCapacity The DynamoDB table used for tracking leases will be provisioned with the specified initial
      *        write capacity
      * @return LeaseCoordinator

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/leases/LeaseTaker.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/leases/LeaseTaker.java
@@ -14,6 +14,7 @@
  */
 package software.amazon.kinesis.leases;
 
+import java.util.Collection;
 import java.util.Map;
 
 import software.amazon.kinesis.leases.exceptions.DependencyException;
@@ -45,4 +46,8 @@ public interface LeaseTaker {
      */
     String getWorkerIdentifier();
 
+    /**
+     * @return Lease object for all leases
+     */
+    Collection<Lease> getAllLeases();
 }

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/leases/LeaseTaker.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/leases/LeaseTaker.java
@@ -14,7 +14,8 @@
  */
 package software.amazon.kinesis.leases;
 
-import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 import software.amazon.kinesis.leases.exceptions.DependencyException;
@@ -47,7 +48,12 @@ public interface LeaseTaker {
     String getWorkerIdentifier();
 
     /**
-     * @return Lease object for all leases
+     * Default implementation returns an empty list and concrete implementaion is expected to return all leases
+     * for the application that are in the lease table either by reading lease table or from an internal cache.
+     *
+     * @return all leases for the application that are in the lease table
      */
-    Collection<Lease> getAllLeases();
+    default List<Lease> allLeases() {
+        return Collections.emptyList();
+    }
 }

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/leases/dynamodb/DynamoDBLeaseCoordinator.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/leases/dynamodb/DynamoDBLeaseCoordinator.java
@@ -279,8 +279,8 @@ public class DynamoDBLeaseCoordinator implements LeaseCoordinator {
     }
 
     @Override
-    public Collection<Lease> getAllAssignments() {
-        return leaseTaker.getAllLeases();
+    public List<Lease> allLeases() {
+        return leaseTaker.allLeases();
     }
 
     @Override

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/leases/dynamodb/DynamoDBLeaseCoordinator.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/leases/dynamodb/DynamoDBLeaseCoordinator.java
@@ -279,6 +279,11 @@ public class DynamoDBLeaseCoordinator implements LeaseCoordinator {
     }
 
     @Override
+    public Collection<Lease> getAllAssignments() {
+        return leaseTaker.getAllLeases();
+    }
+
+    @Override
     public Lease getCurrentlyHeldLease(String leaseKey) {
         return leaseRenewer.getCurrentlyHeldLease(leaseKey);
     }

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/leases/dynamodb/DynamoDBLeaseTaker.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/leases/dynamodb/DynamoDBLeaseTaker.java
@@ -535,7 +535,7 @@ public class DynamoDBLeaseTaker implements LeaseTaker {
      * {@inheritDoc}
      */
     @Override
-    public synchronized Collection<Lease> getAllLeases() {
-        return Collections.unmodifiableCollection(new ArrayList<Lease>(allLeases.values()));
+    public synchronized List<Lease> allLeases() {
+        return new ArrayList<>(allLeases.values());
     }
 }

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/leases/dynamodb/DynamoDBLeaseTaker.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/leases/dynamodb/DynamoDBLeaseTaker.java
@@ -530,4 +530,12 @@ public class DynamoDBLeaseTaker implements LeaseTaker {
     public String getWorkerIdentifier() {
         return workerIdentifier;
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public synchronized Collection<Lease> getAllLeases() {
+        return Collections.unmodifiableCollection(new ArrayList<Lease>(allLeases.values()));
+    }
 }

--- a/amazon-kinesis-client/src/test/java/software/amazon/kinesis/leases/dynamodb/DynamoDBLeaseCoordinatorIntegrationTest.java
+++ b/amazon-kinesis-client/src/test/java/software/amazon/kinesis/leases/dynamodb/DynamoDBLeaseCoordinatorIntegrationTest.java
@@ -156,9 +156,9 @@ public class DynamoDBLeaseCoordinatorIntegrationTest {
         // Run the taker
         coordinator.runLeaseTaker();
 
-        Collection<Lease> allAssignments = coordinator.getAllAssignments();
-        assertEquals(allAssignments.size(), addedLeases.size());
-        assertThat(allAssignments.containsAll(addedLeases.values()), equalTo(true));
+        List<Lease> allLeases = coordinator.allLeases();
+        assertThat(allLeases.size(), equalTo(addedLeases.size()));
+        assertThat(allLeases.containsAll(addedLeases.values()), equalTo(true));
     }
 
     /**

--- a/amazon-kinesis-client/src/test/java/software/amazon/kinesis/leases/dynamodb/DynamoDBLeaseCoordinatorIntegrationTest.java
+++ b/amazon-kinesis-client/src/test/java/software/amazon/kinesis/leases/dynamodb/DynamoDBLeaseCoordinatorIntegrationTest.java
@@ -156,7 +156,7 @@ public class DynamoDBLeaseCoordinatorIntegrationTest {
 
         Collection<Lease> allAssignments = coordinator.getAllAssignments();
         assertEquals(allAssignments.size(), addedLeases.size());
-        allAssignments.containsAll(addedLeases.keySet());
+        assertTrue(allAssignments.containsAll(addedLeases.values()));
     }
 
     /**

--- a/amazon-kinesis-client/src/test/java/software/amazon/kinesis/leases/dynamodb/DynamoDBLeaseCoordinatorIntegrationTest.java
+++ b/amazon-kinesis-client/src/test/java/software/amazon/kinesis/leases/dynamodb/DynamoDBLeaseCoordinatorIntegrationTest.java
@@ -14,10 +14,12 @@
  */
 package software.amazon.kinesis.leases.dynamodb;
 
+import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
 import java.util.Collection;
@@ -156,7 +158,7 @@ public class DynamoDBLeaseCoordinatorIntegrationTest {
 
         Collection<Lease> allAssignments = coordinator.getAllAssignments();
         assertEquals(allAssignments.size(), addedLeases.size());
-        assertTrue(allAssignments.containsAll(addedLeases.values()));
+        assertThat(allAssignments.containsAll(addedLeases.values()), equalTo(true));
     }
 
     /**

--- a/amazon-kinesis-client/src/test/java/software/amazon/kinesis/leases/dynamodb/DynamoDBLeaseCoordinatorIntegrationTest.java
+++ b/amazon-kinesis-client/src/test/java/software/amazon/kinesis/leases/dynamodb/DynamoDBLeaseCoordinatorIntegrationTest.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -134,6 +135,28 @@ public class DynamoDBLeaseCoordinatorIntegrationTest {
         lease.checkpoint(newCheckpoint);
         lease.leaseOwner(coordinator.workerIdentifier());
         assertEquals(lease, fromDynamo);
+    }
+
+    /**
+     * Tests if getAllAssignments() returns all leases
+     */
+    @Test
+    public void testGetAllAssignments() throws Exception {
+        TestHarnessBuilder builder = new TestHarnessBuilder();
+
+        Map<String, Lease> addedLeases = builder.withLease("1", WORKER_ID)
+                .withLease("2", WORKER_ID)
+                .withLease("3", WORKER_ID)
+                .withLease("4", WORKER_ID)
+                .withLease("5", WORKER_ID)
+                .build();
+
+        // Run the taker
+        coordinator.runLeaseTaker();
+
+        Collection<Lease> allAssignments = coordinator.getAllAssignments();
+        assertEquals(allAssignments.size(), addedLeases.size());
+        allAssignments.containsAll(addedLeases.keySet());
     }
 
     /**

--- a/amazon-kinesis-client/src/test/java/software/amazon/kinesis/leases/dynamodb/DynamoDBLeaseTakerIntegrationTest.java
+++ b/amazon-kinesis-client/src/test/java/software/amazon/kinesis/leases/dynamodb/DynamoDBLeaseTakerIntegrationTest.java
@@ -26,7 +26,9 @@ import software.amazon.kinesis.leases.LeaseIntegrationTest;
 import software.amazon.kinesis.leases.exceptions.LeasingException;
 import software.amazon.kinesis.metrics.NullMetricsFactory;
 
+import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 public class DynamoDBLeaseTakerIntegrationTest extends LeaseIntegrationTest {
@@ -126,7 +128,7 @@ public class DynamoDBLeaseTakerIntegrationTest extends LeaseIntegrationTest {
 
         Collection<Lease> allLeases = taker.getAllLeases();
         assertEquals(allLeases.size(), addedLeases.size());
-        assertTrue(addedLeases.values().containsAll(allLeases));
+        assertThat(addedLeases.values().containsAll(allLeases), equalTo(true));
     }
 
     /**

--- a/amazon-kinesis-client/src/test/java/software/amazon/kinesis/leases/dynamodb/DynamoDBLeaseTakerIntegrationTest.java
+++ b/amazon-kinesis-client/src/test/java/software/amazon/kinesis/leases/dynamodb/DynamoDBLeaseTakerIntegrationTest.java
@@ -14,17 +14,19 @@
  */
 package software.amazon.kinesis.leases.dynamodb;
 
+import java.util.Collection;
 import java.util.Map;
 
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import software.amazon.kinesis.leases.Lease;
 import software.amazon.kinesis.leases.LeaseIntegrationTest;
 import software.amazon.kinesis.leases.exceptions.LeasingException;
 import software.amazon.kinesis.metrics.NullMetricsFactory;
+
+import static org.junit.Assert.assertEquals;
 
 public class DynamoDBLeaseTakerIntegrationTest extends LeaseIntegrationTest {
 
@@ -98,6 +100,32 @@ public class DynamoDBLeaseTakerIntegrationTest extends LeaseIntegrationTest {
         builder.withLease("4", "bar").build();
 
         builder.takeMutateAssert(taker, 2);
+    }
+
+    /**
+     * Verify that when getAllLeases() is called, DynamoDBLeaseTaker
+     * - does not call listLeases()
+     * - returns cached result was built during takeLeases() operation to return result
+     */
+    @Test
+    public void testGetAllLeases() throws LeasingException {
+        TestHarnessBuilder builder = new TestHarnessBuilder(leaseRefresher);
+
+        Map<String, Lease> addedLeases = builder.withLease("1", "bar")
+                .withLease("2", "bar")
+                .withLease("3", "baz")
+                .withLease("4", "baz")
+                .withLease("5", "foo")
+                .build();
+
+        // In the current DynamoDBLeaseTaker implementation getAllLeases() gets leases from an internal cache that is built during takeLeases() operation
+        assertEquals(taker.getAllLeases().size(), 0);
+
+        taker.takeLeases();
+
+        Collection<Lease> allLeases = taker.getAllLeases();
+        assertEquals(allLeases.size(), addedLeases.size());
+        addedLeases.values().containsAll(allLeases);
     }
 
     /**

--- a/amazon-kinesis-client/src/test/java/software/amazon/kinesis/leases/dynamodb/DynamoDBLeaseTakerIntegrationTest.java
+++ b/amazon-kinesis-client/src/test/java/software/amazon/kinesis/leases/dynamodb/DynamoDBLeaseTakerIntegrationTest.java
@@ -122,12 +122,12 @@ public class DynamoDBLeaseTakerIntegrationTest extends LeaseIntegrationTest {
                 .build();
 
         // In the current DynamoDBLeaseTaker implementation getAllLeases() gets leases from an internal cache that is built during takeLeases() operation
-        assertEquals(taker.getAllLeases().size(), 0);
+        assertThat(taker.allLeases().size(), equalTo(0));
 
         taker.takeLeases();
 
-        Collection<Lease> allLeases = taker.getAllLeases();
-        assertEquals(allLeases.size(), addedLeases.size());
+        Collection<Lease> allLeases = taker.allLeases();
+        assertThat(allLeases.size(), equalTo(addedLeases.size()));
         assertThat(addedLeases.values().containsAll(allLeases), equalTo(true));
     }
 

--- a/amazon-kinesis-client/src/test/java/software/amazon/kinesis/leases/dynamodb/DynamoDBLeaseTakerIntegrationTest.java
+++ b/amazon-kinesis-client/src/test/java/software/amazon/kinesis/leases/dynamodb/DynamoDBLeaseTakerIntegrationTest.java
@@ -27,6 +27,7 @@ import software.amazon.kinesis.leases.exceptions.LeasingException;
 import software.amazon.kinesis.metrics.NullMetricsFactory;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class DynamoDBLeaseTakerIntegrationTest extends LeaseIntegrationTest {
 
@@ -125,7 +126,7 @@ public class DynamoDBLeaseTakerIntegrationTest extends LeaseIntegrationTest {
 
         Collection<Lease> allLeases = taker.getAllLeases();
         assertEquals(allLeases.size(), addedLeases.size());
-        addedLeases.values().containsAll(allLeases);
+        assertTrue(addedLeases.values().containsAll(allLeases));
     }
 
     /**


### PR DESCRIPTION
… the application

*Issue #, if available:*

*Description of changes:*
- getAllLeases() allows any application managing KCL scheduler to take additional action related to scale or lease management

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
