### PR TITLE
Lease Lost event is notified to shard record processor on enabling co…

### DIFF
--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/coordinator/Scheduler.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/coordinator/Scheduler.java
@@ -575,6 +575,7 @@ public class Scheduler implements Runnable {
                 listShardsBackoffTimeMillis,
                 maxListShardsRetryAttempts,
                 processorConfig.callProcessRecordsEvenForEmptyRecordList(),
+                processorConfig.isRecordProcessorConcurrentlyCallable(),
                 shardConsumerDispatchPollIntervalMillis,
                 initialPosition,
                 cleanupLeasesUponShardCompletion,

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/lifecycle/ShardConsumerArgument.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/lifecycle/ShardConsumerArgument.java
@@ -59,6 +59,7 @@ public class ShardConsumerArgument {
     private final long listShardsBackoffTimeInMillis;
     private final int maxListShardsRetryAttempts;
     private final boolean shouldCallProcessRecordsEvenForEmptyRecordList;
+    private final boolean isRecordProcessorConcurrentlyCallable;
     private final long idleTimeInMilliseconds;
     @NonNull
     private final InitialPositionInStreamExtended initialPositionInStream;

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/processor/ProcessorConfig.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/processor/ProcessorConfig.java
@@ -38,4 +38,10 @@ public class ProcessorConfig {
      */
     private boolean callProcessRecordsEvenForEmptyRecordList = false;
 
+    /**
+     * If set to true, record processor is assumed to be thread safe and concurrent calls could be made
+     *
+     * <p>Default value: false</p>
+     */
+    private boolean isRecordProcessorConcurrentlyCallable = false;
 }

--- a/amazon-kinesis-client/src/test/java/software/amazon/kinesis/lifecycle/ConsumerStatesTest.java
+++ b/amazon-kinesis-client/src/test/java/software/amazon/kinesis/lifecycle/ConsumerStatesTest.java
@@ -103,6 +103,7 @@ public class ConsumerStatesTest {
     private long listShardsBackoffTimeInMillis = 50L;
     private int maxListShardsRetryAttempts = 10;
     private boolean shouldCallProcessRecordsEvenForEmptyRecordList = true;
+    private boolean isRecordProcessorConcurrentlyCallable = false;
     private boolean ignoreUnexpectedChildShards = false;
     private long idleTimeInMillis = 1000L;
     private Optional<Long> logWarningForTaskAfterMillis = Optional.empty();
@@ -112,7 +113,7 @@ public class ConsumerStatesTest {
         argument = new ShardConsumerArgument(shardInfo, STREAM_NAME, leaseRefresher, executorService, recordsPublisher,
                 shardRecordProcessor, checkpointer, recordProcessorCheckpointer, parentShardPollIntervalMillis,
                 taskBackoffTimeMillis, skipShardSyncAtWorkerInitializationIfLeasesExist, listShardsBackoffTimeInMillis,
-                maxListShardsRetryAttempts, shouldCallProcessRecordsEvenForEmptyRecordList, idleTimeInMillis,
+                maxListShardsRetryAttempts, shouldCallProcessRecordsEvenForEmptyRecordList, isRecordProcessorConcurrentlyCallable, idleTimeInMillis,
                 INITIAL_POSITION_IN_STREAM, cleanupLeasesOfCompletedShards, ignoreUnexpectedChildShards, shardDetector,
                 new AggregatorUtil(), hierarchicalShardSyncer, metricsFactory);
         consumer = spy(new ShardConsumer(recordsPublisher, executorService, shardInfo, logWarningForTaskAfterMillis,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR allows record processor to abort current processing on lease loss event. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
