### PR TITLE
Better handling of no lease in getCheckpointObject in KinesisClientLibLeaseCoordinator

### DIFF
--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/KinesisClientLibLeaseCoordinator.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/KinesisClientLibLeaseCoordinator.java
@@ -282,13 +282,16 @@ class KinesisClientLibLeaseCoordinator extends LeaseCoordinator<KinesisClientLea
      */
     @Override
     public Checkpoint getCheckpointObject(String shardId) throws KinesisClientLibException {
+        String errorMessage = "Unable to fetch checkpoint for shardId " + shardId;
         try {
             KinesisClientLease lease = leaseManager.getLease(shardId);
+            if (lease == null) {
+                throw new KinesisClientLibIOException(errorMessage);
+            }
             return new Checkpoint(lease.getCheckpoint(), lease.getPendingCheckpoint());
         } catch (DependencyException | InvalidStateException | ProvisionedThroughputException e) {
-            String message = "Unable to fetch checkpoint for shardId " + shardId;
-            LOG.error(message, e);
-            throw new KinesisClientLibIOException(message, e);
+            LOG.error(errorMessage, e);
+            throw new KinesisClientLibIOException(errorMessage, e);
         }
     }
 

--- a/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/KinesisClientLibLeaseCoordinatorTest.java
+++ b/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/KinesisClientLibLeaseCoordinatorTest.java
@@ -15,10 +15,12 @@
 package com.amazonaws.services.kinesis.clientlibrary.lib.worker;
 
 import static org.mockito.Matchers.anyLong;
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.doReturn;
 
 import java.util.UUID;
 
+import com.amazonaws.services.kinesis.clientlibrary.exceptions.internal.KinesisClientLibIOException;
 import com.amazonaws.services.kinesis.leases.impl.KinesisClientLease;
 import com.amazonaws.services.kinesis.leases.impl.GenericLeaseSelector;
 import com.amazonaws.services.kinesis.leases.interfaces.LeaseSelector;
@@ -75,5 +77,13 @@ public class KinesisClientLibLeaseCoordinatorTest {
         // Set mock lease manager to return false in waiting
         doReturn(false).when(mockLeaseManager).waitUntilLeaseTableExists(anyLong(), anyLong());
         leaseCoordinator.initialize();
+    }
+
+    @Test(expected = KinesisClientLibIOException.class)
+    public void testGetCheckpointObjectWithNoLease()
+            throws DependencyException, ProvisionedThroughputException, IllegalStateException, InvalidStateException,
+            KinesisClientLibException {
+        doReturn(null).when(mockLeaseManager).getLease(anyString());
+        leaseCoordinator.getCheckpointObject(SHARD_ID);
     }
 }


### PR DESCRIPTION
Issue #476  

Description of changes:
Improved the handling of get checkpoint object in KinesisClientLibLeaseCoordinator
by no longer triggering a null pointer exception when lease is null.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
