### PR TITLE
Added Timeouts for DynamoDB and Kinesis Calls

### DIFF
--- a/amazon-kinesis-client-multilang/pom.xml
+++ b/amazon-kinesis-client-multilang/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <artifactId>amazon-kinesis-client-pom</artifactId>
     <groupId>software.amazon.kinesis</groupId>
-    <version>2.1.2</version>
+    <version>2.1.3-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/amazon-kinesis-client/pom.xml
+++ b/amazon-kinesis-client/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>software.amazon.kinesis</groupId>
     <artifactId>amazon-kinesis-client-pom</artifactId>
-    <version>2.1.2</version>
+    <version>2.1.3-SNAPSHOT</version>
   </parent>
 
   <artifactId>amazon-kinesis-client</artifactId>

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/common/FutureUtils.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/common/FutureUtils.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Amazon Software License (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://aws.amazon.com/asl/
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package software.amazon.kinesis.common;
+
+import java.time.Duration;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+public class FutureUtils {
+
+    public static <T> T resolveOrCancelFuture(Future<T> future, Duration timeout)
+            throws ExecutionException, InterruptedException, TimeoutException {
+        try {
+            return future.get(timeout.toMillis(), TimeUnit.MILLISECONDS);
+        } catch (TimeoutException te) {
+            future.cancel(true);
+            throw te;
+        }
+    }
+
+}

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/leases/LeaseManagementConfig.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/leases/LeaseManagementConfig.java
@@ -15,6 +15,7 @@
 
 package software.amazon.kinesis.leases;
 
+import java.time.Duration;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadFactory;
@@ -41,6 +42,9 @@ import software.amazon.kinesis.metrics.NullMetricsFactory;
 @Data
 @Accessors(fluent = true)
 public class LeaseManagementConfig {
+
+    public static final Duration DEFAULT_REQUEST_TIMEOUT = Duration.ofMinutes(1);
+
     /**
      * Name of the table to use in DynamoDB
      *
@@ -159,6 +163,8 @@ public class LeaseManagementConfig {
 
     public long epsilonMillis = 25L;
 
+    private Duration dynamoDbRequestTimeout = DEFAULT_REQUEST_TIMEOUT;
+
     /**
      * The initial position for getting records from Kinesis streams.
      *
@@ -261,7 +267,7 @@ public class LeaseManagementConfig {
                     initialLeaseTableReadCapacity(),
                     initialLeaseTableWriteCapacity(),
                     hierarchicalShardSyncer(),
-                    tableCreatorCallback());
+                    tableCreatorCallback(), dynamoDbRequestTimeout());
         }
         return leaseManagementFactory;
     }

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/polling/PollingConfig.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/polling/PollingConfig.java
@@ -15,6 +15,7 @@
 
 package software.amazon.kinesis.retrieval.polling;
 
+import java.time.Duration;
 import java.util.Optional;
 
 import lombok.Data;
@@ -31,6 +32,8 @@ import software.amazon.kinesis.retrieval.RetrievalSpecificConfig;
 @Data
 @Getter
 public class PollingConfig implements RetrievalSpecificConfig {
+
+    public static final Duration DEFAULT_REQUEST_TIMEOUT = Duration.ofSeconds(30);
 
     /**
      * Name of the Kinesis stream.
@@ -94,9 +97,14 @@ public class PollingConfig implements RetrievalSpecificConfig {
      */
     private RecordsFetcherFactory recordsFetcherFactory = new SimpleRecordsFetcherFactory();
 
+    /**
+     * The maximum time to wait for a future request from Kinesis to complete
+     */
+    private Duration kinesisRequestTimeout = DEFAULT_REQUEST_TIMEOUT;
+
     @Override
     public RetrievalFactory retrievalFactory() {
         return new SynchronousBlockingRetrievalFactory(streamName(), kinesisClient(), recordsFetcherFactory,
-                maxRecords());
+                maxRecords(), kinesisRequestTimeout);
     }
 }

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/polling/PrefetchRecordsPublisher.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/polling/PrefetchRecordsPublisher.java
@@ -51,6 +51,7 @@ import software.amazon.kinesis.retrieval.GetRecordsRetrievalStrategy;
 import software.amazon.kinesis.retrieval.KinesisClientRecord;
 import software.amazon.kinesis.retrieval.RecordsPublisher;
 import software.amazon.kinesis.retrieval.RecordsRetrieved;
+import software.amazon.kinesis.retrieval.RetryableRetrievalException;
 import software.amazon.kinesis.retrieval.kpl.ExtendedSequenceNumber;
 
 /**
@@ -317,6 +318,8 @@ public class PrefetchRecordsPublisher implements RecordsPublisher {
                     drainQueueForRequests();
                 } catch (PositionResetException pse) {
                     throw pse;
+                } catch (RetryableRetrievalException rre) {
+                    log.info("Timeout occurred while waiting for response from Kinesis.  Will retry the request.");
                 } catch (InterruptedException e) {
                     log.info("Thread was interrupted, indicating shutdown was called on the cache.");
                 } catch (ExpiredIteratorException e) {

--- a/amazon-kinesis-client/src/test/java/software/amazon/kinesis/common/FutureUtilsTest.java
+++ b/amazon-kinesis-client/src/test/java/software/amazon/kinesis/common/FutureUtilsTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Amazon Software License (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://aws.amazon.com/asl/
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package software.amazon.kinesis.common;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.time.Duration;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeoutException;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyLong;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class FutureUtilsTest {
+
+    @Mock
+    private Future<String> future;
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    @Test
+    public void testTimeoutExceptionCancelsFuture() throws Exception {
+        expectedException.expect(TimeoutException.class);
+
+        when(future.get(anyLong(), any())).thenThrow(new TimeoutException("Timeout"));
+
+        try {
+            FutureUtils.resolveOrCancelFuture(future, Duration.ofSeconds(1));
+        } finally {
+            verify(future).cancel(eq(true));
+        }
+    }
+}

--- a/amazon-kinesis-client/src/test/java/software/amazon/kinesis/leases/dynamodb/DynamoDBLeaseRefresherTest.java
+++ b/amazon-kinesis-client/src/test/java/software/amazon/kinesis/leases/dynamodb/DynamoDBLeaseRefresherTest.java
@@ -1,0 +1,268 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Amazon Software License (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://aws.amazon.com/asl/
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package software.amazon.kinesis.leases.dynamodb;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyBoolean;
+import static org.mockito.Matchers.anyLong;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.CreateTableRequest;
+import software.amazon.awssdk.services.dynamodb.model.CreateTableResponse;
+import software.amazon.awssdk.services.dynamodb.model.DeleteItemRequest;
+import software.amazon.awssdk.services.dynamodb.model.DeleteItemResponse;
+import software.amazon.awssdk.services.dynamodb.model.DescribeTableRequest;
+import software.amazon.awssdk.services.dynamodb.model.DescribeTableResponse;
+import software.amazon.awssdk.services.dynamodb.model.GetItemRequest;
+import software.amazon.awssdk.services.dynamodb.model.GetItemResponse;
+import software.amazon.awssdk.services.dynamodb.model.PutItemRequest;
+import software.amazon.awssdk.services.dynamodb.model.PutItemResponse;
+import software.amazon.awssdk.services.dynamodb.model.ResourceNotFoundException;
+import software.amazon.awssdk.services.dynamodb.model.ScanRequest;
+import software.amazon.awssdk.services.dynamodb.model.ScanResponse;
+import software.amazon.awssdk.services.dynamodb.model.UpdateItemRequest;
+import software.amazon.awssdk.services.dynamodb.model.UpdateItemResponse;
+import software.amazon.kinesis.leases.Lease;
+import software.amazon.kinesis.leases.LeaseSerializer;
+import software.amazon.kinesis.leases.exceptions.DependencyException;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DynamoDBLeaseRefresherTest {
+
+    private static final String TABLE_NAME = "test";
+    private static final boolean CONSISTENT_READS = true;
+
+    @Mock
+    private DynamoDbAsyncClient dynamoDbClient;
+    @Mock
+    private LeaseSerializer leaseSerializer;
+    @Mock
+    private TableCreatorCallback tableCreatorCallback;
+    @Mock
+    private CompletableFuture<ScanResponse> mockScanFuture;
+    @Mock
+    private CompletableFuture<PutItemResponse> mockPutItemFuture;
+    @Mock
+    private CompletableFuture<GetItemResponse> mockGetItemFuture;
+    @Mock
+    private CompletableFuture<UpdateItemResponse> mockUpdateFuture;
+    @Mock
+    private CompletableFuture<DeleteItemResponse> mockDeleteFuture;
+    @Mock
+    private CompletableFuture<DescribeTableResponse> mockDescribeTableFuture;
+    @Mock
+    private CompletableFuture<CreateTableResponse> mockCreateTableFuture;
+    @Mock
+    private Lease lease;
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    private DynamoDBLeaseRefresher leaseRefresher;
+
+    private Map<String, AttributeValue> serializedLease;
+
+    @Before
+    public void setup() throws Exception {
+        leaseRefresher = new DynamoDBLeaseRefresher(TABLE_NAME, dynamoDbClient, leaseSerializer, CONSISTENT_READS,
+                tableCreatorCallback);
+        serializedLease = new HashMap<>();
+
+    }
+
+    @Test
+    public void testListLeasesHandlesTimeout() throws Exception {
+        TimeoutException te = setRuleForDependencyTimeout();
+
+        when(mockScanFuture.get(anyLong(), any(TimeUnit.class))).thenThrow(te);
+        when(dynamoDbClient.scan(any(ScanRequest.class))).thenReturn(mockScanFuture);
+
+        verifyCancel(mockScanFuture, () -> leaseRefresher.listLeases());
+    }
+
+    @Test
+    public void testListLeasesSucceedsThenFails() throws Exception {
+        TimeoutException te = setRuleForDependencyTimeout();
+
+        when(dynamoDbClient.scan(any(ScanRequest.class))).thenReturn(mockScanFuture);
+
+        Map<String, AttributeValue> lastEvaluatedKey = new HashMap<>();
+        lastEvaluatedKey.put("Test", AttributeValue.builder().s("test").build());
+
+        when(mockScanFuture.get(anyLong(), any(TimeUnit.class)))
+                .thenReturn(ScanResponse.builder().lastEvaluatedKey(lastEvaluatedKey).build())
+                .thenThrow(te);
+
+        verifyCancel(mockScanFuture, () -> leaseRefresher.listLeases());
+
+        verify(mockScanFuture, times(2)).get(anyLong(), any(TimeUnit.class));
+        verify(dynamoDbClient, times(2)).scan(any(ScanRequest.class));
+
+    }
+
+    @Test
+    public void testCreateLeaseIfNotExistsTimesOut() throws Exception {
+        TimeoutException te = setRuleForDependencyTimeout();
+
+        when(dynamoDbClient.putItem(any(PutItemRequest.class))).thenReturn(mockPutItemFuture);
+        when(mockPutItemFuture.get(anyLong(), any())).thenThrow(te);
+
+        when(leaseSerializer.toDynamoRecord(any())).thenReturn(serializedLease);
+        when(leaseSerializer.getDynamoNonexistantExpectation()).thenReturn(Collections.emptyMap());
+
+        verifyCancel(mockPutItemFuture, () -> leaseRefresher.createLeaseIfNotExists(lease));
+    }
+
+    @Test
+    public void testGetLeaseTimesOut() throws Exception {
+        TimeoutException te = setRuleForDependencyTimeout();
+
+        when(dynamoDbClient.getItem(any(GetItemRequest.class))).thenReturn(mockGetItemFuture);
+        when(mockGetItemFuture.get(anyLong(), any())).thenThrow(te);
+
+        when(leaseSerializer.getDynamoHashKey(anyString())).thenReturn(Collections.emptyMap());
+
+        verifyCancel(mockGetItemFuture, () -> leaseRefresher.getLease("test"));
+    }
+
+    @Test
+    public void testRenewLeaseTimesOut() throws Exception {
+        setupUpdateItemTest();
+        verifyCancel(mockUpdateFuture, () ->leaseRefresher.renewLease(lease));
+    }
+
+    @Test
+    public void testTakeLeaseTimesOut() throws Exception {
+        setupUpdateItemTest();
+        verifyCancel(mockUpdateFuture, () -> leaseRefresher.takeLease(lease, "owner"));
+    }
+
+    @Test
+    public void testEvictLeaseTimesOut() throws Exception {
+        setupUpdateItemTest();
+        verifyCancel(mockUpdateFuture, () -> leaseRefresher.evictLease(lease));
+    }
+
+    @Test
+    public void testUpdateLeaseTimesOut() throws Exception {
+        setupUpdateItemTest();
+        verifyCancel(mockUpdateFuture, () -> leaseRefresher.updateLease(lease));
+    }
+
+    @Test
+    public void testDeleteAllLeasesTimesOut() throws Exception {
+        TimeoutException te = setRuleForDependencyTimeout();
+        when(dynamoDbClient.scan(any(ScanRequest.class))).thenReturn(mockScanFuture);
+        when(mockScanFuture.get(anyLong(), any())).thenReturn(ScanResponse.builder().items(Collections.emptyMap()).build());
+        when(leaseSerializer.fromDynamoRecord(any())).thenReturn(lease);
+        when(leaseSerializer.getDynamoHashKey(any(Lease.class))).thenReturn(Collections.emptyMap());
+
+        when(dynamoDbClient.deleteItem(any(DeleteItemRequest.class))).thenReturn(mockDeleteFuture);
+        when(mockDeleteFuture.get(anyLong(), any())).thenThrow(te);
+
+        verifyCancel(mockDeleteFuture, () -> leaseRefresher.deleteAll());
+    }
+
+    @Test
+    public void testDeleteLeaseTimesOut() throws Exception {
+        TimeoutException te = setRuleForDependencyTimeout();
+        when(leaseSerializer.getDynamoHashKey(any(Lease.class))).thenReturn(Collections.emptyMap());
+
+        when(dynamoDbClient.deleteItem(any(DeleteItemRequest.class))).thenReturn(mockDeleteFuture);
+        when(mockDeleteFuture.get(anyLong(), any())).thenThrow(te);
+
+        verifyCancel(mockDeleteFuture, () -> leaseRefresher.deleteLease(lease));
+    }
+
+    @Test
+    public void testLeaseTableExistsTimesOut() throws Exception {
+        TimeoutException te = setRuleForDependencyTimeout();
+
+        when(dynamoDbClient.describeTable(any(DescribeTableRequest.class))).thenReturn(mockDescribeTableFuture);
+        when(mockDescribeTableFuture.get(anyLong(), any())).thenThrow(te);
+
+        verifyCancel(mockDescribeTableFuture, () -> leaseRefresher.leaseTableExists());
+    }
+
+    @Test
+    public void testCreateLeaseTableTimesOut() throws Exception {
+        TimeoutException te = setRuleForDependencyTimeout();
+
+        when(dynamoDbClient.describeTable(any(DescribeTableRequest.class))).thenReturn(mockDescribeTableFuture);
+        when(mockDescribeTableFuture.get(anyLong(), any()))
+                .thenThrow(ResourceNotFoundException.builder().message("Table doesn't exist").build());
+
+        when(dynamoDbClient.createTable(any(CreateTableRequest.class))).thenReturn(mockCreateTableFuture);
+        when(mockCreateTableFuture.get(anyLong(), any())).thenThrow(te);
+
+        verifyCancel(mockCreateTableFuture, () -> leaseRefresher.createLeaseTableIfNotExists(10L, 10L));
+    }
+
+    @FunctionalInterface
+    private interface TestCaller {
+        void call() throws Exception;
+    }
+
+    private void verifyCancel(Future<?> future, TestCaller toExecute) throws Exception {
+        try {
+            toExecute.call();
+        } finally {
+            verify(future).cancel(anyBoolean());
+        }
+    }
+
+    private void setupUpdateItemTest() throws Exception {
+        TimeoutException te = setRuleForDependencyTimeout();
+
+        when(leaseSerializer.getDynamoHashKey(any(Lease.class))).thenReturn(Collections.emptyMap());
+        when(leaseSerializer.getDynamoLeaseCounterExpectation(any(Lease.class))).thenReturn(Collections.emptyMap());
+        when(leaseSerializer.getDynamoLeaseCounterUpdate(any(Lease.class))).thenReturn(Collections.emptyMap());
+        when(leaseSerializer.getDynamoTakeLeaseUpdate(any(), anyString())).thenReturn(Collections.emptyMap());
+
+        when(dynamoDbClient.updateItem(any(UpdateItemRequest.class))).thenReturn(mockUpdateFuture);
+        when(mockUpdateFuture.get(anyLong(), any())).thenThrow(te);
+    }
+
+    private TimeoutException setRuleForDependencyTimeout() {
+        TimeoutException te = new TimeoutException("Timeout");
+        expectedException.expect(DependencyException.class);
+        expectedException.expectCause(equalTo(te));
+
+        return te;
+    }
+
+}

--- a/amazon-kinesis-client/src/test/java/software/amazon/kinesis/retrieval/polling/PrefetchRecordsPublisherIntegrationTest.java
+++ b/amazon-kinesis-client/src/test/java/software/amazon/kinesis/retrieval/polling/PrefetchRecordsPublisherIntegrationTest.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyLong;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -34,6 +35,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 
 import org.junit.After;
 import org.junit.Before;
@@ -93,7 +95,7 @@ public class PrefetchRecordsPublisherIntegrationTest {
     private InitialPositionInStreamExtended initialPosition;
 
     @Before
-    public void setup() throws InterruptedException, ExecutionException {
+    public void setup() throws Exception {
         records = new ArrayList<>();
         dataFetcher = spy(new KinesisDataFetcherForTest(kinesisClient, streamName, shardId, MAX_RECORDS_PER_CALL));
         getRecordsRetrievalStrategy = Mockito.spy(new SynchronousGetRecordsRetrievalStrategy(dataFetcher));
@@ -101,7 +103,7 @@ public class PrefetchRecordsPublisherIntegrationTest {
         CompletableFuture<GetShardIteratorResponse> future = mock(CompletableFuture.class);
 
         when(extendedSequenceNumber.sequenceNumber()).thenReturn("LATEST");
-        when(future.get()).thenReturn(GetShardIteratorResponse.builder().shardIterator("TestIterator").build());
+        when(future.get(anyLong(), any(TimeUnit.class))).thenReturn(GetShardIteratorResponse.builder().shardIterator("TestIterator").build());
         when(kinesisClient.getShardIterator(any(GetShardIteratorRequest.class))).thenReturn(future);
 
         getRecordsCache = new PrefetchRecordsPublisher(MAX_SIZE,

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
   </scm>
 
   <properties>
-    <awssdk.version>2.4.0</awssdk.version>
+    <awssdk.version>2.5.10</awssdk.version>
   </properties>
 
   <licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
   <artifactId>amazon-kinesis-client-pom</artifactId>
   <packaging>pom</packaging>
   <name>Amazon Kinesis Client Library</name>
-  <version>2.1.2</version>
+  <version>2.1.3-SNAPSHOT</version>
   <description>The Amazon Kinesis Client Library for Java enables Java developers to easily consume and process data
     from Amazon Kinesis.
   </description>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Added timeouts for Kinesis and DynamoDB calls

Added a timeout to prevent an issue where the Kinesis or DynamoDB call
never completes.

For Kinesis call to GetRecords the timeout defaults to 30 seconds, and can be configured
on the PollingConfig.

For DynamoDB and Kinesis (when calling ListShards) the timeout
defaults to 60 seconds and can be configured on LeaseManagementConfig.

Updated AWS Java SDK to 2.5.10.

Advance version to 2.1.3-SNAPSHOT


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
