### PR TITLE
Fix FanOutConsumerRegistration not waiting enough on initial registration

### DIFF
--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/fanout/FanOutConsumerRegistration.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/fanout/FanOutConsumerRegistration.java
@@ -149,15 +149,15 @@ public class FanOutConsumerRegistration implements ConsumerRegistration {
 
         int retries = maxDescribeStreamConsumerRetries;
 
-        while (!ConsumerStatus.ACTIVE.equals(status) && retries > 0) {
-            status = describeStreamConsumer().consumerDescription().consumerStatus();
-            retries--;
-            try {
+        try {
+            while (!ConsumerStatus.ACTIVE.equals(status) && retries > 0) {
+                status = describeStreamConsumer().consumerDescription().consumerStatus();
+                retries--;
                 log.info(String.format("Waiting for StreamConsumer %s to have ACTIVE status...", streamConsumerName));
                 Thread.sleep(retryBackoffMillis);
-            } catch (InterruptedException ie) {
-                log.debug("Sleep interrupted, will immediately retry fetching StreamConsumer status.");
             }
+        } catch (InterruptedException ie) {
+            log.debug("Thread was interrupted while fetching StreamConsumer status, moving on.");
         }
 
         if (!ConsumerStatus.ACTIVE.equals(status)) {

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/fanout/FanOutConsumerRegistration.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/fanout/FanOutConsumerRegistration.java
@@ -152,6 +152,12 @@ public class FanOutConsumerRegistration implements ConsumerRegistration {
         while (!ConsumerStatus.ACTIVE.equals(status) && retries > 0) {
             status = describeStreamConsumer().consumerDescription().consumerStatus();
             retries--;
+            try {
+                log.info(String.format("Waiting for StreamConsumer %s to have ACTIVE status...", streamConsumerName));
+                Thread.sleep(retryBackoffMillis);
+            } catch (InterruptedException ie) {
+                log.debug("Sleep interrupted, will immediately retry fetching StreamConsumer status.");
+            }
         }
 
         if (!ConsumerStatus.ACTIVE.equals(status)) {

--- a/amazon-kinesis-client/src/test/java/software/amazon/kinesis/retrieval/fanout/FanOutConsumerRegistrationTest.java
+++ b/amazon-kinesis-client/src/test/java/software/amazon/kinesis/retrieval/fanout/FanOutConsumerRegistrationTest.java
@@ -9,6 +9,7 @@
 package software.amazon.kinesis.retrieval.fanout;
 
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
@@ -20,6 +21,7 @@ import static org.mockito.Mockito.when;
 import java.util.concurrent.CompletableFuture;
 
 import org.apache.commons.lang3.StringUtils;
+import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -172,9 +174,12 @@ public class FanOutConsumerRegistrationTest {
                 .thenReturn(intermidateResponse).thenReturn(successResponse);
         when(client.registerStreamConsumer(any(RegisterStreamConsumerRequest.class))).thenReturn(rscFuture);
 
+        final long startTime = System.currentTimeMillis();
         final String consumerArn = consumerRegistration.getOrCreateStreamConsumerArn();
+        final long endTime = System.currentTimeMillis();
 
-        assertThat(consumerArn, equalTo(CONSUMER_ARN));
+        assertThat(consumerArn, Matchers.equalTo(CONSUMER_ARN));
+        assertThat(endTime - startTime, greaterThanOrEqualTo(2 * BACKOFF_MILLIS));
 
         verify(client).registerStreamConsumer(eq(createRegisterStreamConsumerRequest()));
         verify(client).describeStreamSummary(eq(createDescribeStreamSummaryRequest()));

--- a/amazon-kinesis-client/src/test/java/software/amazon/kinesis/retrieval/fanout/FanOutConsumerRegistrationTest.java
+++ b/amazon-kinesis-client/src/test/java/software/amazon/kinesis/retrieval/fanout/FanOutConsumerRegistrationTest.java
@@ -9,7 +9,7 @@
 package software.amazon.kinesis.retrieval.fanout;
 
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
@@ -178,7 +178,7 @@ public class FanOutConsumerRegistrationTest {
         final String consumerArn = consumerRegistration.getOrCreateStreamConsumerArn();
         final long endTime = System.currentTimeMillis();
 
-        assertThat(consumerArn, Matchers.equalTo(CONSUMER_ARN));
+        assertThat(consumerArn, equalTo(CONSUMER_ARN));
         assertThat(endTime - startTime, greaterThanOrEqualTo(2 * BACKOFF_MILLIS));
 
         verify(client).registerStreamConsumer(eq(createRegisterStreamConsumerRequest()));


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/amazon-kinesis-client/issues/506

*Description of changes:*

- Added Thread.sleep in the while loop that polls for the registration status in software.amazon.kinesis.retrieval.fanout.FanOutConsumerRegistration#waitForActive
- Modified UT to verify that change is effective

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
