### PR TITLE
Add an exception reporter for reporting unhandled exceptions that are terminating a thread

### DIFF
--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/common/ThreadExceptionReporter.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/common/ThreadExceptionReporter.java
@@ -15,8 +15,10 @@
 package software.amazon.kinesis.common;
 
 import lombok.extern.slf4j.Slf4j;
+import software.amazon.kinesis.annotations.KinesisClientInternalApi;
 
 @Slf4j
+@KinesisClientInternalApi
 public class ThreadExceptionReporter implements Thread.UncaughtExceptionHandler {
 
     private final String threadSource;

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/common/ThreadExceptionReporter.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/common/ThreadExceptionReporter.java
@@ -1,0 +1,66 @@
+/*
+ *  Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Amazon Software License (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *  http://aws.amazon.com/asl/
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+package software.amazon.kinesis.common;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class ThreadExceptionReporter implements Thread.UncaughtExceptionHandler {
+
+    private final String threadSource;
+    private final String lastDitchMessage;
+
+    public ThreadExceptionReporter(String threadSource) {
+        this.threadSource = threadSource;
+        this.lastDitchMessage = "[" + threadSource + "] Thread died, and unable to log normally";
+    }
+
+
+    @Override
+    public void uncaughtException(Thread t, Throwable e) {
+
+        try {
+            log.error("[{}] Thread {} (id-{}) died unexpectedly due to {}", threadSource, t.getName(), t.getId(), e.getMessage(), e);
+        } catch (Throwable logThrowable) {
+            //
+            // If the system is very unhealthy it's possible we won't be able create a log message so we attempt to log the last ditch message
+            //
+            attemptToLogLastDitchMessage();
+        }
+
+    }
+
+    private void attemptToLogLastDitchMessage() {
+        try {
+            log.error(lastDitchMessage);
+        } catch (Throwable t) {
+            //
+            // Logging failed for some reason attempt to write to standard error
+            //
+            attemptToWriteStdErrLastDitchMessage();
+        }
+    }
+
+    private void attemptToWriteStdErrLastDitchMessage() {
+        try {
+            System.err.print(lastDitchMessage);
+            System.err.print("\n");
+        } catch (Throwable t) {
+            //
+            // All options are now exhausted allow the message to be lost.
+            //
+        }
+    }
+}

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/common/ThreadExceptionReporter.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/common/ThreadExceptionReporter.java
@@ -1,16 +1,16 @@
 /*
- *  Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
- *  Licensed under the Amazon Software License (the "License").
- *  You may not use this file except in compliance with the License.
- *  A copy of the License is located at
+ * Licensed under the Amazon Software License (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
  *
- *  http://aws.amazon.com/asl/
+ * http://aws.amazon.com/asl/
  *
- *  or in the "license" file accompanying this file. This file is distributed
- *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *  express or implied. See the License for the specific language governing
- *  permissions and limitations under the License.
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
  */
 package software.amazon.kinesis.common;
 
@@ -27,36 +27,38 @@ public class ThreadExceptionReporter implements Thread.UncaughtExceptionHandler 
         this.lastDitchMessage = "[" + threadSource + "] Thread died, and unable to log normally";
     }
 
-
     @Override
     public void uncaughtException(Thread t, Throwable e) {
-
         try {
-            log.error("[{}] Thread {} (id-{}) died unexpectedly due to {}", threadSource, t.getName(), t.getId(), e.getMessage(), e);
+            log.error("[{}] Thread {} (id-{}) died unexpectedly: {}", threadSource, t.getName(), t.getId(),
+                    e.getMessage(), e);
         } catch (Throwable logThrowable) {
             //
-            // If the system is very unhealthy it's possible we won't be able create a log message so we attempt to log the last ditch message
+            // If the system is very unhealthy it's possible we won't be able create a log message so we attempt to log
+            // the last ditch message
             //
-            attemptToLogLastDitchMessage();
+            attemptToLogLastDitchMessage(e);
         }
 
     }
 
-    private void attemptToLogLastDitchMessage() {
+    private void attemptToLogLastDitchMessage(Throwable e) {
         try {
             log.error(lastDitchMessage);
         } catch (Throwable t) {
             //
             // Logging failed for some reason attempt to write to standard error
             //
-            attemptToWriteStdErrLastDitchMessage();
+            attemptToWriteStdErrLastDitchMessage(e);
         }
     }
 
-    private void attemptToWriteStdErrLastDitchMessage() {
+    private void attemptToWriteStdErrLastDitchMessage(Throwable e) {
         try {
             System.err.print(lastDitchMessage);
-            System.err.print("\n");
+            System.err.print(": ");
+            System.err.println(e.getMessage());
+            e.printStackTrace(System.err);
         } catch (Throwable t) {
             //
             // All options are now exhausted allow the message to be lost.

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/coordinator/SchedulerCoordinatorFactory.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/coordinator/SchedulerCoordinatorFactory.java
@@ -27,6 +27,7 @@ import lombok.Data;
 import lombok.NonNull;
 import software.amazon.kinesis.annotations.KinesisClientInternalApi;
 import software.amazon.kinesis.checkpoint.ShardRecordProcessorCheckpointer;
+import software.amazon.kinesis.common.ThreadExceptionReporter;
 import software.amazon.kinesis.leases.ShardInfo;
 import software.amazon.kinesis.processor.Checkpointer;
 
@@ -42,7 +43,7 @@ public class SchedulerCoordinatorFactory implements CoordinatorFactory {
     @Override
     public ExecutorService createExecutorService() {
         return new SchedulerThreadPoolExecutor(
-                new ThreadFactoryBuilder().setNameFormat("ShardRecordProcessor-%04d").build());
+                new ThreadFactoryBuilder().setNameFormat("ShardRecordProcessor-%04d").setUncaughtExceptionHandler(new ThreadExceptionReporter("SchedulerPool")).build());
     }
 
     static class SchedulerThreadPoolExecutor extends ThreadPoolExecutor {

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/leases/LeaseManagementConfig.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/leases/LeaseManagementConfig.java
@@ -30,6 +30,7 @@ import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient;
 import software.amazon.awssdk.services.kinesis.KinesisAsyncClient;
 import software.amazon.kinesis.common.InitialPositionInStream;
 import software.amazon.kinesis.common.InitialPositionInStreamExtended;
+import software.amazon.kinesis.common.ThreadExceptionReporter;
 import software.amazon.kinesis.leases.dynamodb.DynamoDBLeaseManagementFactory;
 import software.amazon.kinesis.leases.dynamodb.TableCreatorCallback;
 import software.amazon.kinesis.metrics.MetricsFactory;
@@ -210,7 +211,7 @@ public class LeaseManagementConfig {
      * <p>Default value: {@link LeaseManagementThreadPool}</p>
      */
     private ExecutorService executorService = new LeaseManagementThreadPool(
-            new ThreadFactoryBuilder().setNameFormat("ShardSyncTaskManager-%04d").build());
+            new ThreadFactoryBuilder().setNameFormat("ShardSyncTaskManager-%04d").setUncaughtExceptionHandler(new ThreadExceptionReporter("ShardSyncTaskManagerPool")).build());
 
     static class LeaseManagementThreadPool extends ThreadPoolExecutor {
         private static final long DEFAULT_KEEP_ALIVE_TIME = 60L;

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/polling/AsynchronousGetRecordsRetrievalStrategy.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/polling/AsynchronousGetRecordsRetrievalStrategy.java
@@ -35,6 +35,7 @@ import lombok.extern.slf4j.Slf4j;
 import software.amazon.awssdk.services.kinesis.model.ExpiredIteratorException;
 import software.amazon.awssdk.services.kinesis.model.GetRecordsResponse;
 import software.amazon.kinesis.annotations.KinesisClientInternalApi;
+import software.amazon.kinesis.common.ThreadExceptionReporter;
 import software.amazon.kinesis.retrieval.DataFetcherResult;
 import software.amazon.kinesis.retrieval.GetRecordsRetrievalStrategy;
 
@@ -137,7 +138,7 @@ public class AsynchronousGetRecordsRetrievalStrategy implements GetRecordsRetrie
         String threadNameFormat = "get-records-worker-" + shardId + "-%d";
         return new ThreadPoolExecutor(CORE_THREAD_POOL_COUNT, maxGetRecordsThreadPool, TIME_TO_KEEP_ALIVE,
                 TimeUnit.SECONDS, new LinkedBlockingQueue<>(1),
-                new ThreadFactoryBuilder().setDaemon(true).setNameFormat(threadNameFormat).build(),
+                new ThreadFactoryBuilder().setDaemon(true).setNameFormat(threadNameFormat).setUncaughtExceptionHandler(new ThreadExceptionReporter("GetRecordsPool-" + shardId)).build(),
                 new ThreadPoolExecutor.AbortPolicy());
     }
 

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/polling/SimpleRecordsFetcherFactory.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/polling/SimpleRecordsFetcherFactory.java
@@ -20,6 +20,7 @@ import com.google.common.util.concurrent.ThreadFactoryBuilder;
 
 import lombok.extern.slf4j.Slf4j;
 import software.amazon.kinesis.annotations.KinesisClientInternalApi;
+import software.amazon.kinesis.common.ThreadExceptionReporter;
 import software.amazon.kinesis.metrics.MetricsFactory;
 import software.amazon.kinesis.retrieval.DataFetchingStrategy;
 import software.amazon.kinesis.retrieval.GetRecordsRetrievalStrategy;
@@ -44,7 +45,7 @@ public class SimpleRecordsFetcherFactory implements RecordsFetcherFactory {
                 Executors
                         .newFixedThreadPool(1,
                                 new ThreadFactoryBuilder().setDaemon(true)
-                                        .setNameFormat("prefetch-cache-" + shardId + "-%04d").build()),
+                                        .setNameFormat("prefetch-cache-" + shardId + "-%04d").setUncaughtExceptionHandler(new ThreadExceptionReporter("PrefetchCachePool-" + shardId)).build()),
                 idleMillisBetweenCalls, metricsFactory, "ProcessTask", shardId);
 
     }

--- a/amazon-kinesis-client/src/test/java/software/amazon/kinesis/common/ThreadExceptionReporterTest.java
+++ b/amazon-kinesis-client/src/test/java/software/amazon/kinesis/common/ThreadExceptionReporterTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Amazon Software License (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://aws.amazon.com/asl/
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package software.amazon.kinesis.common;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import ch.qos.logback.classic.Level;
+import org.junit.Before;
+import org.junit.Test;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.AppenderBase;
+
+public class ThreadExceptionReporterTest {
+
+    @Before
+    public void before() {
+        ThreadExceptionReporterAppender.loggingEvents.clear();
+    }
+
+    @Test
+    public void exceptionReportedTest() {
+        ThreadExceptionReporter reporter = new ThreadExceptionReporter("test");
+        reporter.uncaughtException(Thread.currentThread(), new RuntimeException("Test"));
+
+        assertThat(ThreadExceptionReporterAppender.loggingEvents.size(), equalTo(1));
+        ILoggingEvent event = ThreadExceptionReporterAppender.loggingEvents.get(0);
+        assertThat(event.getFormattedMessage(), equalTo("[test] Thread main (id-1) died unexpectedly: Test"));
+        assertThat(event.getLevel(), equalTo(Level.ERROR));
+        assertThat(event.getThrowableProxy().getClassName(), equalTo(RuntimeException.class.getName()));
+        assertThat(event.getThrowableProxy().getMessage(), equalTo("Test"));
+    }
+
+    public static class ThreadExceptionReporterAppender extends AppenderBase<ILoggingEvent> {
+
+        static List<ILoggingEvent> loggingEvents = new ArrayList<>();
+
+        @Override
+        protected void append(ILoggingEvent eventObject) {
+            loggingEvents.add(eventObject);
+        }
+    }
+}

--- a/amazon-kinesis-client/src/test/resources/logback-test.xml
+++ b/amazon-kinesis-client/src/test/resources/logback-test.xml
@@ -20,6 +20,10 @@
         </encoder>
     </appender>
 
+    <appender name="THREAD_REPORTER" class="software.amazon.kinesis.common.ThreadExceptionReporterTest$ThreadExceptionReporterAppender">
+
+    </appender>
+
     <root level="debug">
         <appender-ref ref="CONSOLE" />
     </root>
@@ -28,4 +32,7 @@
     <logger level="info" name="software.amazon.awssdk.http" />
     <logger level="info" name="io.netty" />
     <logger level="info" name="software.amazon.awssdk.auth.signer" />
+    <logger name="software.amazon.kinesis.common.ThreadExceptionReporter" additivity="false" level="debug">
+        <appender-ref ref="THREAD_REPORTER"/>
+    </logger>
 </configuration>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Added an exception reporter that will report on any unhandled exceptions that are terminating the thread.  This exception reporter is install on all the KCL thread pools.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
