### PR TITLE
Added configuration to ignore a number of ReadTimeouts before printing warnings.

### DIFF
--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/coordinator/Scheduler.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/coordinator/Scheduler.java
@@ -584,7 +584,7 @@ public class Scheduler implements Runnable {
                 hierarchicalShardSyncer,
                 metricsFactory);
         return new ShardConsumer(cache, executorService, shardInfo, lifecycleConfig.logWarningForTaskAfterMillis(),
-                argument, lifecycleConfig.taskExecutionListener());
+                argument, lifecycleConfig.taskExecutionListener(),lifecycleConfig.readTimeoutsToIgnoreBeforeWarning());
     }
 
     /**

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/lifecycle/LifecycleConfig.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/lifecycle/LifecycleConfig.java
@@ -52,4 +52,13 @@ public class LifecycleConfig {
      * <p>Default value: {@link NoOpTaskExecutionListener}</p>
      */
     private TaskExecutionListener taskExecutionListener = new NoOpTaskExecutionListener();
+
+    /**
+     * Number of consecutive ReadTimeouts to ignore before logging warning messages.
+     * If you find yourself seeing frequent ReadTimeout, you should also consider increasing your timeout according to
+     * your expected processing time.
+     *
+     * <p>Default value: 0</p>
+     */
+    private int readTimeoutsToIgnoreBeforeWarning = 0;
 }

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/lifecycle/LifecycleConfig.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/lifecycle/LifecycleConfig.java
@@ -27,6 +27,7 @@ import software.amazon.kinesis.retrieval.AggregatorUtil;
 @Data
 @Accessors(fluent = true)
 public class LifecycleConfig {
+    public static final int DEFAULT_READ_TIMEOUTS_TO_IGNORE = 0;
     /**
      * Logs warn message if as task is held in  a task for more than the set time.
      *
@@ -60,5 +61,5 @@ public class LifecycleConfig {
      *
      * <p>Default value: 0</p>
      */
-    private int readTimeoutsToIgnoreBeforeWarning = 0;
+    private int readTimeoutsToIgnoreBeforeWarning = DEFAULT_READ_TIMEOUTS_TO_IGNORE;
 }

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/lifecycle/ShardConsumer.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/lifecycle/ShardConsumer.java
@@ -84,6 +84,16 @@ public class ShardConsumer {
 
     private final ShardConsumerSubscriber subscriber;
 
+    @Deprecated
+    public ShardConsumer(RecordsPublisher recordsPublisher, ExecutorService executorService, ShardInfo shardInfo,
+            Optional<Long> logWarningForTaskAfterMillis, ShardConsumerArgument shardConsumerArgument,
+            TaskExecutionListener taskExecutionListener) {
+        this(recordsPublisher, executorService, shardInfo, logWarningForTaskAfterMillis, shardConsumerArgument,
+                ConsumerStates.INITIAL_STATE,
+                ShardConsumer.metricsWrappingFunction(shardConsumerArgument.metricsFactory()), 8, taskExecutionListener,
+                LifecycleConfig.DEFAULT_READ_TIMEOUTS_TO_IGNORE);
+    }
+
     public ShardConsumer(RecordsPublisher recordsPublisher, ExecutorService executorService, ShardInfo shardInfo,
             Optional<Long> logWarningForTaskAfterMillis, ShardConsumerArgument shardConsumerArgument,
             TaskExecutionListener taskExecutionListener, int readTimeoutsToIgnoreBeforeWarning) {
@@ -91,6 +101,16 @@ public class ShardConsumer {
                 ConsumerStates.INITIAL_STATE,
                 ShardConsumer.metricsWrappingFunction(shardConsumerArgument.metricsFactory()), 8, taskExecutionListener,
                 readTimeoutsToIgnoreBeforeWarning);
+    }
+
+    @Deprecated
+    public ShardConsumer(RecordsPublisher recordsPublisher, ExecutorService executorService, ShardInfo shardInfo,
+            Optional<Long> logWarningForTaskAfterMillis, ShardConsumerArgument shardConsumerArgument,
+            ConsumerState initialState, Function<ConsumerTask, ConsumerTask> taskMetricsDecorator, int bufferSize,
+            TaskExecutionListener taskExecutionListener) {
+        this(recordsPublisher, executorService, shardInfo, logWarningForTaskAfterMillis, shardConsumerArgument,
+                initialState, taskMetricsDecorator, bufferSize, taskExecutionListener,
+                LifecycleConfig.DEFAULT_READ_TIMEOUTS_TO_IGNORE);
     }
 
     //
@@ -265,9 +285,8 @@ public class ShardConsumer {
                 } else {
                     //
                     // ShardConsumer has been asked to shutdown before the first task even had a chance to run.
-                    // In this case generate a successful task outcome, and allow the shutdown to continue. This should
-                    // only
-                    // happen if the lease was lost before the initial state had a chance to run.
+                    // In this case generate a successful task outcome, and allow the shutdown to continue.
+                    // This should only happen if the lease was lost before the initial state had a chance to run.
                     //
                     updateState(TaskOutcome.SUCCESSFUL);
                 }

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/lifecycle/ShardConsumerSubscriber.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/lifecycle/ShardConsumerSubscriber.java
@@ -1,16 +1,16 @@
 /*
- *  Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
- *  Licensed under the Amazon Software License (the "License").
- *  You may not use this file except in compliance with the License.
- *  A copy of the License is located at
+ * Licensed under the Amazon Software License (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
  *
- *  http://aws.amazon.com/asl/
+ * http://aws.amazon.com/asl/
  *
- *  or in the "license" file accompanying this file. This file is distributed
- *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *  express or implied. See the License for the specific language governing
- *  permissions and limitations under the License.
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
  */
 package software.amazon.kinesis.lifecycle;
 
@@ -31,6 +31,7 @@ import software.amazon.kinesis.retrieval.RetryableRetrievalException;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.atomic.AtomicInteger;
 
 @Slf4j
 @Accessors(fluent = true)
@@ -40,6 +41,8 @@ class ShardConsumerSubscriber implements Subscriber<RecordsRetrieved> {
     private final Scheduler scheduler;
     private final int bufferSize;
     private final ShardConsumer shardConsumer;
+    private final int readTimeoutsToIgnoreBeforeWarning;
+    private volatile int readTimeoutSinceLastRead = 0;
 
     @VisibleForTesting
     final Object lockObject = new Object();
@@ -55,12 +58,14 @@ class ShardConsumerSubscriber implements Subscriber<RecordsRetrieved> {
     private volatile Throwable retrievalFailure;
 
     ShardConsumerSubscriber(RecordsPublisher recordsPublisher, ExecutorService executorService, int bufferSize,
-                            ShardConsumer shardConsumer) {
+            ShardConsumer shardConsumer, int readTimeoutsToIgnoreBeforeWarning) {
         this.recordsPublisher = recordsPublisher;
         this.scheduler = Schedulers.from(executorService);
         this.bufferSize = bufferSize;
         this.shardConsumer = shardConsumer;
+        this.readTimeoutsToIgnoreBeforeWarning = readTimeoutsToIgnoreBeforeWarning;
     }
+
 
     void startSubscriptions() {
         synchronized (lockObject) {
@@ -92,7 +97,8 @@ class ShardConsumerSubscriber implements Subscriber<RecordsRetrieved> {
         Throwable oldFailure = null;
         if (retrievalFailure != null) {
             synchronized (lockObject) {
-                String logMessage = String.format("%s: Failure occurred in retrieval.  Restarting data requests", shardConsumer.shardInfo().shardId());
+                String logMessage = String.format("%s: Failure occurred in retrieval.  Restarting data requests",
+                        shardConsumer.shardInfo().shardId());
                 if (retrievalFailure instanceof RetryableRetrievalException) {
                     log.debug(logMessage, retrievalFailure.getCause());
                 } else {
@@ -157,16 +163,41 @@ class ShardConsumerSubscriber implements Subscriber<RecordsRetrieved> {
                 lastRequestTime = Instant.now();
             }
         }
+
+        readTimeoutSinceLastRead = 0;
     }
 
     @Override
     public void onError(Throwable t) {
         synchronized (lockObject) {
-            log.warn("{}: onError().  Cancelling subscription, and marking self as failed.",
-                    shardConsumer.shardInfo().shardId(), t);
+            if (t instanceof RetryableRetrievalException && t.getMessage().contains("ReadTimeout")) {
+                readTimeoutSinceLastRead++;
+                if (readTimeoutSinceLastRead > readTimeoutsToIgnoreBeforeWarning) {
+                    logOnErrorReadTimeoutWarning(t);
+                }
+            } else {
+                logOnErrorWarning(t);
+            }
+
             subscription.cancel();
             retrievalFailure = t;
         }
+    }
+
+    protected void logOnErrorWarning(Throwable t) {
+        log.warn(
+                "{}: onError().  Cancelling subscription, and marking self as failed. KCL will "
+                        + "recreate the subscription as neccessary to continue processing.",
+                shardConsumer.shardInfo().shardId(), t);
+    }
+
+    protected void logOnErrorReadTimeoutWarning(Throwable t) {
+        log.warn("{}: onError().  Cancelling subscription, and marking self as failed. KCL will"
+                + " recreate the subscription as neccessary to continue processing. If you "
+                + "are seeing this warning frequently consider increasing the SDK timeouts "
+                + "by providing an OverrideConfiguration to the kinesis client. Alternatively you"
+                + "can configure LifecycleConfig.readTimeoutsToIgnoreBeforeWarning to suppress"
+                + "intermittant ReadTimeout warnings.", shardConsumer.shardInfo().shardId(), t);
     }
 
     @Override

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/lifecycle/ShardConsumerSubscriber.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/lifecycle/ShardConsumerSubscriber.java
@@ -57,6 +57,12 @@ class ShardConsumerSubscriber implements Subscriber<RecordsRetrieved> {
     @Getter(AccessLevel.PACKAGE)
     private volatile Throwable retrievalFailure;
 
+    @Deprecated
+    ShardConsumerSubscriber(RecordsPublisher recordsPublisher, ExecutorService executorService, int bufferSize,
+                            ShardConsumer shardConsumer) {
+        this(recordsPublisher,executorService,bufferSize,shardConsumer,new LifecycleConfig().readTimeoutsToIgnoreBeforeWarning());
+    }
+
     ShardConsumerSubscriber(RecordsPublisher recordsPublisher, ExecutorService executorService, int bufferSize,
             ShardConsumer shardConsumer, int readTimeoutsToIgnoreBeforeWarning) {
         this.recordsPublisher = recordsPublisher;

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/lifecycle/ShardConsumerSubscriber.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/lifecycle/ShardConsumerSubscriber.java
@@ -31,12 +31,10 @@ import software.amazon.kinesis.retrieval.RetryableRetrievalException;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.atomic.AtomicInteger;
 
 @Slf4j
 @Accessors(fluent = true)
 class ShardConsumerSubscriber implements Subscriber<RecordsRetrieved> {
-    private static final int DEFAULT_READ_TIMEOUTS_TO_IGNORE = 0;
     private final RecordsPublisher recordsPublisher;
     private final Scheduler scheduler;
     private final int bufferSize;
@@ -60,7 +58,7 @@ class ShardConsumerSubscriber implements Subscriber<RecordsRetrieved> {
     @Deprecated
     ShardConsumerSubscriber(RecordsPublisher recordsPublisher, ExecutorService executorService, int bufferSize,
                             ShardConsumer shardConsumer) {
-        this(recordsPublisher,executorService,bufferSize,shardConsumer, DEFAULT_READ_TIMEOUTS_TO_IGNORE);
+        this(recordsPublisher,executorService,bufferSize,shardConsumer, LifecycleConfig.DEFAULT_READ_TIMEOUTS_TO_IGNORE);
     }
 
     ShardConsumerSubscriber(RecordsPublisher recordsPublisher, ExecutorService executorService, int bufferSize,

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/lifecycle/ShardConsumerSubscriber.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/lifecycle/ShardConsumerSubscriber.java
@@ -36,7 +36,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 @Slf4j
 @Accessors(fluent = true)
 class ShardConsumerSubscriber implements Subscriber<RecordsRetrieved> {
-
+    private static final int DEFAULT_READ_TIMEOUTS_TO_IGNORE = 0;
     private final RecordsPublisher recordsPublisher;
     private final Scheduler scheduler;
     private final int bufferSize;
@@ -60,7 +60,7 @@ class ShardConsumerSubscriber implements Subscriber<RecordsRetrieved> {
     @Deprecated
     ShardConsumerSubscriber(RecordsPublisher recordsPublisher, ExecutorService executorService, int bufferSize,
                             ShardConsumer shardConsumer) {
-        this(recordsPublisher,executorService,bufferSize,shardConsumer,new LifecycleConfig().readTimeoutsToIgnoreBeforeWarning());
+        this(recordsPublisher,executorService,bufferSize,shardConsumer, DEFAULT_READ_TIMEOUTS_TO_IGNORE);
     }
 
     ShardConsumerSubscriber(RecordsPublisher recordsPublisher, ExecutorService executorService, int bufferSize,

--- a/amazon-kinesis-client/src/test/java/software/amazon/kinesis/lifecycle/ConsumerStatesTest.java
+++ b/amazon-kinesis-client/src/test/java/software/amazon/kinesis/lifecycle/ConsumerStatesTest.java
@@ -117,7 +117,7 @@ public class ConsumerStatesTest {
                 cleanupLeasesOfCompletedShards, ignoreUnexpectedChildShards, shardDetector, new AggregatorUtil(),
                 hierarchicalShardSyncer, metricsFactory);
         consumer = spy(
-                new ShardConsumer(recordsPublisher, executorService, shardInfo, logWarningForTaskAfterMillis, argument, taskExecutionListener));
+                new ShardConsumer(recordsPublisher, executorService, shardInfo, logWarningForTaskAfterMillis, argument, taskExecutionListener,0));
 
         when(shardInfo.shardId()).thenReturn("shardId-000000000000");
         when(recordProcessorCheckpointer.checkpointer()).thenReturn(checkpointer);

--- a/amazon-kinesis-client/src/test/java/software/amazon/kinesis/lifecycle/ConsumerStatesTest.java
+++ b/amazon-kinesis-client/src/test/java/software/amazon/kinesis/lifecycle/ConsumerStatesTest.java
@@ -111,13 +111,12 @@ public class ConsumerStatesTest {
     public void setup() {
         argument = new ShardConsumerArgument(shardInfo, STREAM_NAME, leaseRefresher, executorService, recordsPublisher,
                 shardRecordProcessor, checkpointer, recordProcessorCheckpointer, parentShardPollIntervalMillis,
-                taskBackoffTimeMillis, skipShardSyncAtWorkerInitializationIfLeasesExist,
-                listShardsBackoffTimeInMillis, maxListShardsRetryAttempts,
-                shouldCallProcessRecordsEvenForEmptyRecordList, idleTimeInMillis, INITIAL_POSITION_IN_STREAM,
-                cleanupLeasesOfCompletedShards, ignoreUnexpectedChildShards, shardDetector, new AggregatorUtil(),
-                hierarchicalShardSyncer, metricsFactory);
-        consumer = spy(
-                new ShardConsumer(recordsPublisher, executorService, shardInfo, logWarningForTaskAfterMillis, argument, taskExecutionListener,0));
+                taskBackoffTimeMillis, skipShardSyncAtWorkerInitializationIfLeasesExist, listShardsBackoffTimeInMillis,
+                maxListShardsRetryAttempts, shouldCallProcessRecordsEvenForEmptyRecordList, idleTimeInMillis,
+                INITIAL_POSITION_IN_STREAM, cleanupLeasesOfCompletedShards, ignoreUnexpectedChildShards, shardDetector,
+                new AggregatorUtil(), hierarchicalShardSyncer, metricsFactory);
+        consumer = spy(new ShardConsumer(recordsPublisher, executorService, shardInfo, logWarningForTaskAfterMillis,
+                argument, taskExecutionListener, 0));
 
         when(shardInfo.shardId()).thenReturn("shardId-000000000000");
         when(recordProcessorCheckpointer.checkpointer()).thenReturn(checkpointer);
@@ -257,7 +256,8 @@ public class ConsumerStatesTest {
         consumer.gracefulShutdown(shutdownNotification);
         ConsumerTask task = state.createTask(argument, consumer, null);
 
-        assertThat(task, shutdownReqTask(ShardRecordProcessor.class, "shardRecordProcessor", equalTo(shardRecordProcessor)));
+        assertThat(task,
+                shutdownReqTask(ShardRecordProcessor.class, "shardRecordProcessor", equalTo(shardRecordProcessor)));
         assertThat(task, shutdownReqTask(RecordProcessorCheckpointer.class, "recordProcessorCheckpointer",
                 equalTo(recordProcessorCheckpointer)));
         assertThat(task,
@@ -304,7 +304,8 @@ public class ConsumerStatesTest {
         ConsumerTask task = state.createTask(argument, consumer, null);
 
         assertThat(task, shutdownTask(ShardInfo.class, "shardInfo", equalTo(shardInfo)));
-        assertThat(task, shutdownTask(ShardRecordProcessor.class, "shardRecordProcessor", equalTo(shardRecordProcessor)));
+        assertThat(task,
+                shutdownTask(ShardRecordProcessor.class, "shardRecordProcessor", equalTo(shardRecordProcessor)));
         assertThat(task, shutdownTask(ShardRecordProcessorCheckpointer.class, "recordProcessorCheckpointer",
                 equalTo(recordProcessorCheckpointer)));
         assertThat(task, shutdownTask(ShutdownReason.class, "reason", equalTo(reason)));
@@ -318,8 +319,7 @@ public class ConsumerStatesTest {
         assertThat(state.successTransition(), equalTo(ShardConsumerState.SHUTDOWN_COMPLETE.consumerState()));
 
         for (ShutdownReason reason : ShutdownReason.values()) {
-            assertThat(state.shutdownTransition(reason),
-                    equalTo(ShardConsumerState.SHUTDOWN_COMPLETE.consumerState()));
+            assertThat(state.shutdownTransition(reason), equalTo(ShardConsumerState.SHUTDOWN_COMPLETE.consumerState()));
         }
 
         assertThat(state.state(), equalTo(ShardConsumerState.SHUTTING_DOWN));

--- a/amazon-kinesis-client/src/test/java/software/amazon/kinesis/lifecycle/ShardConsumerSubscriberTest.java
+++ b/amazon-kinesis-client/src/test/java/software/amazon/kinesis/lifecycle/ShardConsumerSubscriberTest.java
@@ -501,7 +501,7 @@ public class ShardConsumerSubscriberTest {
      * @throws Exception
      */
     @Test
-    public void testLoggingSuppressedAfterTimeoutIgnoreDefaultHappyPath() throws Exception {
+    public void noLoggingSuppressionNeededOnHappyPathTest() throws Exception {
         Exception exceptionToThrow = new software.amazon.kinesis.retrieval.RetryableRetrievalException("ReadTimeout");
         boolean[] requestsToThrowException = { false, false, false, false, false };
         int[] expectedLogs = { 0, 0, 0, 0, 0 };
@@ -514,7 +514,7 @@ public class ShardConsumerSubscriberTest {
      * @throws Exception
      */
     @Test
-    public void testLoggingSuppressedAfterTimeoutIgnoreDefault() throws Exception {
+    public void loggingNotSuppressedAfterTimeoutTest() throws Exception {
         Exception exceptionToThrow = new software.amazon.kinesis.retrieval.RetryableRetrievalException("ReadTimeout");
         boolean[] requestsToThrowException = { false, false, true, false, true };
         int[] expectedLogs = { 0, 0, 1, 1, 2 };
@@ -528,7 +528,7 @@ public class ShardConsumerSubscriberTest {
      * @throws Exception
      */
     @Test
-    public void testLoggingSuppressedAfterTimeoutIgnore1() throws Exception {
+    public void loggingSuppressedAfterIntermittentTimeoutTest() throws Exception {
         Exception exceptionToThrow = new software.amazon.kinesis.retrieval.RetryableRetrievalException("ReadTimeout");
         boolean[] requestsToThrowException = { false, false, true, false, true };
         int[] expectedLogs = { 0, 0, 0, 0, 0 };
@@ -542,7 +542,7 @@ public class ShardConsumerSubscriberTest {
      * @throws Exception
      */
     @Test
-    public void testLoggingSuppressedAfterMultipleTimeoutIgnore1() throws Exception {
+    public void loggingPartiallySuppressedAfterMultipleTimeoutTest() throws Exception {
         Exception exceptionToThrow = new software.amazon.kinesis.retrieval.RetryableRetrievalException("ReadTimeout");
         boolean[] requestsToThrowException = { true, true, false, true, true };
         int[] expectedLogs = { 0, 1, 1, 1, 2 };
@@ -555,7 +555,7 @@ public class ShardConsumerSubscriberTest {
      * @throws Exception
      */
     @Test
-    public void testLoggingSuppressedAfterMultipleTimeoutIgnore2() throws Exception {
+    public void loggingPartiallySuppressedAfterConsecutiveTimeoutTest() throws Exception {
         Exception exceptionToThrow = new software.amazon.kinesis.retrieval.RetryableRetrievalException("ReadTimeout");
         boolean[] requestsToThrowException = { true, true, true, true, true };
         int[] expectedLogs = { 0, 0, 1, 2, 3 };
@@ -569,7 +569,7 @@ public class ShardConsumerSubscriberTest {
      * @throws Exception
      */
     @Test
-    public void testLoggingSuppressedAfterExceptionDefault() throws Exception {
+    public void loggingNotSuppressedOnNonReadTimeoutExceptionNotIgnoringReadTimeoutsExceptionTest() throws Exception {
         // We're not throwing a ReadTimeout, so no suppression is expected.
         Exception exceptionToThrow = new RuntimeException("Uh oh Not a ReadTimeout");
         boolean[] requestsToThrowException = { false, false, true, false, true };
@@ -614,7 +614,7 @@ public class ShardConsumerSubscriberTest {
      * @throws Exception
      */
     @Test
-    public void testLoggingNotSuppressedAfterExceptionIgnore2ReadTimeouts() throws Exception {
+    public void loggingNotSuppressedOnNonReadTimeoutExceptionIgnoringReadTimeoutsTest() throws Exception {
         // We're not throwing a ReadTimeout, so no suppression is expected.
         Exception exceptionToThrow = new RuntimeException("Uh oh Not a ReadTimeout");
         boolean[] requestsToThrowException = { false, false, true, false, true };

--- a/amazon-kinesis-client/src/test/java/software/amazon/kinesis/lifecycle/ShardConsumerSubscriberTest.java
+++ b/amazon-kinesis-client/src/test/java/software/amazon/kinesis/lifecycle/ShardConsumerSubscriberTest.java
@@ -473,16 +473,6 @@ public class ShardConsumerSubscriberTest {
         }
 
         @Override
-        public void onNext(RecordsRetrieved input) {
-            super.onNext(input);
-        }
-
-        @Override
-        public void onError(Throwable t) {
-            super.onError(t);
-        }
-
-        @Override
         protected void logOnErrorWarning(Throwable t) {
             genericWarningLogged++;
             super.logOnErrorWarning(t);

--- a/amazon-kinesis-client/src/test/java/software/amazon/kinesis/lifecycle/ShardConsumerSubscriberTest.java
+++ b/amazon-kinesis-client/src/test/java/software/amazon/kinesis/lifecycle/ShardConsumerSubscriberTest.java
@@ -457,12 +457,6 @@ public class ShardConsumerSubscriberTest {
         private int bufferSize;
         private ShardConsumer shardConsumer;
 
-        TestShardConsumerSubscriber(int readTimeoutsToIgnoreBeforeWarning) {
-            this(mock(RecordsPublisher.class), Executors.newFixedThreadPool(1), 8, mock(ShardConsumer.class),
-                    readTimeoutsToIgnoreBeforeWarning);
-            Mockito.when(shardConsumer.shardInfo()).thenReturn(new ShardInfo("001", "token", null, null));
-        }
-
         TestShardConsumerSubscriber(RecordsPublisher recordsPublisher, ExecutorService executorService, int bufferSize,
                 ShardConsumer shardConsumer, int readTimeoutsToIgnoreBeforeWarning) {
             super(recordsPublisher, executorService, bufferSize, shardConsumer, readTimeoutsToIgnoreBeforeWarning);
@@ -570,11 +564,15 @@ public class ShardConsumerSubscriberTest {
     private void runLogSuppressionTest(boolean[] requestsToThrowException, int[] expectedLogCounts,
             int readTimeoutsToIgnore, Exception exceptionToThrow) {
         // Setup Test
+        ShardConsumer shardConsumer = mock(ShardConsumer.class);
+        Mockito.when(shardConsumer.shardInfo()).thenReturn(new ShardInfo("001", "token", null, null));
+
         // Logging supressions specific setup
         int expectedRequest = 0;
         int expectedPublish = 0;
 
-        TestShardConsumerSubscriber consumer = new TestShardConsumerSubscriber(readTimeoutsToIgnore);
+        TestShardConsumerSubscriber consumer = new TestShardConsumerSubscriber(mock(RecordsPublisher.class), Executors.newFixedThreadPool(1), 8, shardConsumer,readTimeoutsToIgnore);
+
         consumer.startSubscriptions();
         // Run the configured test
         for (int i = 0; i < requestsToThrowException.length; i++) {

--- a/amazon-kinesis-client/src/test/java/software/amazon/kinesis/lifecycle/ShardConsumerTest.java
+++ b/amazon-kinesis-client/src/test/java/software/amazon/kinesis/lifecycle/ShardConsumerTest.java
@@ -20,10 +20,10 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
-import static org.mockito.Matchers.*;
-import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyLong;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -34,19 +34,22 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
-import java.lang.reflect.Field;
-import java.lang.reflect.Modifier;
 import java.time.Instant;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import java.util.concurrent.*;
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.BrokenBarrierException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 
-import lombok.Getter;
-import lombok.Setter;
-import lombok.experimental.Accessors;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Ignore;
@@ -62,15 +65,12 @@ import org.reactivestreams.Subscription;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 
 import lombok.extern.slf4j.Slf4j;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import software.amazon.kinesis.common.InitialPositionInStreamExtended;
 import software.amazon.kinesis.leases.ShardInfo;
 import software.amazon.kinesis.lifecycle.events.ProcessRecordsInput;
 import software.amazon.kinesis.lifecycle.events.TaskExecutionListenerInput;
 import software.amazon.kinesis.retrieval.RecordsPublisher;
 import software.amazon.kinesis.retrieval.RecordsRetrieved;
-import software.amazon.kinesis.retrieval.RetryableRetrievalException;
 import software.amazon.kinesis.retrieval.kpl.ExtendedSequenceNumber;
 
 /**
@@ -139,16 +139,15 @@ public class ShardConsumerTest {
 
         processRecordsInput = ProcessRecordsInput.builder().isAtShardEnd(false).cacheEntryTime(Instant.now())
                 .millisBehindLatest(1000L).records(Collections.emptyList()).build();
-        initialTaskInput = TaskExecutionListenerInput.builder().shardInfo(shardInfo)
-                .taskType(TaskType.INITIALIZE).build();
-        processTaskInput = TaskExecutionListenerInput.builder().shardInfo(shardInfo)
-                .taskType(TaskType.PROCESS).build();
+        initialTaskInput = TaskExecutionListenerInput.builder().shardInfo(shardInfo).taskType(TaskType.INITIALIZE)
+                .build();
+        processTaskInput = TaskExecutionListenerInput.builder().shardInfo(shardInfo).taskType(TaskType.PROCESS).build();
         shutdownRequestedTaskInput = TaskExecutionListenerInput.builder().shardInfo(shardInfo)
                 .taskType(TaskType.SHUTDOWN_NOTIFICATION).build();
         shutdownRequestedAwaitTaskInput = TaskExecutionListenerInput.builder().shardInfo(shardInfo)
                 .taskType(TaskType.SHUTDOWN_COMPLETE).build();
-        shutdownTaskInput = TaskExecutionListenerInput.builder().shardInfo(shardInfo)
-                .taskType(TaskType.SHUTDOWN).build();
+        shutdownTaskInput = TaskExecutionListenerInput.builder().shardInfo(shardInfo).taskType(TaskType.SHUTDOWN)
+                .build();
     }
 
     @After
@@ -245,7 +244,7 @@ public class ShardConsumerTest {
 
         TestPublisher cache = new TestPublisher();
         ShardConsumer consumer = new ShardConsumer(cache, executorService, shardInfo, logWarningForTaskAfterMillis,
-                shardConsumerArgument, initialState, Function.identity(), 1, taskExecutionListener,0);
+                shardConsumerArgument, initialState, Function.identity(), 1, taskExecutionListener, 0);
 
         boolean initComplete = false;
         while (!initComplete) {
@@ -299,7 +298,7 @@ public class ShardConsumerTest {
 
         TestPublisher cache = new TestPublisher();
         ShardConsumer consumer = new ShardConsumer(cache, executorService, shardInfo, logWarningForTaskAfterMillis,
-                shardConsumerArgument, initialState, Function.identity(), 1, taskExecutionListener,0);
+                shardConsumerArgument, initialState, Function.identity(), 1, taskExecutionListener, 0);
 
         boolean initComplete = false;
         while (!initComplete) {
@@ -323,7 +322,7 @@ public class ShardConsumerTest {
         log.debug("Release processing task interlock");
         awaitAndResetBarrier(processingTaskInterlock);
 
-        while(!consumer.isShutdown()) {
+        while (!consumer.isShutdown()) {
             consumer.executeLifecycle();
             Thread.yield();
         }
@@ -358,7 +357,7 @@ public class ShardConsumerTest {
 
         TestPublisher cache = new TestPublisher();
         ShardConsumer consumer = new ShardConsumer(cache, executorService, shardInfo, logWarningForTaskAfterMillis,
-                shardConsumerArgument, initialState, Function.identity(), 1, taskExecutionListener,0);
+                shardConsumerArgument, initialState, Function.identity(), 1, taskExecutionListener, 0);
 
         boolean initComplete = false;
         while (!initComplete) {
@@ -417,7 +416,8 @@ public class ShardConsumerTest {
     @Ignore
     public final void testInitializationStateUponFailure() throws Exception {
         ShardConsumer consumer = new ShardConsumer(recordsPublisher, executorService, shardInfo,
-                logWarningForTaskAfterMillis, shardConsumerArgument, initialState, Function.identity(), 1, taskExecutionListener,0);
+                logWarningForTaskAfterMillis, shardConsumerArgument, initialState, Function.identity(), 1,
+                taskExecutionListener, 0);
 
         when(initialState.createTask(eq(shardConsumerArgument), eq(consumer), any())).thenReturn(initializeTask);
         when(initializeTask.call()).thenReturn(new TaskResult(new Exception("Bad")));
@@ -450,7 +450,7 @@ public class ShardConsumerTest {
 
         ExecutorService failingService = mock(ExecutorService.class);
         ShardConsumer consumer = new ShardConsumer(recordsPublisher, failingService, shardInfo,
-                logWarningForTaskAfterMillis, shardConsumerArgument, initialState, t -> t, 1, taskExecutionListener,0);
+                logWarningForTaskAfterMillis, shardConsumerArgument, initialState, t -> t, 1, taskExecutionListener, 0);
 
         doThrow(new RejectedExecutionException()).when(failingService).execute(any());
 
@@ -464,7 +464,7 @@ public class ShardConsumerTest {
     @Test
     public void testErrorThrowableInInitialization() throws Exception {
         ShardConsumer consumer = new ShardConsumer(recordsPublisher, executorService, shardInfo,
-                logWarningForTaskAfterMillis, shardConsumerArgument, initialState, t -> t, 1, taskExecutionListener,0);
+                logWarningForTaskAfterMillis, shardConsumerArgument, initialState, t -> t, 1, taskExecutionListener, 0);
 
         when(initialState.createTask(any(), any(), any())).thenReturn(initializeTask);
         when(initialState.taskType()).thenReturn(TaskType.INITIALIZE);
@@ -488,7 +488,7 @@ public class ShardConsumerTest {
 
         TestPublisher cache = new TestPublisher();
         ShardConsumer consumer = new ShardConsumer(cache, executorService, shardInfo, logWarningForTaskAfterMillis,
-                shardConsumerArgument, initialState, t -> t, 1, taskExecutionListener,0);
+                shardConsumerArgument, initialState, t -> t, 1, taskExecutionListener, 0);
 
         mockSuccessfulInitialize(null);
 
@@ -571,7 +571,7 @@ public class ShardConsumerTest {
         TestPublisher cache = new TestPublisher();
 
         ShardConsumer consumer = new ShardConsumer(cache, executorService, shardInfo, Optional.of(1L),
-                shardConsumerArgument, initialState, Function.identity(), 1, taskExecutionListener,0);
+                shardConsumerArgument, initialState, Function.identity(), 1, taskExecutionListener, 0);
 
         mockSuccessfulInitialize(null);
         mockSuccessfulProcessing(null);
@@ -618,7 +618,7 @@ public class ShardConsumerTest {
         TestPublisher cache = new TestPublisher();
 
         ShardConsumer consumer = new ShardConsumer(cache, executorService, shardInfo, Optional.of(1L),
-                shardConsumerArgument, initialState, Function.identity(), 1, taskExecutionListener,0);
+                shardConsumerArgument, initialState, Function.identity(), 1, taskExecutionListener, 0);
 
         CyclicBarrier taskArriveBarrier = new CyclicBarrier(2);
         CyclicBarrier taskDepartBarrier = new CyclicBarrier(2);
@@ -773,353 +773,4 @@ public class ShardConsumerTest {
         barrier.await();
         barrier.reset();
     }
-
-
-    //Increased timeout to attempt to get auto-build working...
-    private static final int awaitTimeout = 15;
-    private static final TimeUnit awaitTimeoutUnit = TimeUnit.SECONDS;
-
-    /**
-     * Test to validate the warning message from ShardConsumer is not suppressed with the default configuration of 0
-     * @throws Exception
-     */
-    @Test
-    public void testLoggingSuppressedAfterTimeoutIgnoreDefaultHappyPath() throws Exception {
-        Exception exceptionToThrow=new software.amazon.kinesis.retrieval.RetryableRetrievalException("ReadTimeout");
-        boolean[] requestsToThrowException = {false, false, false, false, false};
-        int[] expectedLogs={0,0,0,0,0};
-        runLogSuppressionTest(requestsToThrowException, expectedLogs,0, exceptionToThrow);
-    }
-
-    /**
-     * Test to validate the warning message from ShardConsumer is not suppressed with the default configuration of 0
-     * @throws Exception
-     */
-    @Test
-    public void testLoggingSuppressedAfterTimeoutIgnoreDefault() throws Exception {
-        Exception exceptionToThrow=new software.amazon.kinesis.retrieval.RetryableRetrievalException("ReadTimeout");
-        boolean[] requestsToThrowException = {false, false, true, false, true};
-        int[] expectedLogs={0,0,1,1,2};
-        runLogSuppressionTest(requestsToThrowException, expectedLogs,0, exceptionToThrow);
-    }
-
-    /**
-     * Test to validate the warning message from ShardConsumer is successfully supressed if we only have intermittant readTimeouts.
-     * @throws Exception
-     */
-    @Test
-    public void testLoggingSuppressedAfterTimeoutIgnore1() throws Exception {
-        Exception exceptionToThrow=new software.amazon.kinesis.retrieval.RetryableRetrievalException("ReadTimeout");
-        boolean[] requestsToThrowException = {false, false, true, false, true};
-        int[] expectedLogs={0,0,0,0,0};
-        runLogSuppressionTest(requestsToThrowException, expectedLogs,1, exceptionToThrow);
-    }
-
-    /**
-     * Test to validate the warning message from ShardConsumer is successfully logged if multiple sequential timeouts occur.
-     * @throws Exception
-     */
-    @Test
-    public void testLoggingSuppressedAfterMultipleTimeoutIgnore1() throws Exception {
-        Exception exceptionToThrow=new software.amazon.kinesis.retrieval.RetryableRetrievalException("ReadTimeout");
-        boolean[] requestsToThrowException = {true, true, false, true, true};
-        int[] expectedLogs={0,1,1,1,2};
-        runLogSuppressionTest(requestsToThrowException, expectedLogs,1, exceptionToThrow);
-    }
-
-    /**
-     * Test to validate the warning message from ShardConsumer is successfully logged if sequential timeouts occur.
-     * @throws Exception
-     */
-    @Test
-    public void testLoggingSuppressedAfterMultipleTimeoutIgnore2() throws Exception {
-        Exception exceptionToThrow=new software.amazon.kinesis.retrieval.RetryableRetrievalException("ReadTimeout");
-        boolean[] requestsToThrowException = {true, true, true, true, true};
-        int[] expectedLogs={0,0,1,2,3};
-        runLogSuppressionTest(requestsToThrowException, expectedLogs,2, exceptionToThrow);
-    }
-
-    /**
-     * Test to validate the non-timeout warning message from ShardConsumer is not suppressed with the default configuration of 0
-     * @throws Exception
-     */
-    @Test
-    public void testLoggingSuppressedAfterExceptionDefault() throws Exception {
-        //We're not throwing a ReadTimeout, so no suppression is expected.
-        Exception exceptionToThrow=new RuntimeException("Uh oh Not a ReadTimeout");
-        boolean[] requestsToThrowException = {false, false, true, false, true};
-        int[] expectedLogs={0,0,1,1,2};
-        runLogSuppressionTest(requestsToThrowException, expectedLogs,0, exceptionToThrow);
-    }
-
-    /**
-     * Test to validate the non-timeout warning message from ShardConsumer is not suppressed with 2 ReadTimeouts to ignore
-     * @throws Exception
-     */
-    @Test
-    public void testLoggingNotSuppressedAfterExceptionIgnore2ReadTimeouts() throws Exception {
-        //We're not throwing a ReadTimeout, so no suppression is expected.
-        Exception exceptionToThrow=new RuntimeException("Uh oh Not a ReadTimeout");
-        boolean[] requestsToThrowException = {false, false, true, false, true};
-        int[] expectedLogs={0,0,1,1,2};
-        runLogSuppressionTest(requestsToThrowException, expectedLogs,2, exceptionToThrow);
-    }
-
-    /**
-     * Runs the log suppression test which mocks exceptions to be thrown during shard consumption and validates log messages and requests recieved.
-     * @param requestsToThrowException - Controls the test execution for how many requests to mock, and if they are successful, or throw an exception.
-     *                                 true-> publish throws exception
-     *                                 false-> publish successfully processes
-     * @param expectedLogCounts - The expected warning log counts given the request profile from <tt>requestsToThrowException</tt> and <tt>readTimeoutsToIgnoreBeforeWarning</tt>
-     * @param readTimeoutsToIgnoreBeforeWarning - Used to configure the ShardConsumer for the test to specify the configurable number of timeouts to suppress. This should not suppress any non-timeout exception.
-     * @param exceptionToThrow - Specifies the type of exception to throw.
-     * @throws Exception
-     */
-    private void runLogSuppressionTest(boolean[] requestsToThrowException, int[] expectedLogCounts, int readTimeoutsToIgnoreBeforeWarning, Exception exceptionToThrow) throws Exception {
-        //Setup Test
-        ExecutorService executor = Executors.newSingleThreadExecutor();
-        CyclicBarrier taskCallBarrier = new CyclicBarrier(2);
-
-        mockSuccessfulInitialize(null);
-        mockSuccessfulProcessing(taskCallBarrier);
-        mockSuccessfulShutdown(null);
-        CyclicBarrierTestPublisher cache = new CyclicBarrierTestPublisher(true, processRecordsInput ,requestsToThrowException, exceptionToThrow);
-
-        //Logging supressions specific setup
-        int expectedRequest=0;
-        int expectedPublish=0;
-
-        ShardConsumer consumer = new ShardConsumer(cache, executorService, shardInfo, logWarningForTaskAfterMillis,
-                shardConsumerArgument, initialState, Function.identity(), 1, taskExecutionListener,
-                readTimeoutsToIgnoreBeforeWarning);
-
-        Logger mockLogger = mock(Logger.class);
-        injectLogger(consumer.subscriber(), mockLogger);
-
-        //This needs to be executed in a seperate thread before an expected timeout
-        // publish call to await the required cyclic barriers
-        Runnable awaitingCacheThread = () -> {
-            try {
-                cache.awaitRequest();
-            } catch (Exception e) {
-                e.printStackTrace();
-            }
-        };
-
-        //Run the configured test
-        boolean initComplete = false;
-        while (!initComplete) {
-            initComplete = consumer.initializeComplete().get();
-        }
-        //Initialize Shard Consumer Subscriptions
-        consumer.subscribe();
-        cache.awaitInitialSetup();
-        for(int i=0; i< requestsToThrowException.length; i++){
-            boolean shouldTimeout = requestsToThrowException[i];
-            int expectedLogCount = expectedLogCounts[i];
-            expectedRequest++;
-            if(shouldTimeout){
-                //Mock a ReadTimeout call
-                executor.submit(awaitingCacheThread);
-                cache.publish();
-                // Sleep to increase liklihood of async processing is picked up in ShardConsumer.
-                // Previous cyclic barriers are used to sync Publisher with the test, this test would require another subscriptionBarrier
-                // in the ShardConsumer to fully sync the processing with the Test.
-                Thread.sleep(50);
-                //Restart subscription after failed request
-                consumer.subscribe();
-                cache.awaitSubscription();
-            }else{
-                expectedPublish++;
-                //Mock a successful call
-                cache.publish();
-                awaitAndResetBarrierWithTimeout(taskCallBarrier);
-                cache.awaitRequest();
-            }
-            assertEquals(expectedPublish,cache.getPublishCount());
-            assertEquals(expectedRequest, cache.getRequestCount());
-            if(exceptionToThrow instanceof RetryableRetrievalException
-                    && exceptionToThrow.getMessage().contains("ReadTimeout")){
-                verify(mockLogger, times(expectedLogCount)).warn(eq(
-                        "{}: onError().  Cancelling subscription, and marking self as failed. KCL will" +
-                                " recreate the subscription as neccessary to continue processing. If you " +
-                                "are seeing this warning frequently consider increasing the SDK timeouts " +
-                                "by providing an OverrideConfiguration to the kinesis client. Alternatively you" +
-                                "can configure LifecycleConfig.readTimeoutsToIgnoreBeforeWarning to suppress" +
-                                "intermittant ReadTimeout warnings."), anyString(), any());
-            }else {
-                verify(mockLogger, times(expectedLogCount)).warn(eq(
-                        "{}: onError().  Cancelling subscription, and marking self as failed. KCL will " +
-                                "recreate the subscription as neccessary to continue processing."), anyString(), any());
-            }
-        }
-
-        //Clean Up Test
-        injectLogger(consumer.subscriber(), LoggerFactory.getLogger(ShardConsumerSubscriber.class));
-
-        Thread closingThread =
-                new Thread(
-                        new Runnable() {
-                            public void run() {
-                                consumer.leaseLost();
-                            }
-                        });
-        closingThread.start();
-        cache.awaitRequest();
-
-        //We need to await and reset the task subscriptionBarrier prior to going into the shutdown loop.
-        Runnable awaitingTaskThread = ()->{
-            try {
-                awaitAndResetBarrierWithTimeout(taskCallBarrier);
-            } catch (Exception e) {
-                e.printStackTrace();
-            }
-        };
-        executor.submit(awaitingTaskThread);
-        while (!consumer.shutdownComplete().get()) { }
-    }
-
-    /**
-     * Use reflection to inject a logger for verification. This will mute any logging occuring with this logger,
-     * but allow it to be verifiable.
-     *
-     * After executing the test, a normal Logger from a standard LoggerFactory should be injected to continue logging
-     * as expected.
-     */
-    private void injectLogger(final ShardConsumerSubscriber subscriber, final Logger logger) throws SecurityException,
-            NoSuchFieldException, ClassNotFoundException, IllegalArgumentException, IllegalAccessException {
-        // Get the private field
-        final Field field = subscriber.getClass().getDeclaredField("log");
-        // Allow modification on the field
-        field.setAccessible(true);
-        //Make the logger non-final
-        Field modifiersField = Field.class.getDeclaredField("modifiers");
-        modifiersField.setAccessible(true);
-        modifiersField.setInt(field, field.getModifiers() & ~Modifier.FINAL);
-        // Inject the mock...
-        field.set(subscriber, logger );
-
-    }
-
-    public static void awaitBarrierWithTimeout(CyclicBarrier barrier) throws Exception {
-        if (barrier != null) {
-            barrier.await(awaitTimeout, awaitTimeoutUnit);
-        }
-    }
-
-    public static void awaitAndResetBarrierWithTimeout(CyclicBarrier barrier) throws Exception {
-        if(barrier!=null) {
-            barrier.await(awaitTimeout, awaitTimeoutUnit);
-            barrier.reset();
-        }
-    }
-
-    /**
-     * Test Publisher with seperate barriers for Task processing and creating a subscription.
-     *
-     * These barriers need to be "primed" in a seperate thread via the await/reset methods to allow processing
-     * to sync along these barriers.
-     *
-     * Optionally, you can errors also trigger the Task Processing Barrier if you are wanting to validate
-     * handling around error conditions.
-     */
-    public class CyclicBarrierTestPublisher implements RecordsPublisher {
-        protected final CyclicBarrier subscriptionBarrier = new CyclicBarrier(2);
-        protected final CyclicBarrier requestBarrier = new CyclicBarrier(2);
-        private final Exception exceptionToThrow;
-        private final boolean[] requestsToThrowException;
-
-        public int getRequestCount() {
-            return requestCount.get();
-        }
-
-        public int getPublishCount() {
-            return publishCount;
-        }
-
-        private AtomicInteger requestCount=new AtomicInteger(0);
-
-        Subscriber<? super RecordsRetrieved> subscriber;
-        final Subscription subscription = mock(Subscription.class);
-        private int publishCount=0;
-        private ProcessRecordsInput processRecordsInput;
-
-        CyclicBarrierTestPublisher(ProcessRecordsInput processRecordsInput) {
-            this(false,processRecordsInput);
-        }
-
-        CyclicBarrierTestPublisher(boolean enableCancelAwait,ProcessRecordsInput processRecordsInput) { this(enableCancelAwait,processRecordsInput, null,null);}
-
-        CyclicBarrierTestPublisher(boolean enableCancelAwait, ProcessRecordsInput processRecordsInput, boolean[] requestsToThrowException, Exception exceptionToThrow){
-            doAnswer(a -> {
-                requestBarrier.await(awaitTimeout, awaitTimeoutUnit);
-                return null;
-            }).when(subscription).request(anyLong());
-            doAnswer(a -> {
-                if (enableCancelAwait) {
-                    requestBarrier.await(awaitTimeout, awaitTimeoutUnit);
-                }
-                return null;
-            }).when(subscription).cancel();
-            this.requestsToThrowException = requestsToThrowException;
-            this.exceptionToThrow=exceptionToThrow;
-            this.processRecordsInput=processRecordsInput;
-        }
-
-        @Override
-        public void start(ExtendedSequenceNumber extendedSequenceNumber,
-                InitialPositionInStreamExtended initialPositionInStreamExtended) {
-
-        }
-
-        @Override
-        public void shutdown() {
-
-        }
-
-        @Override
-        public void subscribe(Subscriber<? super RecordsRetrieved> s) {
-            subscriber = s;
-            subscriber.onSubscribe(subscription);
-            try {
-                subscriptionBarrier.await(awaitTimeout, awaitTimeoutUnit);
-            } catch (Exception ex) {
-                throw new RuntimeException(ex);
-            }
-        }
-
-        @Override
-        public void restartFrom(RecordsRetrieved recordsRetrieved) {
-
-        }
-
-        public void awaitSubscription() throws InterruptedException, BrokenBarrierException, TimeoutException {
-            subscriptionBarrier.await(awaitTimeout, awaitTimeoutUnit);
-            subscriptionBarrier.reset();
-        }
-
-        public void awaitRequest() throws InterruptedException, BrokenBarrierException, TimeoutException {
-            requestBarrier.await(awaitTimeout, awaitTimeoutUnit);
-            requestBarrier.reset();
-        }
-
-        public void awaitInitialSetup() throws InterruptedException, BrokenBarrierException, TimeoutException {
-            awaitRequest();
-            awaitSubscription();
-        }
-
-        public void publish() {
-            if (requestsToThrowException != null && requestsToThrowException[requestCount.getAndIncrement() % requestsToThrowException.length]) {
-                subscriber.onError(exceptionToThrow);
-            } else {
-                publish(()->processRecordsInput);
-            }
-        }
-
-        public void publish(RecordsRetrieved input) {
-            subscriber.onNext(input);
-            publishCount++;
-        }
-    }
-
 }


### PR DESCRIPTION

*Issue #, if available:*

*Description of changes:*
__Added configuration to ignore a number of ReadTimeouts before printing warnings.__

 * Messaging now directs customer to configure the SDK with appropriate timeouts based on their processing model.
 * Warning messages from ShardConsumer now specify that the KCL will reattempt to subscribe to the stream as needed.
 * Added configuraiton to Lifecycle configuration to enable ignoring a number of ReadTimeouts before printing warning messages.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
