### PR TITLE
Allow RecordProcessors To bubble up shutdown exception

### DIFF
--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/coordinator/Scheduler.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/coordinator/Scheduler.java
@@ -548,7 +548,8 @@ public class Scheduler implements Runnable {
         // one if the shard has been
         // completely processed (shutdown reason terminate).
         if ((consumer == null)
-                || (consumer.isShutdown() && consumer.shutdownReason().equals(ShutdownReason.LEASE_LOST))) {
+                || (consumer.isShutdown() && (consumer.shutdownReason().equals(ShutdownReason.LEASE_LOST)
+                || consumer.shutdownReason().equals(ShutdownReason.UNRECOVERABLE)))) {
             consumer = buildConsumer(shardInfo, shardRecordProcessorFactory);
             shardInfoShardConsumerMap.put(shardInfo, consumer);
             slog.infoForce("Created new shardConsumer for : " + shardInfo);

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/lifecycle/ProcessTask.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/lifecycle/ProcessTask.java
@@ -198,10 +198,6 @@ public class ProcessTask implements ConsumerTask {
         final long startTime = System.currentTimeMillis();
         try {
             shardRecordProcessor.processRecords(processRecordsInput);
-        } catch (Exception e) {
-            log.error("ShardId {}: Application processRecords() threw an exception when processing shard ",
-                    shardInfo.shardId(), e);
-            log.error("ShardId {}: Skipping over the following data records: {}", shardInfo.shardId(), records);
         } finally {
             MetricsUtil.addLatency(scope, RECORD_PROCESSOR_PROCESS_RECORDS_METRIC, startTime, MetricsLevel.SUMMARY);
             MetricsUtil.endScope(scope);

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/lifecycle/ShutdownReason.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/lifecycle/ShutdownReason.java
@@ -31,6 +31,13 @@ import static software.amazon.kinesis.lifecycle.ConsumerStates.ShardConsumerStat
  * that they have successfully processed all the records (processing of child shards can then begin).
  */
 public enum ShutdownReason {
+
+    /**
+     * Processing Records threw an unrecoverable error. Shutdown the processor and recreate.
+     */
+    UNRECOVERABLE(4, ShardConsumerState.SHUTTING_DOWN.consumerState()),
+
+
     /**
      * Processing will be moved to a different record processor (fail over, load balancing use cases).
      * Applications SHOULD NOT checkpoint their progress (as another record processor may have already started

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/processor/ShardRecordProcessor.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/processor/ShardRecordProcessor.java
@@ -14,6 +14,7 @@
  */
 package software.amazon.kinesis.processor;
 
+import software.amazon.kinesis.exceptions.ShutdownException;
 import software.amazon.kinesis.lifecycle.events.InitializationInput;
 import software.amazon.kinesis.lifecycle.events.LeaseLostInput;
 import software.amazon.kinesis.lifecycle.events.ProcessRecordsInput;
@@ -43,7 +44,7 @@ public interface ShardRecordProcessor {
      * @param processRecordsInput Provides the records to be processed as well as information and capabilities related
      *        to them (eg checkpointing).
      */
-    void processRecords(ProcessRecordsInput processRecordsInput);
+    void processRecords(ProcessRecordsInput processRecordsInput) throws ShutdownException;
 
     /**
      * Called when the lease that tied to this record processor has been lost. Once the lease has been lost the record


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/amazon-kinesis-client/issues/537
*Description of changes:*
This change is aimed to allow the ShardRecordProcessor bubble up an unrecoverable exception given the current consumer state i.e issues with checkpointing or bugs around the lease coordinator. The goal of the unrecoverable exception is to make the scheduler re-create a shard consumer and refresh its concurrency tokens and lease. Fair warning I am not very versed in this library so i may be off basis by allowing this to happen. However it seems like it would be a fair ability to give to the implementer.

The problem listed above may be another root problem that this works around but I am unaware of what is really causing that issue hence the workaround.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
