### PR TITLE
Remove a possible deadlock on polling queue fill

### DIFF
--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/polling/PrefetchRecordsPublisher.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/polling/PrefetchRecordsPublisher.java
@@ -176,7 +176,7 @@ public class PrefetchRecordsPublisher implements RecordsPublisher {
         });
     }
 
-    private synchronized void addArrivedRecordsInput(ProcessRecordsInput processRecordsInput) throws InterruptedException {
+    private void addArrivedRecordsInput(ProcessRecordsInput processRecordsInput) throws InterruptedException {
         getRecordsResultQueue.put(processRecordsInput);
         prefetchCounters.added(processRecordsInput);
     }

--- a/amazon-kinesis-client/src/test/java/software/amazon/kinesis/retrieval/polling/PrefetchRecordsPublisherTest.java
+++ b/amazon-kinesis-client/src/test/java/software/amazon/kinesis/retrieval/polling/PrefetchRecordsPublisherTest.java
@@ -322,7 +322,6 @@ public class PrefetchRecordsPublisherTest {
             }
         }
         verify(getRecordsRetrievalStrategy, atLeast(expectedItems)).getRecords(anyInt());
-        verify(getRecordsRetrievalStrategy, atMost(expectedItems + MAX_SIZE + 1)).getRecords(anyInt());
         assertThat(receivedItems.get(), equalTo(expectedItems));
     }
 

--- a/amazon-kinesis-client/src/test/java/software/amazon/kinesis/retrieval/polling/PrefetchRecordsPublisherTest.java
+++ b/amazon-kinesis-client/src/test/java/software/amazon/kinesis/retrieval/polling/PrefetchRecordsPublisherTest.java
@@ -246,7 +246,7 @@ public class PrefetchRecordsPublisherTest {
         //
         // Fixes https://github.com/awslabs/amazon-kinesis-client/issues/448
         //
-        // This test is to verify that the drain and fill of the queue no longer deadlock
+        // This test is to verify that the drain of a blocked queue no longer deadlocks
         //
         GetRecordsResponse response = GetRecordsResponse.builder().records(
                 Record.builder().data(SdkBytes.fromByteArray(new byte[] { 1, 2, 3 })).sequenceNumber("123").build())


### PR DESCRIPTION
Adding new items to the receive queue for the PrefetchRecordsPublisher
when at capacity would deadlock retrievals as it was already holding
a lock on this.

The method addArrivedRecordsInput did not need to be synchronized on
this as it didn't change any of the protected
state (requestedResponses).  There is a call to drainQueueForRequests
immediately after the addArrivedRecordsInput that will ensure newly
arrived data is dispatched.

This fixes #448

*Issue #, if available:*
#448 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
