### PR TITLE
Release 2.1.3 of the Amazon Kinesis Client Library for Java

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+### Release 2.1.3 (March 18, 2019)
+[Milestone#30](https://github.com/awslabs/amazon-kinesis-client/milestone/30)
+* Added a message to recommend using `KinesisClientUtil` when an acquire timeout occurs in the `FanOutRecordsPublisher`.
+  * [PR#514](https://github.com/awslabs/amazon-kinesis-client/pull/514)
+* Added a sleep between retries while waiting for a newly created stream consumer to become active.
+  * [PR#506](https://github.com/awslabs/amazon-kinesis-client/issues/506)
+* Added timeouts on all futures returned from the DynamoDB and Kinesis clients.  
+  The timeouts can be configured by setting `LeaseManagementConfig#requestTimeout(Duration)` for DynamoDB, and `PollingConfig#kinesisRequestTimeout(Duration)` for Kinesis.
+  * [PR#518](https://github.com/awslabs/amazon-kinesis-client/pull/518)
+* Upgraded to SDK version 2.5.10.
+  * [PR#518](https://github.com/awslabs/amazon-kinesis-client/pull/518)
+* Artifacts for the Amazon Kinesis Client for Java are now signed by a new GPG key:
+  ```
+  pub   4096R/86368934 2019-02-14 [expires: 2020-02-14]
+  uid                  Amazon Kinesis Tools <amazon-kinesis-tools@amazon.com>
+  ```
+
 ### Release 2.1.2 (February 18, 2019)
 [Milestone#29](https://github.com/awslabs/amazon-kinesis-client/milestone/29)
 * Fixed handling of the progress detection in the `ShardConsumer` to restart from the last accepted record, instead of the last queued record.

--- a/README.md
+++ b/README.md
@@ -58,18 +58,25 @@ The recommended way to use the KCL for Java is to consume it from Maven.
   </dependency>
   ```
 
-
 ## Release Notes
 
-### Latest Release (2.1.2 - February 18, 2019)
-[Milestone#29](https://github.com/awslabs/amazon-kinesis-client/milestone/29)
-* Fixed handling of the progress detection in the `ShardConsumer` to restart from the last accepted record, instead of the last queued record.
-  * [PR#492](https://github.com/awslabs/amazon-kinesis-client/pull/492)
-* Fixed handling of exceptions when using polling so that it will no longer treat `SdkException`s as an unexpected exception.
-  * [PR#497](https://github.com/awslabs/amazon-kinesis-client/pull/497)
-  * [PR#502](https://github.com/awslabs/amazon-kinesis-client/pull/502)
-* Fixed a case where lease loss would block the `Scheduler` while waiting for a record processor's `processRecords` method to complete.
-  * [PR#501](https://github.com/awslabs/amazon-kinesis-client/pull/501)
+### Latest Release (2.1.3 - March 18, 2019)
+[Milestone#30](https://github.com/awslabs/amazon-kinesis-client/milestone/30)
+* Added a message to recommend using `KinesisClientUtil` when an acquire timeout occurs in the `FanOutRecordsPublisher`.
+  * [PR#514](https://github.com/awslabs/amazon-kinesis-client/pull/514)
+* Added a sleep between retries while waiting for a newly created stream consumer to become active.
+  * [PR#506](https://github.com/awslabs/amazon-kinesis-client/issues/506)
+* Added timeouts on all futures returned from the DynamoDB and Kinesis clients.  
+  The timeouts can be configured by setting `LeaseManagementConfig#requestTimeout(Duration)` for DynamoDB, and `PollingConfig#kinesisRequestTimeout(Duration)` for Kinesis.
+  * [PR#518](https://github.com/awslabs/amazon-kinesis-client/pull/518)
+* Upgraded to SDK version 2.5.10.
+  * [PR#518](https://github.com/awslabs/amazon-kinesis-client/pull/518)
+* Artifacts for the Amazon Kinesis Client for Java are now signed by a new GPG key:
+  ```
+  pub   4096R/86368934 2019-02-14 [expires: 2020-02-14]
+  uid                  Amazon Kinesis Tools <amazon-kinesis-tools@amazon.com>
+  ```
+
 
 ### For remaining release notes check **[CHANGELOG.md][changelog-md]**.
 

--- a/amazon-kinesis-client-multilang/pom.xml
+++ b/amazon-kinesis-client-multilang/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <artifactId>amazon-kinesis-client-pom</artifactId>
     <groupId>software.amazon.kinesis</groupId>
-    <version>2.1.3-SNAPSHOT</version>
+    <version>2.1.3</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/amazon-kinesis-client/pom.xml
+++ b/amazon-kinesis-client/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>software.amazon.kinesis</groupId>
     <artifactId>amazon-kinesis-client-pom</artifactId>
-    <version>2.1.3-SNAPSHOT</version>
+    <version>2.1.3</version>
   </parent>
 
   <artifactId>amazon-kinesis-client</artifactId>

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/RetrievalConfig.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/RetrievalConfig.java
@@ -34,7 +34,7 @@ public class RetrievalConfig {
      */
     public static final String KINESIS_CLIENT_LIB_USER_AGENT = "amazon-kinesis-client-library-java";
 
-    public static final String KINESIS_CLIENT_LIB_USER_AGENT_VERSION = "2.1.2";
+    public static final String KINESIS_CLIENT_LIB_USER_AGENT_VERSION = "2.1.3";
 
     /**
      * Client used to make calls to Kinesis for records retrieval

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
   <artifactId>amazon-kinesis-client-pom</artifactId>
   <packaging>pom</packaging>
   <name>Amazon Kinesis Client Library</name>
-  <version>2.1.3-SNAPSHOT</version>
+  <version>2.1.3</version>
   <description>The Amazon Kinesis Client Library for Java enables Java developers to easily consume and process data
     from Amazon Kinesis.
   </description>


### PR DESCRIPTION
Milestone#30: https://github.com/awslabs/amazon-kinesis-client/milestone/30
* Added a message to recommend using `KinesisClientUtil` when an acquire timeout occurs in the `FanOutRecordsPublisher`.
  * PR#514: https://github.com/awslabs/amazon-kinesis-client/pull/514
* Added a sleep between retries while waiting for a newly created stream consumer to become active.
  * PR#506: https://github.com/awslabs/amazon-kinesis-client/issues/506
* Added timeouts on all futures returned from the DynamoDB and Kinesis clients.
  The timeouts can be configured by setting `LeaseManagementConfig#requestTimeout(Duration)` for DynamoDB, and `PollingConfig#kinesisRequestTimeout(Duration)` for Kinesis.
  * PR#518: https://github.com/awslabs/amazon-kinesis-client/pull/518
* Upgraded to SDK version 2.5.10.
  * PR#518: https://github.com/awslabs/amazon-kinesis-client/pull/518
* Artifacts for the Amazon Kinesis Client for Java are now signed by a new GPG key:
```
  pub   4096R/86368934 2019-02-14 [expires: 2020-02-14]
  uid                  Amazon Kinesis Tools <amazon-kinesis-tools@amazon.com>
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
