### PR TITLE
Release 2.1.2 of the Amazon Kinesis Client Library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+### Release 2.1.2 (February 15, 2019)
+[Milestone#29](https://github.com/awslabs/amazon-kinesis-client/milestone/29)
+* Fixed handling of the progress detection in the `ShardConsumer` to restart from the last accepted record, instead of the last queued record.
+  * [PR#492](https://github.com/awslabs/amazon-kinesis-client/pull/492)
+* Fixed handling of exceptions when using polling so that it will no longer treat `SdkException`s as an unexpected exception.
+  * [PR#497](https://github.com/awslabs/amazon-kinesis-client/pull/497)
+  * [PR#502](https://github.com/awslabs/amazon-kinesis-client/pull/502)
+* Fixed a case where lease loss would block the `Scheduler` while waiting for a record processor's `processRecords` method to complete.
+  * [PR#501](https://github.com/awslabs/amazon-kinesis-client/pull/501)
+
 ### Release 2.1.1 (February 6, 2019)
 [Milestone#28](https://github.com/awslabs/amazon-kinesis-client/milestone/28)
 * Introducing `SHUT_DOWN_STARTED` state for the `WorkerStateChangeListener`.

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The recommended way to use the KCL for Java is to consume it from Maven.
   <dependency>
       <groupId>software.amazon.kinesis</groupId>
       <artifactId>amazon-kinesis-client</artifactId>
-      <version>2.1.1</version>
+      <version>2.1.2</version>
   </dependency>
   ```
 
@@ -61,14 +61,15 @@ The recommended way to use the KCL for Java is to consume it from Maven.
 
 ## Release Notes
 
-### Latest Release (2.1.1 - February 6, 2019)
-[Milestone#28](https://github.com/awslabs/amazon-kinesis-client/milestone/28)
-* Introducing `SHUT_DOWN_STARTED` state for the `WorkerStateChangeListener`.
-  * [PR#457](https://github.com/awslabs/amazon-kinesis-client/pull/457)
-* Fixed a bug with `AWSSessionCredentials` using `AWSSecretID` instead of `AWSAccessID` and vice versa.
-  * [PR#486](https://github.com/awslabs/amazon-kinesis-client/pull/486)
-* Upgrading SDK version to 2.4.0, which includes a fix for a possible deadlock when using Enhanced Fan-Out.
-  * [PR#493](https://github.com/awslabs/amazon-kinesis-client/pull/493)
+### Latest Release (2.1.2 - February 15, 2019)
+[Milestone#29](https://github.com/awslabs/amazon-kinesis-client/milestone/29)
+* Fixed handling of the progress detection in the `ShardConsumer` to restart from the last accepted record, instead of the last queued record.
+  * [PR#492](https://github.com/awslabs/amazon-kinesis-client/pull/492)
+* Fixed handling of exceptions when using polling so that it will no longer treat `SdkException`s as an unexpected exception.
+  * [PR#497](https://github.com/awslabs/amazon-kinesis-client/pull/497)
+  * [PR#502](https://github.com/awslabs/amazon-kinesis-client/pull/502)
+* Fixed a case where lease loss would block the `Scheduler` while waiting for a record processor's `processRecords` method to complete.
+  * [PR#501](https://github.com/awslabs/amazon-kinesis-client/pull/501)
 
 ### For remaining release notes check **[CHANGELOG.md][changelog-md]**.
 

--- a/amazon-kinesis-client-multilang/pom.xml
+++ b/amazon-kinesis-client-multilang/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <artifactId>amazon-kinesis-client-pom</artifactId>
     <groupId>software.amazon.kinesis</groupId>
-    <version>2.1.2-SNAPSHOT</version>
+    <version>2.1.2</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/amazon-kinesis-client/pom.xml
+++ b/amazon-kinesis-client/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>software.amazon.kinesis</groupId>
     <artifactId>amazon-kinesis-client-pom</artifactId>
-    <version>2.1.2-SNAPSHOT</version>
+    <version>2.1.2</version>
   </parent>
 
   <artifactId>amazon-kinesis-client</artifactId>

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/RetrievalConfig.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/RetrievalConfig.java
@@ -34,7 +34,7 @@ public class RetrievalConfig {
      */
     public static final String KINESIS_CLIENT_LIB_USER_AGENT = "amazon-kinesis-client-library-java";
 
-    public static final String KINESIS_CLIENT_LIB_USER_AGENT_VERSION = "2.1.1";
+    public static final String KINESIS_CLIENT_LIB_USER_AGENT_VERSION = "2.1.2";
 
     /**
      * Client used to make calls to Kinesis for records retrieval

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
   <artifactId>amazon-kinesis-client-pom</artifactId>
   <packaging>pom</packaging>
   <name>Amazon Kinesis Client Library</name>
-  <version>2.1.2-SNAPSHOT</version>
+  <version>2.1.2</version>
   <description>The Amazon Kinesis Client Library for Java enables Java developers to easily consume and process data
     from Amazon Kinesis.
   </description>


### PR DESCRIPTION
https://github.com/awslabs/amazon-kinesis-client/milestone/29
* Fixed handling of the progress detection in the `ShardConsumer` to restart from the last accepted record, instead of the last queued record.
  * https://github.com/awslabs/amazon-kinesis-client/pull/492
* Fixed handling of exceptions when using polling so that it will no longer treat `SdkException`s as an unexpected exception.
  * https://github.com/awslabs/amazon-kinesis-client/pull/497
  * https://github.com/awslabs/amazon-kinesis-client/pull/502
* Fixed a case where lease loss would block the `Scheduler` while waiting for a record processor's `processRecords` method to complete.
  * https://github.com/awslabs/amazon-kinesis-client/pull/501


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
