### PR TITLE
Upgrade awssdk.version to 2.2.0

### DIFF
--- a/amazon-kinesis-client/pom.xml
+++ b/amazon-kinesis-client/pom.xml
@@ -46,7 +46,7 @@
 
   <properties>
     <aws-java-sdk.version>1.11.272</aws-java-sdk.version>
-    <awssdk.version>2.0.6</awssdk.version>
+    <awssdk.version>2.2.0</awssdk.version>
     <sqlite4java.version>1.0.392</sqlite4java.version>
     <sqlite4java.native>libsqlite4java</sqlite4java.native>
     <sqlite4java.libpath>${project.build.directory}/test-lib</sqlite4java.libpath>


### PR DESCRIPTION
Upgrade the sdk version to 2.2.0 for compatibility with latest AWS S3 2.2.0 SDK client.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.