### PR TITLE
Advance version of the AWS SDK to 2.0.6

### DIFF
--- a/amazon-kinesis-client/pom.xml
+++ b/amazon-kinesis-client/pom.xml
@@ -46,7 +46,7 @@
 
   <properties>
     <aws-java-sdk.version>1.11.272</aws-java-sdk.version>
-    <awssdk.version>2.0.1</awssdk.version>
+    <awssdk.version>2.0.6</awssdk.version>
     <sqlite4java.version>1.0.392</sqlite4java.version>
     <sqlite4java.native>libsqlite4java</sqlite4java.native>
     <sqlite4java.libpath>${project.build.directory}/test-lib</sqlite4java.libpath>


### PR DESCRIPTION

*Issue #, if available:*
#391 

*Description of changes:*
Fixes a bug when making SubscribeToShard requests over HTTP 1.1.
Using HTTP 1.1 for SubscribeToShard isn't supported, and may be
break at any time.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
