### PR TITLE
missleading warning message

### DIFF
--- a/amazon-kinesis-client-multilang/src/main/java/software/amazon/kinesis/multilang/config/RetrievalMode.java
+++ b/amazon-kinesis-client-multilang/src/main/java/software/amazon/kinesis/multilang/config/RetrievalMode.java
@@ -55,7 +55,7 @@ public enum RetrievalMode {
     private static RetrievalConfigBuilder decideForDefault(MultiLangDaemonConfiguration configuration) {
         if (configuration.getPollingConfig().anyPropertiesSet()) {
             log.warn("Some polling properties have been set, defaulting to polling. "
-                    + "To switch to Fanout either add `RetrievalMode=FANOUT` to your "
+                    + "To switch to Fanout either add `retrievalMode=FANOUT` to your "
                     + "properties or remove the any configuration for polling.");
             return configuration.getPollingConfig();
         }


### PR DESCRIPTION
As best as I can tell, the correct config would be:
`retrievalMode=FANOUT`

in fact, I want to use
`retrievalMode=POLLING`

but that probably belongs in some other docs.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
