### PR TITLE
Fixing bug where initial subscription failure causes shard consumer to get stuck.

### DIFF
--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/lifecycle/ShardConsumerSubscriber.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/lifecycle/ShardConsumerSubscriber.java
@@ -44,6 +44,7 @@ class ShardConsumerSubscriber implements Subscriber<RecordsRetrieved> {
 
     @VisibleForTesting
     final Object lockObject = new Object();
+    // This holds the last time a request to upstream service is made including the first try to establish subscription.
     private Instant lastRequestTime = null;
     private RecordsRetrieved lastAccepted = null;
 
@@ -73,6 +74,8 @@ class ShardConsumerSubscriber implements Subscriber<RecordsRetrieved> {
 
     void startSubscriptions() {
         synchronized (lockObject) {
+            // Setting the lastRequestTime to allow for health checks to restart subscriptions if they failed to
+            // during initial try.
             lastRequestTime = Instant.now();
             if (lastAccepted != null) {
                 recordsPublisher.restartFrom(lastAccepted);

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/lifecycle/ShardConsumerSubscriber.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/lifecycle/ShardConsumerSubscriber.java
@@ -44,7 +44,8 @@ class ShardConsumerSubscriber implements Subscriber<RecordsRetrieved> {
 
     @VisibleForTesting
     final Object lockObject = new Object();
-    // This holds the last time a request to upstream service is made including the first try to establish subscription.
+    // This holds the last time an attempt of request to upstream service was made including the first try to
+    // establish subscription.
     private Instant lastRequestTime = null;
     private RecordsRetrieved lastAccepted = null;
 
@@ -131,12 +132,8 @@ class ShardConsumerSubscriber implements Subscriber<RecordsRetrieved> {
                             "{}: Last request was dispatched at {}, but no response as of {} ({}).  Cancelling subscription, and restarting.",
                             shardConsumer.shardInfo().shardId(), lastRequestTime, now, timeSinceLastResponse);
                     cancel();
-                    //
-                    // Set the last request time to now, we specifically don't null it out since we want it to
-                    // trigger a
-                    // restart if the subscription still doesn't start producing.
-                    //
-                    lastRequestTime = Instant.now();
+
+                    // Start the subscription again which will update the lastRequestTime as well.
                     startSubscriptions();
                 }
             }

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/lifecycle/ShardConsumerSubscriber.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/lifecycle/ShardConsumerSubscriber.java
@@ -73,6 +73,7 @@ class ShardConsumerSubscriber implements Subscriber<RecordsRetrieved> {
 
     void startSubscriptions() {
         synchronized (lockObject) {
+            lastRequestTime = Instant.now();
             if (lastAccepted != null) {
                 recordsPublisher.restartFrom(lastAccepted);
             }


### PR DESCRIPTION
Fixing bug where initial subscription failure causes shard consumer to get stuck.

*Issue #, if available:*

*Description of changes:*
This change is to fix the scenario where the initial SubscribeToShard call failing silently in the SDK layer during the state transition and KCL will be not be able to set the variables which causes the health check to retry the failure. The shard consumer will hold the lease and get stuck without making any progress. 
The fix is to update the lastRequestTime variable when we start the subscription to get the health check work in case the initial SubscribeToShard call fail and we don't make progress. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
