### PR TITLE
Don't open a lease on the parent shard of a newly discovered shard if…

### DIFF
--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ConsumerStates.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ConsumerStates.java
@@ -531,7 +531,8 @@ class ConsumerStates {
                     consumer.getLeaseManager(),
                     consumer.getTaskBackoffTimeMillis(),
                     consumer.getGetRecordsCache(),
-                    consumer.getShardSyncer());
+                    consumer.getShardSyncer(),
+                    consumer.shouldNotCreateLeaseIfDescendantExists());
         }
 
         @Override

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/KinesisClientLibConfiguration.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/KinesisClientLibConfiguration.java
@@ -230,6 +230,7 @@ public class KinesisClientLibConfiguration {
     private boolean skipShardSyncAtWorkerInitializationIfLeasesExist;
     private ShardPrioritization shardPrioritization;
     private long shutdownGraceMillis;
+    private boolean dontCreateLeaseIfDescendantExists;
 
     @Getter
     private Optional<Integer> timeoutInSeconds = Optional.empty();
@@ -898,6 +899,14 @@ public class KinesisClientLibConfiguration {
         return shutdownGraceMillis;
     }
 
+    /**
+     *
+     * @return true if KCL will not create lease for any shard if its descendant already exists and is being processed.
+     */
+    public boolean shouldNotCreateLeaseIfDescendantExists() {
+        return dontCreateLeaseIfDescendantExists;
+    }
+
     /*
     // CHECKSTYLE:IGNORE HiddenFieldCheck FOR NEXT 190 LINES
     /**
@@ -1414,6 +1423,16 @@ public class KinesisClientLibConfiguration {
     public KinesisClientLibConfiguration withMaxListShardsRetryAttempts(int maxListShardsRetryAttempts) {
         checkIsValuePositive("maxListShardsRetryAttempts", maxListShardsRetryAttempts);
         this.maxListShardsRetryAttempts = maxListShardsRetryAttempts;
+        return this;
+    }
+
+    /**
+     * @param dontCreateLeaseIfDescendantExists Don't create lease for a shard if any descendant lease already exists
+     *                                          and is being processed.
+     * @return
+     */
+    public KinesisClientLibConfiguration withDontCreateLeaseIfDescendantExists(boolean dontCreateLeaseIfDescendantExists) {
+        this.dontCreateLeaseIfDescendantExists = dontCreateLeaseIfDescendantExists;
         return this;
     }
 }

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardConsumer.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardConsumer.java
@@ -512,4 +512,8 @@ class ShardConsumer {
     ShutdownNotification getShutdownNotification() {
         return shutdownNotification;
     }
+
+    boolean shouldNotCreateLeaseIfDescendantExists() {
+        return config.shouldNotCreateLeaseIfDescendantExists();
+    }
 }

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardReprocessingDetectionUtil.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardReprocessingDetectionUtil.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Amazon Software License (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://aws.amazon.com/asl/
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.services.kinesis.clientlibrary.lib.worker;
+
+import com.amazonaws.services.kinesis.clientlibrary.types.ExtendedSequenceNumber;
+import com.amazonaws.services.kinesis.leases.impl.KinesisClientLease;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * This class removes shards from newLeasesToCreate that have:
+ * a) Already begun processing, or
+ * b) One of their descendants have begun processing.
+ * If a lease for the shard itself of any one of their descendants is found
+ * in currentLeases, and the lease is not checkpointed at TRIM_HORIZON, LATEST,
+ * or AT_TIMESTAMP, it is considered to have begun processing.
+ * This class expects newLeasesToCreate to be sorted in increasing order of
+ * sequence number range.
+ */
+public class ShardReprocessingDetectionUtil {
+    private final List<KinesisClientLease> newLeasesToCreate;
+    private final Map<String, Set<String>> shardToChildShard;
+
+    private final Map<String, KinesisClientLease> currentShardToLease;
+    private final Map<String, Boolean> memoizeIsBeingReprocessed;
+
+    public ShardReprocessingDetectionUtil(List<KinesisClientLease> newLeasesToCreate,
+            List<KinesisClientLease> currentLeases,
+            Map<String, Set<String>> shardToChildShard) {
+        this.newLeasesToCreate = newLeasesToCreate;
+        this.shardToChildShard = shardToChildShard;
+        this.currentShardToLease = new HashMap<>();
+        this.memoizeIsBeingReprocessed = new HashMap<>();
+
+        currentLeases.stream().forEach(currentLease ->
+            currentShardToLease.put(currentLease.getLeaseKey(), currentLease)
+        );
+    }
+
+    /**
+     * This method iterates through every lease in the newLeasesToCreate list and determines if the shard is being
+     * reprocessed by using a helper method isShardBeingReprocessed, in which case, it emits a metric.
+     * In the future, after validation of this shard reprocessing detection mechanism, this method will also
+     * return a modified list of newLeasesToCreate by removing the reprocessed shards.
+     */
+    public List<KinesisClientLease> removeShardsWhoseDescendantsExist() {
+        return newLeasesToCreate.stream()
+                .filter(lease -> !hasShardBeenProcessed(lease.getLeaseKey()))
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * This helper method traverses through graph of descendant shards for the given shardId, to determine if
+     * the given shard has been processed before. It does this by finding any descendant of the given shard
+     * in the currentLeases.
+     */
+    private boolean hasShardBeenProcessed(final String shardId) {
+        // If there's memoized result about this shard, return that.
+        if (memoizeIsBeingReprocessed.containsKey(shardId)) {
+            return memoizeIsBeingReprocessed.get(shardId);
+        }
+
+        // If a lease exists and it has begun processing, mark this shard as being processed.
+        if (currentShardToLease.containsKey(shardId)
+                && hasShardBegunProcessing(currentShardToLease.get(shardId))) {
+            memoizeIsBeingReprocessed.put(shardId, true);
+            return true;
+        }
+
+        if (shardToChildShard.containsKey(shardId)) {
+            // For every child shard ...
+            for (String childShard : shardToChildShard.get(shardId)) {
+                // If child shard is being reprocessed, this shard is also being reprocessed.
+                // Memoize the result and return true.
+                if (hasShardBeenProcessed(childShard)) {
+                    memoizeIsBeingReprocessed.put(shardId, true);
+                    return true;
+                }
+            }
+        }
+
+        memoizeIsBeingReprocessed.put(shardId, false);
+        return false;
+    }
+
+
+    /**
+     * This helper function tells if the given shard has begun processing by checking the
+     * checkpoint for its lease. If checkpoint is TRIM_HORIZON, LATEST or AT_TIMESTAMP,
+     * it is safe to assume the lease hasn't begun processing yet.
+     */
+    private boolean hasShardBegunProcessing(KinesisClientLease lease) {
+        return !lease.getCheckpoint().equals(ExtendedSequenceNumber.TRIM_HORIZON)
+                && !lease.getCheckpoint().equals(ExtendedSequenceNumber.LATEST)
+                && !lease.getCheckpoint().equals(ExtendedSequenceNumber.AT_TIMESTAMP);
+    }
+}

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardSyncTask.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardSyncTask.java
@@ -39,6 +39,7 @@ class ShardSyncTask implements ITask {
     private final long shardSyncTaskIdleTimeMillis;
     private final TaskType taskType = TaskType.SHARDSYNC;
     private final ShardSyncer shardSyncer;
+    private final boolean dontCreateLeaseIfDescendantExists;
 
     /**
      * @param kinesisProxy Used to fetch information about the stream (e.g. shard list)
@@ -57,7 +58,8 @@ class ShardSyncTask implements ITask {
             boolean cleanupLeasesUponShardCompletion,
             boolean ignoreUnexpectedChildShards,
             long shardSyncTaskIdleTimeMillis,
-            ShardSyncer shardSyncer) {
+            ShardSyncer shardSyncer,
+            boolean dontCreateLeaseIfDescendantExists) {
         this.kinesisProxy = kinesisProxy;
         this.leaseManager = leaseManager;
         this.initialPosition = initialPositionInStream;
@@ -65,6 +67,7 @@ class ShardSyncTask implements ITask {
         this.ignoreUnexpectedChildShards = ignoreUnexpectedChildShards;
         this.shardSyncTaskIdleTimeMillis = shardSyncTaskIdleTimeMillis;
         this.shardSyncer = shardSyncer;
+        this.dontCreateLeaseIfDescendantExists = dontCreateLeaseIfDescendantExists;
     }
 
     /* (non-Javadoc)
@@ -79,7 +82,8 @@ class ShardSyncTask implements ITask {
                     leaseManager,
                     initialPosition,
                     cleanupLeasesUponShardCompletion,
-                    ignoreUnexpectedChildShards);
+                    ignoreUnexpectedChildShards,
+                    dontCreateLeaseIfDescendantExists);
             if (shardSyncTaskIdleTimeMillis > 0) {
                 Thread.sleep(shardSyncTaskIdleTimeMillis);
             }

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardSyncTaskManager.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardSyncTaskManager.java
@@ -47,6 +47,7 @@ class ShardSyncTaskManager {
     private boolean ignoreUnexpectedChildShards;
     private final long shardSyncIdleTimeMillis;
     private final ShardSyncer shardSyncer;
+    private final boolean dontCreateLeaseIfDescendantExists;
 
 
     /**
@@ -71,7 +72,8 @@ class ShardSyncTaskManager {
             final long shardSyncIdleTimeMillis,
             final IMetricsFactory metricsFactory,
             ExecutorService executorService,
-            ShardSyncer shardSyncer) {
+            ShardSyncer shardSyncer,
+            final boolean dontCreateLeaseIfDescendantExists) {
         this.kinesisProxy = kinesisProxy;
         this.leaseManager = leaseManager;
         this.metricsFactory = metricsFactory;
@@ -81,6 +83,7 @@ class ShardSyncTaskManager {
         this.executorService = executorService;
         this.initialPositionInStream = initialPositionInStream;
         this.shardSyncer = shardSyncer;
+        this.dontCreateLeaseIfDescendantExists = dontCreateLeaseIfDescendantExists;
     }
 
     synchronized boolean syncShardAndLeaseInfo(Set<String> closedShardIds) {
@@ -109,7 +112,8 @@ class ShardSyncTaskManager {
                             cleanupLeasesUponShardCompletion,
                             ignoreUnexpectedChildShards,
                             shardSyncIdleTimeMillis,
-                            shardSyncer), metricsFactory);
+                            shardSyncer,
+                            dontCreateLeaseIfDescendantExists), metricsFactory);
             future = executorService.submit(currentTask);
             submittedNewTask = true;
             if (LOG.isDebugEnabled()) {

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShutdownTask.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShutdownTask.java
@@ -49,6 +49,7 @@ class ShutdownTask implements ITask {
     private final long backoffTimeMillis;
     private final GetRecordsCache getRecordsCache;
     private final ShardSyncer shardSyncer;
+    private final boolean dontCreateLeaseIfDescendantExists;
 
     /**
      * Constructor.
@@ -65,7 +66,8 @@ class ShutdownTask implements ITask {
             ILeaseManager<KinesisClientLease> leaseManager,
             long backoffTimeMillis,
             GetRecordsCache getRecordsCache,
-            ShardSyncer shardSyncer) {
+            ShardSyncer shardSyncer,
+            boolean dontCreateLeaseIfDescendantExists) {
         this.shardInfo = shardInfo;
         this.recordProcessor = recordProcessor;
         this.recordProcessorCheckpointer = recordProcessorCheckpointer;
@@ -78,6 +80,7 @@ class ShutdownTask implements ITask {
         this.backoffTimeMillis = backoffTimeMillis;
         this.getRecordsCache = getRecordsCache;
         this.shardSyncer = shardSyncer;
+        this.dontCreateLeaseIfDescendantExists = dontCreateLeaseIfDescendantExists;
     }
 
     /*
@@ -134,7 +137,8 @@ class ShutdownTask implements ITask {
                         leaseManager,
                         initialPositionInStream,
                         cleanupLeasesOfCompletedShards,
-                        ignoreUnexpectedChildShards);
+                        ignoreUnexpectedChildShards,
+                        dontCreateLeaseIfDescendantExists);
                 LOG.debug("Finished checking for child shards of shard " + shardInfo.getShardId());
             }
 

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/Worker.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/Worker.java
@@ -536,7 +536,7 @@ public class Worker implements Runnable {
         this.shardSyncer = new ShardSyncer(leaseCleanupValidator);
         this.controlServer = new ShardSyncTaskManager(streamConfig.getStreamProxy(), leaseCoordinator.getLeaseManager(),
                 initialPositionInStream, cleanupLeasesUponShardCompletion, config.shouldIgnoreUnexpectedChildShards(),
-                shardSyncIdleTimeMillis, metricsFactory, executorService, shardSyncer);
+                shardSyncIdleTimeMillis, metricsFactory, executorService, shardSyncer, config.shouldNotCreateLeaseIfDescendantExists());
         this.taskBackoffTimeMillis = taskBackoffTimeMillis;
         this.failoverTimeMillis = failoverTimeMillis;
         this.skipShardSyncAtWorkerInitializationIfLeasesExist = skipShardSyncAtWorkerInitializationIfLeasesExist;
@@ -638,7 +638,8 @@ public class Worker implements Runnable {
                     LOG.info("Syncing Kinesis shard info");
                     ShardSyncTask shardSyncTask = new ShardSyncTask(streamConfig.getStreamProxy(),
                             leaseCoordinator.getLeaseManager(), initialPosition, cleanupLeasesUponShardCompletion,
-                            config.shouldIgnoreUnexpectedChildShards(), 0L, shardSyncer);
+                            config.shouldIgnoreUnexpectedChildShards(), 0L, shardSyncer,
+                            config.shouldNotCreateLeaseIfDescendantExists());
                     result = new MetricsCollectingTaskDecorator(shardSyncTask, metricsFactory).call();
                 } else {
                     LOG.info("Skipping shard sync per config setting (and lease table is not empty)");

--- a/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ConsumerStatesTest.java
+++ b/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ConsumerStatesTest.java
@@ -83,6 +83,9 @@ public class ConsumerStatesTest {
     private boolean cleanupLeasesOfCompletedShards = true;
     private long taskBackoffTimeMillis = 0xBEEF;
     private ShutdownReason reason = ShutdownReason.TERMINATE;
+    private boolean dontCreateLeaseIfDescendantExists = true;
+    private boolean dontCreateLeaseIfDescendantExistsss = false;
+
 
     @Before
     public void setup() {
@@ -101,6 +104,7 @@ public class ConsumerStatesTest {
         when(consumer.getTaskBackoffTimeMillis()).thenReturn(taskBackoffTimeMillis);
         when(consumer.getShutdownReason()).thenReturn(reason);
         when(consumer.getGetRecordsCache()).thenReturn(getRecordsCache);
+        when(consumer.shouldNotCreateLeaseIfDescendantExists()).thenReturn(dontCreateLeaseIfDescendantExists);
     }
 
     private static final Class<ILeaseManager<KinesisClientLease>> LEASE_MANAGER_CLASS = (Class<ILeaseManager<KinesisClientLease>>) (Class<?>) ILeaseManager.class;
@@ -302,7 +306,8 @@ public class ConsumerStatesTest {
         assertThat(task, shutdownTask(Long.class, "backoffTimeMillis", equalTo(taskBackoffTimeMillis)));
 
         assertThat(state.successTransition(), equalTo(ShardConsumerState.SHUTDOWN_COMPLETE.getConsumerState()));
-
+        assertThat(task,
+                shutdownTask(Boolean.class, "dontCreateLeaseIfDescendantExists", equalTo(dontCreateLeaseIfDescendantExists)));
         for (ShutdownReason reason : ShutdownReason.values()) {
             assertThat(state.shutdownTransition(reason),
                     equalTo(ShardConsumerState.SHUTDOWN_COMPLETE.getConsumerState()));

--- a/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/KinesisClientLibConfigurationTest.java
+++ b/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/KinesisClientLibConfigurationTest.java
@@ -369,4 +369,13 @@ public class KinesisClientLibConfigurationTest {
         config = config.withIgnoreUnexpectedChildShards(true);
         assertTrue(config.shouldIgnoreUnexpectedChildShards());
     }
+
+    @Test
+    public void testKCLConfigurationDontCreateLeaseIfDescendantExists() {
+        KinesisClientLibConfiguration config =
+                new KinesisClientLibConfiguration("TestApplication", "TestStream", null, "TestWorker");
+        assertFalse(config.shouldNotCreateLeaseIfDescendantExists());
+        config = config.withDontCreateLeaseIfDescendantExists(true);
+        assertTrue(config.shouldNotCreateLeaseIfDescendantExists());
+    }
 }

--- a/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardReprocessingDetectionUtilTest.java
+++ b/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardReprocessingDetectionUtilTest.java
@@ -1,0 +1,224 @@
+/*
+ * Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Amazon Software License (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://aws.amazon.com/asl/
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.services.kinesis.clientlibrary.lib.worker;
+
+import com.amazonaws.services.kinesis.clientlibrary.types.ExtendedSequenceNumber;
+import com.amazonaws.services.kinesis.leases.impl.KinesisClientLease;
+import com.amazonaws.services.kinesis.leases.impl.KinesisClientLeaseBuilder;
+import com.google.common.collect.Sets;
+import org.junit.Assert;
+import org.junit.Test;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class ShardReprocessingDetectionUtilTest {
+
+    @Test
+    public void testEmptyCurrentLeases() {
+        // Set up.
+        String shardId1 = "shard-1";
+        String shardId2 = "shard-2";
+        KinesisClientLease lease1 = new KinesisClientLeaseBuilder().withLeaseKey(shardId1)
+                .withCheckpoint(ExtendedSequenceNumber.TRIM_HORIZON).build();
+        KinesisClientLease lease2 = new KinesisClientLeaseBuilder().withLeaseKey(shardId2)
+                .withCheckpoint(ExtendedSequenceNumber.TRIM_HORIZON)
+                .withParentShardIds(Sets.newHashSet(shardId1)).build();
+        List<KinesisClientLease> newLeasesToCreate = Arrays.asList(lease1, lease2);
+
+        Map<String, Set<String>> shardIdToChildShardIdsDescribeStream = new HashMap<>();
+        shardIdToChildShardIdsDescribeStream.put(shardId1, Sets.newHashSet(shardId2));
+
+        // Test.
+        List<KinesisClientLease> finalLeases = new ShardReprocessingDetectionUtil(newLeasesToCreate,
+                Arrays.asList(), shardIdToChildShardIdsDescribeStream).removeShardsWhoseDescendantsExist();
+
+        // Verify.
+        Assert.assertEquals(finalLeases, newLeasesToCreate);
+    }
+
+    @Test
+    public void tesEmptyNewLeasesToCreate() {
+        // Set up.
+        String shardId1 = "shard-1";
+        String shardId2 = "shard-2";
+        KinesisClientLease lease1 = new KinesisClientLeaseBuilder().withLeaseKey(shardId1)
+                .withCheckpoint(ExtendedSequenceNumber.TRIM_HORIZON).build();
+        KinesisClientLease lease2 = new KinesisClientLeaseBuilder().withLeaseKey(shardId2)
+                .withCheckpoint(ExtendedSequenceNumber.TRIM_HORIZON)
+                .withParentShardIds(Sets.newHashSet(shardId1)).build();
+        List<KinesisClientLease> currentLeases = Arrays.asList(lease1, lease2);
+
+        Map<String, Set<String>> shardIdToChildShardIdsDescribeStream = new HashMap<>();
+        shardIdToChildShardIdsDescribeStream.put(shardId1, Sets.newHashSet(shardId2));
+
+        // Test.
+        List<KinesisClientLease> finalLeases = new ShardReprocessingDetectionUtil(Arrays.asList(),
+                currentLeases, shardIdToChildShardIdsDescribeStream).removeShardsWhoseDescendantsExist();
+
+        // Verify.
+        Assert.assertTrue(finalLeases.isEmpty());
+    }
+
+    /**
+     *
+     *   1
+     *  / \
+     * 2  3
+     *
+     *  DescribeStream returned empty result.
+     *  Leases for 1, 2, 3 are new leases to be create.
+     *
+     *  1. No currentLeases: All leases are created.
+     *  2. Lease for descendant 2 checkpointed at Trim_Horizon, Latest, or At_timestamp:
+     *     All leases are created.
+     *  3. Lease for descendant 2 checkpointed at a sequence number:
+     *     Only 1 and 2 are created.
+     */
+    @Test
+    public void testEmptyDescribeStream() {
+        // Set up.
+        String shardId1 = "shard-1";
+        String shardId2 = "shard-2";
+        String shardId3 = "shard-3";
+
+        KinesisClientLease lease1 = new KinesisClientLeaseBuilder()
+                .withLeaseKey(shardId1).build();
+        KinesisClientLease lease2 = new KinesisClientLeaseBuilder()
+                .withLeaseKey(shardId2)
+                .withParentShardIds(Sets.newHashSet(shardId1)).build();
+        KinesisClientLease lease3 = new KinesisClientLeaseBuilder()
+                .withLeaseKey(shardId3)
+                .withParentShardIds(Sets.newHashSet(shardId1)).build();
+        List<KinesisClientLease> newLeasesToCreate = Arrays.asList(lease1, lease2, lease3);
+
+        emptyCurrentLeases(newLeasesToCreate);
+
+        lease2.setCheckpoint(ExtendedSequenceNumber.TRIM_HORIZON);
+        descendantUnprocessed(newLeasesToCreate, Collections.emptyMap(), lease2);
+
+        lease2.setCheckpoint(ExtendedSequenceNumber.LATEST);
+        descendantUnprocessed(newLeasesToCreate, Collections.emptyMap(), lease2);
+
+        lease2.setCheckpoint(ExtendedSequenceNumber.AT_TIMESTAMP);
+        descendantUnprocessed(newLeasesToCreate, Collections.emptyMap(), lease2);
+
+        lease2.setCheckpoint(new ExtendedSequenceNumber("1234567890"));
+        descendantBeganProcessing(newLeasesToCreate, Collections.emptyMap(), lease2, Collections.emptyList());
+    }
+
+
+    /**
+     *   0
+     *   |
+     *   1
+     *  / \
+     * 2  3
+     *   / \
+     *  4   5
+     *       \
+     *        6
+     *
+     *  The above shard graph is obtained from describeStream.
+     *  Leases for 0, 1, 2, 3, 4, 5, 6 are new leases to be created.
+     *  Lease for 4 exists.
+     *
+     *  1. Lease for descendant 4 at Trim_Horizon, Latest or At_Timestamp:
+     *     All leases are created.
+     *  2. Lease for descendant 4 checkpointed at a sequence number:
+     *     2, 5, 6 are created.
+     */
+    @Test
+    public void testDescendantExists() {
+        // Set up.
+        String shardId0 = "shard-0";
+        String shardId1 = "shard-1";
+        String shardId2 = "shard-2";
+        String shardId3 = "shard-3";
+        String shardId4 = "shard-4";
+        String shardId5 = "shard-5";
+        String shardId6 = "shard-6";
+
+        KinesisClientLease lease0 = new KinesisClientLeaseBuilder().withLeaseKey(shardId0)
+                .build();
+        KinesisClientLease lease1 = new KinesisClientLeaseBuilder().withLeaseKey(shardId1)
+                .withParentShardIds(Sets.newHashSet(shardId0)).build();
+        KinesisClientLease lease2 = new KinesisClientLeaseBuilder().withLeaseKey(shardId2)
+                .withParentShardIds(Sets.newHashSet(shardId1)).build();
+        KinesisClientLease lease3 = new KinesisClientLeaseBuilder().withLeaseKey(shardId3)
+                .withParentShardIds(Sets.newHashSet(shardId1)).build();
+        KinesisClientLease lease4 = new KinesisClientLeaseBuilder().withLeaseKey(shardId4)
+                .withParentShardIds(Sets.newHashSet(shardId3)).build();
+        KinesisClientLease lease5 = new KinesisClientLeaseBuilder().withLeaseKey(shardId5)
+                .withParentShardIds(Sets.newHashSet(shardId3)).build();
+        KinesisClientLease lease6 = new KinesisClientLeaseBuilder().withLeaseKey(shardId6)
+                .withParentShardIds(Sets.newHashSet(shardId5)).build();
+
+        List<KinesisClientLease> newLeasesToCreate = Arrays.asList(lease0, lease1, lease2,
+                lease3, lease4, lease5, lease6);
+
+        Map<String, Set<String>> shardIdToChildShardIdsDescribeStream = new HashMap<>();
+        shardIdToChildShardIdsDescribeStream.put(shardId0, Sets.newHashSet(shardId1));
+        shardIdToChildShardIdsDescribeStream.put(shardId1, Sets.newHashSet(shardId2, shardId3));
+        shardIdToChildShardIdsDescribeStream.put(shardId3, Sets.newHashSet(shardId4, shardId5));
+        shardIdToChildShardIdsDescribeStream.put(shardId5, Sets.newHashSet(shardId6));
+
+        lease4.setCheckpoint(ExtendedSequenceNumber.LATEST);
+        descendantUnprocessed(newLeasesToCreate, shardIdToChildShardIdsDescribeStream, lease4);
+
+        lease4.setCheckpoint(ExtendedSequenceNumber.TRIM_HORIZON);
+        descendantUnprocessed(newLeasesToCreate, shardIdToChildShardIdsDescribeStream, lease4);
+
+        lease4.setCheckpoint(ExtendedSequenceNumber.AT_TIMESTAMP);
+        descendantUnprocessed(newLeasesToCreate, shardIdToChildShardIdsDescribeStream, lease4);
+
+        lease4.setCheckpoint(new ExtendedSequenceNumber("1234567890"));
+        descendantBeganProcessing(newLeasesToCreate, shardIdToChildShardIdsDescribeStream, lease4,
+                Arrays.asList(lease0, lease1, lease3));
+    }
+
+    private void descendantUnprocessed(List<KinesisClientLease> newLeasesToCreate,
+            Map<String, Set<String>> shardIdToChildShardIdsDescribeStream,
+            KinesisClientLease existingDescendant) {
+        List<KinesisClientLease> finalLeases = new ShardReprocessingDetectionUtil(newLeasesToCreate,
+                Arrays.asList(existingDescendant), shardIdToChildShardIdsDescribeStream).removeShardsWhoseDescendantsExist();
+
+        Assert.assertEquals(finalLeases, newLeasesToCreate);
+    }
+
+    private void descendantBeganProcessing(List<KinesisClientLease> newLeasesToCreate,
+            Map<String, Set<String>> shardIdToChildShardIdsDescribeStream,
+            KinesisClientLease existingDescendant,
+            List<KinesisClientLease> ancestorsOfDescendant) {
+        List<KinesisClientLease> finalLeases = new ShardReprocessingDetectionUtil(newLeasesToCreate,
+                Arrays.asList(existingDescendant), shardIdToChildShardIdsDescribeStream).removeShardsWhoseDescendantsExist();
+        List<KinesisClientLease> expectedLeases = newLeasesToCreate.stream()
+                .filter(lease -> !lease.equals(existingDescendant) && !ancestorsOfDescendant.contains(lease))
+                .collect(Collectors.toList());
+
+        Assert.assertEquals(finalLeases, expectedLeases);
+    }
+
+    private void emptyCurrentLeases(List<KinesisClientLease> newLeasesToCreate) {
+        List<KinesisClientLease> finalLeases = new ShardReprocessingDetectionUtil(newLeasesToCreate,
+                Collections.emptyList(), Collections.emptyMap()).removeShardsWhoseDescendantsExist();
+
+        Assert.assertEquals(newLeasesToCreate, finalLeases);
+    }
+}

--- a/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardSyncTaskIntegrationTest.java
+++ b/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardSyncTaskIntegrationTest.java
@@ -127,7 +127,8 @@ public class ShardSyncTaskIntegrationTest {
                 false,
                 false,
                 0L,
-                shardSyncer);
+                shardSyncer,
+                false);
         syncTask.call();
         List<KinesisClientLease> leases = leaseManager.listLeases();
         Set<String> leaseKeys = new HashSet<String>();

--- a/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardSyncerTest.java
+++ b/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardSyncerTest.java
@@ -230,7 +230,7 @@ public class ShardSyncerTest {
         IKinesisProxy kinesisProxy = new KinesisLocalFileProxy(dataFile.getAbsolutePath());
 
         shardSyncer.checkAndCreateLeasesForNewShards(kinesisProxy, leaseManager, INITIAL_POSITION_LATEST,
-                cleanupLeasesOfCompletedShards, false);
+                cleanupLeasesOfCompletedShards, false, false);
         List<KinesisClientLease> newLeases = leaseManager.listLeases();
         Set<String> expectedLeaseShardIds = new HashSet<String>();
         expectedLeaseShardIds.add("shardId-4");
@@ -262,7 +262,7 @@ public class ShardSyncerTest {
         IKinesisProxy kinesisProxy = new KinesisLocalFileProxy(dataFile.getAbsolutePath());
 
         shardSyncer.checkAndCreateLeasesForNewShards(kinesisProxy, leaseManager, INITIAL_POSITION_TRIM_HORIZON,
-                cleanupLeasesOfCompletedShards, false);
+                cleanupLeasesOfCompletedShards, false, false);
         List<KinesisClientLease> newLeases = leaseManager.listLeases();
         Set<String> expectedLeaseShardIds = new HashSet<String>();
         for (int i = 0; i < 11; i++) {
@@ -293,7 +293,7 @@ public class ShardSyncerTest {
         IKinesisProxy kinesisProxy = new KinesisLocalFileProxy(dataFile.getAbsolutePath());
 
         shardSyncer.checkAndCreateLeasesForNewShards(kinesisProxy, leaseManager, INITIAL_POSITION_AT_TIMESTAMP,
-                cleanupLeasesOfCompletedShards, false);
+                cleanupLeasesOfCompletedShards, false, false);
         List<KinesisClientLease> newLeases = leaseManager.listLeases();
         Set<String> expectedLeaseShardIds = new HashSet<String>();
         for (int i = 0; i < 11; i++) {
@@ -327,7 +327,7 @@ public class ShardSyncerTest {
         IKinesisProxy kinesisProxy = new KinesisLocalFileProxy(dataFile.getAbsolutePath());
 
         shardSyncer.checkAndCreateLeasesForNewShards(kinesisProxy, leaseManager, INITIAL_POSITION_TRIM_HORIZON,
-                cleanupLeasesOfCompletedShards, false);
+                cleanupLeasesOfCompletedShards, false, false);
         dataFile.delete();
     }
 
@@ -352,7 +352,7 @@ public class ShardSyncerTest {
         dataFile.deleteOnExit();
         IKinesisProxy kinesisProxy = new KinesisLocalFileProxy(dataFile.getAbsolutePath());
         shardSyncer.checkAndCreateLeasesForNewShards(kinesisProxy, leaseManager, INITIAL_POSITION_LATEST,
-                cleanupLeasesOfCompletedShards, true);
+                cleanupLeasesOfCompletedShards, true, false);
         List<KinesisClientLease> newLeases = leaseManager.listLeases();
         Set<String> expectedLeaseShardIds = new HashSet<String>();
         expectedLeaseShardIds.add("shardId-4");
@@ -467,6 +467,7 @@ public class ShardSyncerTest {
                             exceptionThrowingLeaseManager,
                             position,
                             cleanupLeasesOfCompletedShards,
+                            false,
                             false);
                     return;
                 } catch (LeasingException e) {
@@ -480,6 +481,7 @@ public class ShardSyncerTest {
                     leaseManager,
                     position,
                     cleanupLeasesOfCompletedShards,
+                    false,
                     false);
         }
     }
@@ -659,7 +661,7 @@ public class ShardSyncerTest {
         IKinesisProxy kinesisProxy = new KinesisLocalFileProxy(dataFile.getAbsolutePath());
 
         shardSyncer.bootstrapShardLeases(kinesisProxy, leaseManager, initialPosition, cleanupLeasesOfCompletedShards,
-                false);
+                false, false);
         List<KinesisClientLease> newLeases = leaseManager.listLeases();
         Assert.assertEquals(2, newLeases.size());
         Set<String> expectedLeaseShardIds = new HashSet<String>();

--- a/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShutdownTaskTest.java
+++ b/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShutdownTaskTest.java
@@ -113,7 +113,8 @@ public class ShutdownTaskTest {
                 leaseManager,
                 TASK_BACKOFF_TIME_MILLIS,
                 getRecordsCache,
-                shardSyncer);
+                shardSyncer,
+                false);
         TaskResult result = task.call();
         Assert.assertNotNull(result.getException());
         Assert.assertTrue(result.getException() instanceof IllegalArgumentException);
@@ -142,7 +143,8 @@ public class ShutdownTaskTest {
                 leaseManager,
                 TASK_BACKOFF_TIME_MILLIS,
                 getRecordsCache,
-                shardSyncer);
+                shardSyncer,
+                false);
         TaskResult result = task.call();
         Assert.assertNotNull(result.getException());
         Assert.assertTrue(result.getException() instanceof KinesisClientLibIOException);
@@ -154,7 +156,7 @@ public class ShutdownTaskTest {
      */
     @Test
     public final void testGetTaskType() {
-        ShutdownTask task = new ShutdownTask(null, null, null, null, null, null, false, false, null, 0, getRecordsCache, shardSyncer);
+        ShutdownTask task = new ShutdownTask(null, null, null, null, null, null, false, false, null, 0, getRecordsCache, shardSyncer, false);
         Assert.assertEquals(TaskType.SHUTDOWN, task.getTaskType());
     }
 


### PR DESCRIPTION
… any of the other descendants of that parent shard have leases

*Issue #, if available: Default KCL lease garbage collection strategy can cause reprocessing of old shards during non-atomic partition splits

*Description of changes:
- Create a util class ShardReprocessingDetectionUtil, to traverse through list of new leases that shard syncer wants to create, and remove any lease for a parent shard from that list whose descendant exists in lease table
- To be more careful while not creating leases for a parent shard, the util also checks that descendant's lease is checkpointed at some sequence number and not trim_horizon, latest or at_timestamp
- This will be an opt-in behavior using flag `dontCreateLeaseIfDescendantExists` in KinesisClientLibConfiguration
- Util is unit tested separately and not as part of ShardSyncer unit tests


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
