### PR TITLE
Adding the option to do periodic shard syncs on elected leader workers instead of shard sync on each shard end event across workers

### DIFF
--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/periodicshardsync/ILeaderElectionStrategyFactory.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/periodicshardsync/ILeaderElectionStrategyFactory.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates.
+ * Licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.amazonaws.services.kinesis.clientlibrary.lib.periodicshardsync;
+
+import com.amazonaws.services.kinesis.leases.impl.Lease;
+
+/**
+ * Factory interface to vend LeaderElectionStrategy instance
+ * 
+ * @param <T>
+ */
+public interface ILeaderElectionStrategyFactory<T extends Lease> {
+
+    /**
+     * @return Returns a {@code LeaderElectionStrategy}
+     */
+    LeaderElectionStrategy<T> getLeaderElectionStrategy();
+
+}

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/periodicshardsync/ILeasesCache.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/periodicshardsync/ILeasesCache.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates.
+ * Licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.amazonaws.services.kinesis.clientlibrary.lib.periodicshardsync;
+
+import java.util.List;
+
+import com.amazonaws.services.kinesis.clientlibrary.lib.worker.LeasesCacheException;
+import com.amazonaws.services.kinesis.leases.impl.Lease;
+
+/**
+ * Cache interface for caching leases
+ *
+ * @param <T>
+ */
+public interface ILeasesCache<T extends Lease> {
+
+    /**
+     * @param key Key to look for in the cache
+     * @return Returns the List of leases mapped to the key. If not found in the
+     *         cache, loads from the source registered with the cache
+     * @throws LeasesCacheException
+     */
+    List<T> getLeases(String key) throws LeasesCacheException;
+}

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/periodicshardsync/IShardSyncManager.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/periodicshardsync/IShardSyncManager.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates.
+ * Licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.amazonaws.services.kinesis.clientlibrary.lib.periodicshardsync;
+
+import com.amazonaws.services.kinesis.leases.impl.Lease;
+
+/**
+ * ShardSyncManager interface which exposes methods to start and stop the Sync
+ * Manager and also get the associated LeaderPoller
+ * 
+ * @param <T>
+ */
+public interface IShardSyncManager<T extends Lease> {
+    /**
+     * Starts the ShardSyncManager
+     */
+    public void start();
+
+    /**
+     * Stops the ShardSyncManager
+     */
+    public void stop();
+
+    /**
+     * @return Returns the associated LeaderPoller
+     */
+    LeaderPoller<T> getLeaderPoller();
+}

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/periodicshardsync/ITaskSchedulerFactory.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/periodicshardsync/ITaskSchedulerFactory.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates.
+ * Licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.amazonaws.services.kinesis.clientlibrary.lib.periodicshardsync;
+
+/**
+ * Factory for vending {@codeTaskSchedulerStrategy} instance which is
+ * responsible for Scheduling task e.g ShardSync
+ *
+ */
+public interface ITaskSchedulerFactory {
+
+    /**
+     * @return Returns TaskSchedulerStrategy instance which encapsulates the
+     *         scheduling logic
+     */
+    TaskSchedulerStrategy getTaskScheduler();
+
+}

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/periodicshardsync/LeaderElectionStrategy.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/periodicshardsync/LeaderElectionStrategy.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates.
+ * Licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.amazonaws.services.kinesis.clientlibrary.lib.periodicshardsync;
+
+import java.util.List;
+import java.util.Set;
+
+import com.amazonaws.services.kinesis.leases.impl.Lease;
+
+/**
+ * Interface for electing leaders and registering listeners interested in being
+ * notified on leader election
+ *
+ * @param <T>
+ */
+public interface LeaderElectionStrategy<T extends Lease> extends Runnable {
+	
+    /**
+     * @param listener Listener interested in being notified on leader election
+     */
+    void registerLeadersElectionListener(LeadersElectionListener listener);
+
+    /**
+     * @param leases Leases held by workers from which the leaders are chsoen
+     * @return Elected set of leaders based on the concrete leader election strategy implementation
+     */
+    Set<String> electLeaders(List<T> leases);
+}

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/periodicshardsync/LeaderPoller.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/periodicshardsync/LeaderPoller.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates.
+ * Licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.amazonaws.services.kinesis.clientlibrary.lib.periodicshardsync;
+
+import com.amazonaws.services.kinesis.leases.impl.Lease;
+
+/**
+ * Interface for polling for the leaders
+ *
+ * @param <T>
+ */
+public interface LeaderPoller<T extends Lease> {
+    /**
+     * check for leaders
+     */
+    void pollForLeaders();
+
+    /**
+     * @return Returns the LeaderElectionStrategy associated with this poller
+     */
+    LeaderElectionStrategy<T> getLeaderElectionStrategy();
+
+    void stop();
+}

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/periodicshardsync/LeadersElectionListener.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/periodicshardsync/LeadersElectionListener.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates.
+ * Licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.amazonaws.services.kinesis.clientlibrary.lib.periodicshardsync;
+
+import java.util.Set;
+
+/**
+ * Interface which exposes callback for notifying registered listeners upon
+ * leader election
+ *
+ */
+public interface LeadersElectionListener {
+    /**
+     * Notify registered listeners upon leader election
+     * 
+     * @param newLeadersWorkerIds
+     *            current set of chosen leaders
+     */
+    void leadersElected(Set<String> newLeadersWorkerIds);
+}

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/periodicshardsync/TaskSchedulerStrategy.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/periodicshardsync/TaskSchedulerStrategy.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates.
+ * Licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.amazonaws.services.kinesis.clientlibrary.lib.periodicshardsync;
+
+import java.util.concurrent.Callable;
+
+/**
+ * Interface to schedule tasks e.g ShardSync
+ *
+ * @param <T>
+ */
+public interface TaskSchedulerStrategy<T extends Callable> {
+	
+    /**
+     * @param task Task to be scheduled
+     */
+	void scheduleTask(T task);
+
+    /**
+     * Start the scheduling of tasks
+     */
+    void start();
+
+    /**
+     * Stop the scheduled tasks
+     */
+    void stop();
+
+    /*
+    Cleans up any open resources
+     */
+    void shutdown();
+}

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/periodicshardsync/WorkerStateChangeListener.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/periodicshardsync/WorkerStateChangeListener.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates.
+ * Licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.amazonaws.services.kinesis.clientlibrary.lib.periodicshardsync;
+
+
+import com.amazonaws.services.kinesis.clientlibrary.lib.worker.WorkerState;
+
+/**
+ * Interface to expose methods for Worker state change e.g from IdleState to
+ * RunningState
+ *
+ */
+public interface WorkerStateChangeListener {
+    /**
+     * Start the leader action for the worker
+     */
+    void startLeader();
+
+    /**
+     * Stop the leader action for the worker
+     */
+    void stopLeader();
+
+    /**
+     * Nothing to be done by the worker
+     */
+    void noOp();
+
+    /**
+     * @param workerState Set the worker state
+     */
+    void setWorkerState(WorkerState workerState);
+}

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ActiveShardCountBasedShardSyncStrategyDecider.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ActiveShardCountBasedShardSyncStrategyDecider.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates.
+ * Licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.amazonaws.services.kinesis.clientlibrary.lib.worker;
+
+import java.util.List;
+
+import com.amazonaws.services.kinesis.clientlibrary.types.ExtendedSequenceNumber;
+import com.amazonaws.services.kinesis.leases.exceptions.DependencyException;
+import com.amazonaws.services.kinesis.leases.exceptions.InvalidStateException;
+import com.amazonaws.services.kinesis.leases.exceptions.ProvisionedThroughputException;
+import com.amazonaws.services.kinesis.leases.impl.KinesisClientLease;
+import com.amazonaws.services.kinesis.leases.interfaces.ILeaseManager;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+/**
+ * ShardSyncStrategyDecider implementation which looks at the active shard count
+ * to decide the strategy for shard sync
+ *
+ */
+class ActiveShardCountBasedShardSyncStrategyDecider implements ShardSyncStrategyDecider {
+
+    private static final Object LOCK = new Object();
+    private static final Log LOG = LogFactory.getLog(ActiveShardCountBasedShardSyncStrategyDecider.class);
+    private ILeaseManager<KinesisClientLease> leaseManager;
+    private volatile List<KinesisClientLease> leases;
+
+    ActiveShardCountBasedShardSyncStrategyDecider(ILeaseManager<KinesisClientLease> leaseManager) {
+        this.leaseManager = leaseManager;
+    }
+
+    static final int MIN_ACTIVE_SHARDS_FOR_PERIODIC_SYNC = 3000;
+
+    /*
+     * Gets the active shards count and decides the shard sync strategy based on the threshold
+     *
+     * @see com.amazonaws.services.kinesis.clientlibrary.lib.worker.
+     * ShardSyncStrategyDecider#getShardSyncStrategy()
+     */
+    @Override
+    public ShardSyncStrategy getShardSyncStrategy()
+            throws DependencyException, InvalidStateException, ProvisionedThroughputException {
+        ShardSyncStrategy shardSyncStrategy = null;
+        int activeShardleasesCount = getActiveShardleasesCount();
+        if (activeShardleasesCount != 0) {
+            shardSyncStrategy = activeShardleasesCount >= MIN_ACTIVE_SHARDS_FOR_PERIODIC_SYNC ? ShardSyncStrategy.PERIODIC
+                                        : ShardSyncStrategy.SHARD_END;
+        }
+        LOG.debug(String.format("ActiveShardLeasesCount: %d, ShardSyncStrategy: %s", activeShardleasesCount, shardSyncStrategy.name()));
+        return shardSyncStrategy;
+    }
+
+    /**
+     * Gets the leases and filters out the SHARD_END leases to get the count of
+     * active leases
+     *
+     * @return Active leases count
+     * @throws DependencyException
+     * @throws InvalidStateException
+     * @throws ProvisionedThroughputException
+     */
+    private int getActiveShardleasesCount()
+            throws DependencyException, InvalidStateException, ProvisionedThroughputException {
+        // double checked locking to ensure only a single thread populates the
+        // leases as all threads will get roughly the same view of the leases at
+        // startup. This keeps a check on IOPS utilisation of Leases table. Also
+        // once populated, the strategy will never move back from Periodic to
+        // Shard sync as the number of shards never reduce. For the other case
+        // of increasing shards, its a fair assumption that there would be at
+        // least one deployment and the workers would initialize again before
+        // that happens
+        if(leases == null) {
+            synchronized (LOCK) {
+                if (leases == null) {
+                    getLeases();
+                }
+            }
+        }
+        return leases == null ? 0
+                       : (int) leases.stream().filter(lease -> lease.getCheckpoint() != null && lease.getCheckpoint() != ExtendedSequenceNumber.SHARD_END)
+                                     .count();
+    }
+
+    private void getLeases() throws DependencyException, InvalidStateException, ProvisionedThroughputException {
+        leases = leaseManager.listLeases();
+    }
+
+}

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ConfigBasedPeriodicSyncScheduler.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ConfigBasedPeriodicSyncScheduler.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates.
+ * Licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.amazonaws.services.kinesis.clientlibrary.lib.worker;
+
+import java.util.Random;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+import com.amazonaws.services.kinesis.clientlibrary.lib.periodicshardsync.TaskSchedulerStrategy;
+import com.amazonaws.services.kinesis.clientlibrary.proxies.IKinesisProxy;
+import com.amazonaws.services.kinesis.leases.impl.KinesisClientLease;
+import com.amazonaws.services.kinesis.leases.interfaces.ILeaseManager;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+/**
+ * This implementation is responsible for scheduling periodic shard syncs on a
+ * worker based on the values such as Max concurrency, jitter, frequency etc set
+ * by the client in the config
+ */
+class ConfigBasedPeriodicSyncScheduler implements TaskSchedulerStrategy<ShardSyncTask> {
+
+    private final IKinesisProxy kinesisProxy;
+    private final ILeaseManager<KinesisClientLease> leaseManager;
+    private InitialPositionInStreamExtended initialPosition;
+    private final KinesisClientLibConfiguration config;
+    private final ShardSyncer shardSyncer;
+    private final ScheduledThreadPoolExecutor scheduledExecutor;
+    private ScheduledFuture scheduledFuture;
+    private boolean isRunning;
+
+    private static final Log LOG = LogFactory.getLog(ScheduledLeaseLeaderPoller.class);
+    private static final long SHARD_SYNC_TASK_IDLE_TIME_MILIS = 0;
+    private static final long INITIAL_DELAY = 0;
+    private static final int AWAIT_TERMINATION_SECS = 5;
+    private static final long PERIODIC_SHARD_SYNC_FREQUENCY_MILLIS = 10000;
+    private static final int PERIODIC_SHARD_SYNC_MAX_JITTER_MILLIS = 10;
+
+    ConfigBasedPeriodicSyncScheduler(IKinesisProxy kinesisProxy, ILeaseManager<KinesisClientLease> leaseManager,
+                                     InitialPositionInStreamExtended initialPosition, KinesisClientLibConfiguration config,
+                                     ScheduledThreadPoolExecutor scheduledThreadPoolExecutor, ShardSyncer shardSyncer) {
+        this.initialPosition = initialPosition;
+        this.kinesisProxy = kinesisProxy;
+        this.leaseManager = leaseManager;
+        this.config = config;
+        this.scheduledExecutor = scheduledThreadPoolExecutor;
+        this.shardSyncer = shardSyncer;
+    }
+
+    @Override
+    public void scheduleTask(ShardSyncTask task) {
+        // adding jitter to stagger the syncs across workers
+        Random jitterDelayGen = new Random();
+        int jitterDelay = jitterDelayGen.nextInt(PERIODIC_SHARD_SYNC_MAX_JITTER_MILLIS);
+        scheduledFuture = scheduledExecutor.scheduleAtFixedRate(task, INITIAL_DELAY,
+                                                                PERIODIC_SHARD_SYNC_FREQUENCY_MILLIS + jitterDelay,
+                                                                TimeUnit.MILLISECONDS);
+    }
+
+    @Override
+    public void start() {
+        if (!isRunning) {
+            ShardSyncTask shardSyncTask = new ShardSyncTask(kinesisProxy, leaseManager, initialPosition,
+                                                            config.shouldCleanupLeasesUponShardCompletion(), config.shouldIgnoreUnexpectedChildShards(),
+                                                            SHARD_SYNC_TASK_IDLE_TIME_MILIS, shardSyncer);
+            scheduleTask(shardSyncTask);
+            isRunning = true;
+        }
+    }
+
+    @Override
+    public void stop() {
+        if (isRunning && scheduledFuture != null) {
+            scheduledFuture.cancel(true /* mayInterruptIfRunning */);
+            isRunning = false;
+        }
+    }
+
+    @Override
+    public void shutdown() {
+        try {
+            scheduledExecutor.shutdown();
+            if (scheduledExecutor.awaitTermination(AWAIT_TERMINATION_SECS, TimeUnit.SECONDS)) {
+                LOG.info("Successfully stopped leader polling threads on the worker");
+            } else {
+                scheduledExecutor.shutdownNow();
+                LOG.info(String.format("Stopped leader polling threads after awaiting termination for %d seconds",
+                                       AWAIT_TERMINATION_SECS));
+            }
+        } catch (InterruptedException e) {
+            LOG.debug("Encountered InterruptedException while awaiting leader polling threadpool termination");
+        }
+    }
+}

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ConsumerStates.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ConsumerStates.java
@@ -531,7 +531,8 @@ class ConsumerStates {
                     consumer.getLeaseManager(),
                     consumer.getTaskBackoffTimeMillis(),
                     consumer.getGetRecordsCache(),
-                    consumer.getShardSyncer());
+                    consumer.getShardSyncer(),
+                    consumer.getShardSyncStrategy());
         }
 
         @Override

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/DeterministicShuffleLeaderElection.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/DeterministicShuffleLeaderElection.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates.
+ * Licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.amazonaws.services.kinesis.clientlibrary.lib.worker;
+
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Random;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import com.amazonaws.services.kinesis.clientlibrary.lib.periodicshardsync.ILeasesCache;
+import com.amazonaws.services.kinesis.clientlibrary.lib.periodicshardsync.LeaderElectionStrategy;
+import com.amazonaws.services.kinesis.clientlibrary.lib.periodicshardsync.LeadersElectionListener;
+import com.amazonaws.services.kinesis.leases.impl.KinesisClientLease;
+import com.amazonaws.util.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+/**
+ * This implementation of the {@code LeaderElectionStrategy} elects the leaders
+ * by firstly getting all the leases. The leases are then shuffled using a
+ * predetermined constant seed so that the lease ordering is preserved across
+ * workers. This strategy helps in randomly shuffling the leases in order to
+ * reduce the probability of choosing the leader workers co-located on the same
+ * host in case the lease owner field in the lease doesn't distinguish between workers
+ * on the same host e.g using ip address of the host for the lease owner for all workers
+ * on a host. The number of leaders to elect is configurable here
+ * {@code config.getPeriodicShardSyncMaxWorkers()}. Once the leaders are
+ * elected, all the registered listeners are informed about the new election
+ */
+class DeterministicShuffleLeaderElection
+        implements LeaderElectionStrategy<KinesisClientLease>, Comparator<KinesisClientLease> {
+
+    static final String LEAES_CACHE_KEY = "all_leases";
+    // Fixed seed so that the shuffle order is preserved across workers
+    static final int DETERMINISTIC_SHUFFLE_SEED = 1947;
+    private static final int PERIODIC_SHARD_SYNC_MAX_WORKERS = 5;
+
+    private static final Log LOG = LogFactory.getLog(DeterministicShuffleLeaderElection.class);
+    private KinesisClientLibConfiguration config;
+    private Set<LeadersElectionListener> leadersElectionListeners;
+    private ILeasesCache<KinesisClientLease> leasesCache;
+
+    DeterministicShuffleLeaderElection(KinesisClientLibConfiguration config,
+                                       ILeasesCache<KinesisClientLease> leasesCache) {
+        this.config = config;
+        this.leasesCache = leasesCache;
+
+        this.leadersElectionListeners = new HashSet<LeadersElectionListener>();
+    }
+
+    @Override
+    public void run() {
+        List<KinesisClientLease> leases = getLeases();
+        if (leases != null) {
+            electLeaders(leases);
+        }
+    }
+
+    @Override
+    public void registerLeadersElectionListener(LeadersElectionListener listener) {
+        leadersElectionListeners.add(listener);
+    }
+
+    /*
+     * shuffles the leases deterministically and elects configured no of workers
+     * as leaders
+     *
+     * @see com.amazonaws.services.kinesis.clientlibrary.lib.periodicshardsync.
+     * interfaces.LeaderElectionStrategy#electLeaders(java.util.List)
+     */
+    @Override
+    public Set<String> electLeaders(List<KinesisClientLease> leases) {
+        if (CollectionUtils.isNullOrEmpty(leases)) {
+            return new HashSet<String>();
+        }
+        leases = leases.stream().filter(lease -> lease.getLeaseOwner() != null).sorted(this)
+                       .collect(Collectors.toList());
+        Collections.shuffle(leases, new Random(DETERMINISTIC_SHUFFLE_SEED));
+        Set<String> leaders = leases.stream()
+                                    .limit(Math.min(PERIODIC_SHARD_SYNC_MAX_WORKERS, getUniqueWorkerIds(leases).size()))
+                                    .map(lease -> lease.getLeaseOwner()).collect(Collectors.toSet());
+        leadersElectionListeners.forEach(listener -> listener.leadersElected(leaders));
+        return leaders;
+    }
+
+    private Set<String> getUniqueWorkerIds(List<KinesisClientLease> leases) {
+        Set<String> workers = new HashSet<String>();
+        for (KinesisClientLease lease : leases) {
+            if (StringUtils.isNotBlank(lease.getLeaseOwner())) {
+                workers.add(lease.getLeaseOwner());
+            }
+        }
+        return workers;
+    }
+
+    private List<KinesisClientLease> getLeases() {
+        List<KinesisClientLease> leases = null;
+        try {
+            //The leases are cached to keep a check on the IOPS consumption on the leases table
+            // caching is feasible as the worker composition should remain fairly constant 
+            leases = leasesCache.getLeases(LEAES_CACHE_KEY);
+        } catch (LeasesCacheException e) {
+            LOG.error("Exception occurred while trying to fetch all leases for leader election", e.getCause());
+        }
+        return leases;
+    }
+
+    @Override
+    public int compare(KinesisClientLease lease1, KinesisClientLease lease2) {
+        return lease1.getLeaseOwner().compareTo(lease2.getLeaseOwner());
+    }
+
+}

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/IdleState.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/IdleState.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates.
+ * Licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.amazonaws.services.kinesis.clientlibrary.lib.worker;
+
+import com.amazonaws.services.kinesis.clientlibrary.lib.periodicshardsync.WorkerStateChangeListener;
+
+/**
+ * The worker in IdleState represents that the worker is not executing the
+ * periodic shard syncs.
+ */
+class IdleState extends WorkerState {
+
+    IdleState(String workerId, WorkerStateChangeListener workerStateChangeListener) {
+        this.workerId = workerId;
+        this.workerStateChangeListener = workerStateChangeListener;
+    }
+
+    /*
+     * IdleState worker on transitioning as a leader needs to start executing
+     * the leader behaviour and update to the RunningState
+     *
+     * @see
+     * com.amazonaws.services.kinesis.clientlibrary.lib.periodicshardsync.impl.
+     * WorkerState#leaderStateTransition()
+     */
+    @Override
+    protected void leaderStateTransition() {
+        workerStateChangeListener.startLeader();
+        workerStateChangeListener.setWorkerState(new RunningState(workerId, workerStateChangeListener));
+    }
+
+    /*
+     * No operation needed if IdleState worker not elected as a leader
+     *
+     * @see
+     * com.amazonaws.services.kinesis.clientlibrary.lib.periodicshardsync.impl.
+     * WorkerState#nonleaderStateTransition()
+     */
+    @Override
+    protected void nonLeaderStateTransition() {
+        workerStateChangeListener.noOp();
+    }
+
+}

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/KinesisClientLibConfiguration.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/KinesisClientLibConfiguration.java
@@ -166,6 +166,12 @@ public class KinesisClientLibConfiguration {
      * during incremental deployments of an application).
      */
     public static final boolean DEFAULT_SKIP_SHARD_SYNC_AT_STARTUP_IF_LEASES_EXIST = false;
+    
+    /**
+     * Opt in for periodic shard sync by setting this flag to true. However, setting this to true doesn't guarantee periodic shard sync. The decision
+     * to trigger shard syncs is taken by the ShardSyncStrategyDecider
+     */
+    public static final boolean DEFAULT_ENABLE_PERIODIC_SHARD_SYNC = false;
 
     /**
      * Default Shard prioritization strategy.
@@ -230,6 +236,7 @@ public class KinesisClientLibConfiguration {
     private boolean skipShardSyncAtWorkerInitializationIfLeasesExist;
     private ShardPrioritization shardPrioritization;
     private long shutdownGraceMillis;
+    private boolean enablePeriodicShardSync;
 
     @Getter
     private Optional<Integer> timeoutInSeconds = Optional.empty();
@@ -492,6 +499,7 @@ public class KinesisClientLibConfiguration {
         this.initialPositionInStreamExtended =
                 InitialPositionInStreamExtended.newInitialPosition(initialPositionInStream);
         this.skipShardSyncAtWorkerInitializationIfLeasesExist = DEFAULT_SKIP_SHARD_SYNC_AT_STARTUP_IF_LEASES_EXIST;
+        this.enablePeriodicShardSync = DEFAULT_ENABLE_PERIODIC_SHARD_SYNC;
         this.shardPrioritization = DEFAULT_SHARD_PRIORITIZATION;
         this.recordsFetcherFactory = new SimpleRecordsFetcherFactory();
     }
@@ -600,6 +608,7 @@ public class KinesisClientLibConfiguration {
         this.initialPositionInStreamExtended =
                 InitialPositionInStreamExtended.newInitialPosition(initialPositionInStream);
         this.skipShardSyncAtWorkerInitializationIfLeasesExist = DEFAULT_SKIP_SHARD_SYNC_AT_STARTUP_IF_LEASES_EXIST;
+        this.enablePeriodicShardSync = DEFAULT_ENABLE_PERIODIC_SHARD_SYNC;
         this.shardPrioritization = DEFAULT_SHARD_PRIORITIZATION;
         this.recordsFetcherFactory = recordsFetcherFactory;
         this.shutdownGraceMillis = shutdownGraceMillis;
@@ -839,7 +848,16 @@ public class KinesisClientLibConfiguration {
     public boolean getSkipShardSyncAtWorkerInitializationIfLeasesExist() {
         return skipShardSyncAtWorkerInitializationIfLeasesExist;
     }
-
+    
+    
+    /**
+     * @return true if periodic shard sync is enabled. true however doesn't guarantee periodic shard sync. The decision
+     * to trigger shard syncs is taken by the ShardSyncStrategyDecider
+     */
+    public boolean getEnablePeriodicShardSync() {
+        return enablePeriodicShardSync;
+    }
+    
     /**
      * @return Max leases this Worker can handle at a time
      */
@@ -1196,6 +1214,17 @@ public class KinesisClientLibConfiguration {
     public KinesisClientLibConfiguration withSkipShardSyncAtStartupIfLeasesExist(
             boolean skipShardSyncAtStartupIfLeasesExist) {
         this.skipShardSyncAtWorkerInitializationIfLeasesExist = skipShardSyncAtStartupIfLeasesExist;
+        return this;
+    }
+    
+    
+    /**
+     * @param periodicShardSync whether to opt in for enabling periodic shard sync. true doesn't guarantee periodic shard sync would be in effect. The decision
+     * to trigger shard syncs is taken by the ShardSyncStrategyDecider
+     * @return {@link KinesisClientLibConfiguration}
+     */
+    public KinesisClientLibConfiguration withEnablePeriodicShardSync(boolean enablePeriodicShardSync) {
+        this.enablePeriodicShardSync = enablePeriodicShardSync;
         return this;
     }
 

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/LeaderElectionStrategy.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/LeaderElectionStrategy.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates.
+ * Licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.amazonaws.services.kinesis.clientlibrary.lib.worker;
+
+import java.util.List;
+
+public interface LeaderElectionStrategy {
+	
+	Worker electLeader(List<Worker> workers);
+
+}

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/LeaderElectionStrategyFactory.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/LeaderElectionStrategyFactory.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates.
+ * Licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.amazonaws.services.kinesis.clientlibrary.lib.worker;
+
+import java.util.concurrent.TimeUnit;
+
+import com.amazonaws.services.kinesis.clientlibrary.lib.periodicshardsync.ILeaderElectionStrategyFactory;
+import com.amazonaws.services.kinesis.clientlibrary.lib.periodicshardsync.ILeasesCache;
+import com.amazonaws.services.kinesis.clientlibrary.lib.periodicshardsync.LeaderElectionStrategy;
+import com.amazonaws.services.kinesis.leases.impl.KinesisClientLease;
+import com.amazonaws.services.kinesis.leases.interfaces.ILeaseManager;
+
+/**
+ * Factory implementation to vend singleton instance of leaderElectionStrategy
+ */
+class LeaderElectionStrategyFactory implements ILeaderElectionStrategyFactory<KinesisClientLease> {
+    private ILeaseManager<KinesisClientLease> leaseManager;
+    private KinesisClientLibConfiguration config;
+    int vendedInstanceCount;
+    private static final int LEADER_ELECTION_LEASES_CACHE_TTL_MINS = 5;
+
+    private volatile LeaderElectionStrategy<KinesisClientLease> leaderElectionStrategy;
+
+    LeaderElectionStrategyFactory(KinesisClientLibConfiguration config,
+                                  ILeaseManager<KinesisClientLease> leaseManager) {
+        this.config = config;
+        this.leaseManager = leaseManager;
+    }
+
+    /*
+     * Vends a singleton DeterministicShuffleLeaderElection strategy shared across different workers
+     *
+     * @see com.amazonaws.services.kinesis.clientlibrary.lib.periodicshardsync.
+     * interfaces.ILeaderElectionStrategyFactory#getLeaderElectionStrategy()
+     */
+    @Override
+    public LeaderElectionStrategy<KinesisClientLease> getLeaderElectionStrategy() {
+        if (leaderElectionStrategy == null) {
+            synchronized (this) {
+                if (leaderElectionStrategy == null) {
+                    ILeasesCache<KinesisClientLease> leasesCache = new LeasesCache(leaseManager,
+                                                                                   LEADER_ELECTION_LEASES_CACHE_TTL_MINS /* ttl */, TimeUnit.MINUTES);
+                    leaderElectionStrategy = new DeterministicShuffleLeaderElection(config, leasesCache);
+                    vendedInstanceCount++;
+                }
+            }
+        }
+        return leaderElectionStrategy;
+    }
+}

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/LeasesCache.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/LeasesCache.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates.
+ * Licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.amazonaws.services.kinesis.clientlibrary.lib.worker;
+
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+import com.amazonaws.services.kinesis.clientlibrary.lib.periodicshardsync.ILeasesCache;
+import com.amazonaws.services.kinesis.leases.exceptions.DependencyException;
+import com.amazonaws.services.kinesis.leases.exceptions.InvalidStateException;
+import com.amazonaws.services.kinesis.leases.exceptions.ProvisionedThroughputException;
+import com.amazonaws.services.kinesis.leases.impl.KinesisClientLease;
+import com.amazonaws.services.kinesis.leases.interfaces.ILeaseManager;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.google.common.util.concurrent.ExecutionError;
+import com.google.common.util.concurrent.UncheckedExecutionException;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+/**
+ * Guava cache implementation for caching the leases
+ */
+class LeasesCache implements ILeasesCache<KinesisClientLease> {
+
+    private static final Log LOG = LogFactory.getLog(LeasesCache.class);
+    private LoadingCache<String, List<KinesisClientLease>> cache;
+
+    /**
+     * @param leaseManager to interact with the leases table
+     * @param ttl time after which the cached leases expire after being written
+     *            for the first time to the cache
+     * @param timeUnit unit for ttl
+     */
+    LeasesCache(ILeaseManager<KinesisClientLease> leaseManager, int ttl, TimeUnit timeUnit) {
+        CacheLoader<String, List<KinesisClientLease>> cacheLoader = new CacheLoader<String, List<KinesisClientLease>>() {
+
+            @Override
+            public List<KinesisClientLease> load(String key)
+                    throws DependencyException, InvalidStateException, ProvisionedThroughputException {
+                return leaseManager.listLeases();
+            }
+        };
+        cache = CacheBuilder.newBuilder()
+                            .expireAfterWrite(ttl, timeUnit)
+                            .build(cacheLoader);
+    }
+
+    /*
+     * Fetches the leases from the cache. If not found, fetches from the leases
+     * table and caches it for the provided TTl
+     *
+     * @see com.amazonaws.services.kinesis.clientlibrary.lib.periodicshardsync.
+     * interfaces.ILeasesCache#getLeases(java.lang.String)
+     */
+    @Override
+    public List<KinesisClientLease> getLeases(String key) throws LeasesCacheException {
+        try {
+            return cache.get(key);
+        } catch (ExecutionException | UncheckedExecutionException | ExecutionError e) {
+            throw new LeasesCacheException("Exception occurred while trying to fetch all leases from the leases cache",
+                                           e.getCause());
+        }
+    }
+
+}

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/LeasesCacheException.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/LeasesCacheException.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates.
+ * Licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.amazonaws.services.kinesis.clientlibrary.lib.worker;
+
+/**
+ * Represents an exception thrown while fetching leases from the cache
+ */
+public class LeasesCacheException extends Exception {
+    private static final long serialVersionUID = 1L;
+
+    public LeasesCacheException(Throwable e) {
+        super(e);
+    }
+
+    public LeasesCacheException(String message, Throwable e) {
+        super(message, e);
+    }
+}

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/PeriodicShardSyncManager.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/PeriodicShardSyncManager.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates.
+ * Licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.amazonaws.services.kinesis.clientlibrary.lib.worker;
+
+import java.util.Objects;
+import java.util.Set;
+
+import com.amazonaws.services.kinesis.clientlibrary.lib.periodicshardsync.IShardSyncManager;
+import com.amazonaws.services.kinesis.clientlibrary.lib.periodicshardsync.LeaderPoller;
+import com.amazonaws.services.kinesis.clientlibrary.lib.periodicshardsync.LeadersElectionListener;
+import com.amazonaws.services.kinesis.clientlibrary.lib.periodicshardsync.TaskSchedulerStrategy;
+import com.amazonaws.services.kinesis.clientlibrary.lib.periodicshardsync.WorkerStateChangeListener;
+import com.amazonaws.services.kinesis.leases.impl.KinesisClientLease;
+import com.amazonaws.services.kinesis.metrics.interfaces.IMetricsFactory;
+import lombok.Getter;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+/**
+ * The top level orchestrator for coordinating the periodic shard sync related
+ * activities like polling for leader election, scheduling shard sync taks,
+ * responding to leader election events etc
+ */
+@Getter
+class PeriodicShardSyncManager
+        implements IShardSyncManager<KinesisClientLease>, LeadersElectionListener, WorkerStateChangeListener {
+
+    private static final Log LOG = LogFactory.getLog(PeriodicShardSyncManager.class);
+
+    private final String workerId;
+    private final IMetricsFactory metricsFactory;
+
+    private final TaskSchedulerStrategy taskSchedulerStrategy;
+    private final LeaderPoller<KinesisClientLease> leaderPoller;
+    private com.amazonaws.services.kinesis.clientlibrary.lib.worker.WorkerState workerState;
+    private boolean isRunning;
+
+    private PeriodicShardSyncManager(PeriodicShardSyncManagerBuilder builder) {
+        this.workerId = builder.workerId;
+        this.metricsFactory = builder.metricsFactory;
+
+        this.taskSchedulerStrategy = builder.taskSchedulerStrategy;
+        this.leaderPoller = builder.leaderPoller;
+        this.workerState = new IdleState(workerId, this);
+    }
+
+    static PeriodicShardSyncManagerBuilder getBuilder() {
+        return new PeriodicShardSyncManagerBuilder();
+    }
+
+    static class PeriodicShardSyncManagerBuilder {
+        private String workerId;
+        private IMetricsFactory metricsFactory;
+
+        private TaskSchedulerStrategy taskSchedulerStrategy;
+        private LeaderPoller<KinesisClientLease> leaderPoller;
+
+        private PeriodicShardSyncManagerBuilder() {
+        }
+
+        public PeriodicShardSyncManagerBuilder withTaskSchedulerStrategy(TaskSchedulerStrategy taskSchedulerStrategy) {
+            this.taskSchedulerStrategy = taskSchedulerStrategy;
+            return this;
+        }
+
+        public PeriodicShardSyncManagerBuilder withLeaderPoller(LeaderPoller<KinesisClientLease> leaderPoller) {
+            this.leaderPoller = leaderPoller;
+            return this;
+        }
+
+        public PeriodicShardSyncManagerBuilder withWorkerId(String workerId) {
+            this.workerId = workerId;
+            return this;
+        }
+
+        public PeriodicShardSyncManagerBuilder withMetricsFactory(IMetricsFactory metricsFactory) {
+            this.metricsFactory = metricsFactory;
+            return this;
+        }
+
+        public PeriodicShardSyncManager build() {
+            return new PeriodicShardSyncManager(this);
+        }
+    }
+
+    /*
+     * Starts polling for leaders
+     *
+     * @see com.amazonaws.services.kinesis.clientlibrary.lib.periodicshardsync.
+     * interfaces.IShardSyncManager#start()
+     */
+    @Override
+    public void start() {
+        if (!isRunning) {
+            leaderPoller.pollForLeaders();
+            isRunning = true;
+        }
+    }
+
+    /*
+     * callback for being notified about the new leaders election. Refreshes
+     * worker state upon being notified
+     *
+     * @see com.amazonaws.services.kinesis.clientlibrary.lib.periodicshardsync.
+     * interfaces.LeadersElectionListener#leadersElected(java.util.Set)
+     */
+    @Override
+    public synchronized void leadersElected(Set<String> newLeadersWorkerIds) {
+        LOG.info(String.format("Worker %s notified about new leaders %s", workerId, newLeadersWorkerIds));
+        workerState.refresh(newLeadersWorkerIds);
+    }
+
+    /*
+     * Inititate Leader action, in this case start periodic shard syncs
+     *
+     * @see com.amazonaws.services.kinesis.clientlibrary.lib.periodicshardsync.
+     * interfaces.WorkerStateChangeListener#startLeader()
+     */
+    @Override
+    public void startLeader() {
+        LOG.info(String.format("Worker %s is one of the elected leaders, starting periodic shard syncs ", workerId));
+        taskSchedulerStrategy.start();
+    }
+
+    /*
+     * Stop Leader action, in this case stop periodic shard syncs
+     *
+     * @see com.amazonaws.services.kinesis.clientlibrary.lib.periodicshardsync.
+     * interfaces.WorkerStateChangeListener#stopLeader()
+     */
+    @Override
+    public void stopLeader() {
+        LOG.info(String.format("Worker %s is no longer an elected leader, stopping periodic shard syncs ", workerId));
+        taskSchedulerStrategy.stop();
+    }
+
+    @Override
+    public void noOp() {
+        LOG.info(String.format("Worker %s, no change in worker state", workerId));
+    }
+
+    @Override
+    public void setWorkerState(com.amazonaws.services.kinesis.clientlibrary.lib.worker.WorkerState workerState) {
+        this.workerState = workerState;
+    }
+
+    @Override
+    public LeaderPoller<KinesisClientLease> getLeaderPoller() {
+        return leaderPoller;
+    }
+
+    @Override
+    public void stop() {
+        if (isRunning) {
+            LOG.info(String.format("Stopping the leader poller on the worker %s", workerId));
+            leaderPoller.stop();
+            LOG.info(String.format("Stopping the periodic shard sync task scheduler on the worker %s", workerId));
+            taskSchedulerStrategy.shutdown();
+            workerState = new IdleState(workerId, this);
+            isRunning = false;
+        }
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(workerId);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || obj.getClass() != getClass()) {
+            return false;
+        }
+        PeriodicShardSyncManager other = (PeriodicShardSyncManager) obj;
+
+        return Objects.equals(workerId, other.workerId);
+    }
+
+}

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/RunningState.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/RunningState.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates.
+ * Licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.amazonaws.services.kinesis.clientlibrary.lib.worker;
+
+import com.amazonaws.services.kinesis.clientlibrary.lib.periodicshardsync.WorkerStateChangeListener;
+
+/**
+ * The worker in RunningState represents that the worker is executing the
+ * periodic shard syncs.
+ */
+class RunningState extends WorkerState {
+
+    RunningState(String workerId, WorkerStateChangeListener workerStateChangeListener) {
+        this.workerId = workerId;
+        this.workerStateChangeListener = workerStateChangeListener;
+    }
+
+    /*
+     * RunningState worker shows up again as a leader, no action needed
+     *
+     * @see
+     * com.amazonaws.services.kinesis.clientlibrary.lib.periodicshardsync.impl.
+     * WorkerState#leaderStateTransition()
+     */
+    @Override
+    protected void leaderStateTransition() {
+        workerStateChangeListener.noOp();
+
+    }
+
+    /*
+     * RunningState worker shows up as a non leader implies that the worker is
+     * no longer a leader and it should stop the leader behaviour
+     *
+     * @see
+     * com.amazonaws.services.kinesis.clientlibrary.lib.periodicshardsync.impl.
+     * WorkerState#nonleaderStateTransition()
+     */
+    @Override
+    protected void nonLeaderStateTransition() {
+        workerStateChangeListener.stopLeader();
+        workerStateChangeListener.setWorkerState(new IdleState(workerId, workerStateChangeListener));
+    }
+
+}

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ScheduledLeaseLeaderPoller.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ScheduledLeaseLeaderPoller.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates.
+ * Licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.amazonaws.services.kinesis.clientlibrary.lib.worker;
+
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+import com.amazonaws.services.kinesis.clientlibrary.lib.periodicshardsync.LeaderElectionStrategy;
+import com.amazonaws.services.kinesis.clientlibrary.lib.periodicshardsync.LeaderPoller;
+import com.amazonaws.services.kinesis.leases.impl.KinesisClientLease;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+/**
+ * Leader Poller implementation polling for the leaders as per the config values
+ * for frequency and concurrency
+ *
+ */
+class ScheduledLeaseLeaderPoller implements LeaderPoller<KinesisClientLease> {
+
+    private final LeaderElectionStrategy<KinesisClientLease> leaderElectionStrategy;
+    private final KinesisClientLibConfiguration config;
+    private final ScheduledThreadPoolExecutor scheduledExecutor;
+
+    private static final Log LOG = LogFactory.getLog(ScheduledLeaseLeaderPoller.class);
+    // Setting the initial delay to a minute so that the lease taker as part of
+    // the initialize step runs and the shards(leases) are assigned owners
+    private static final int POLLER_INITIAL_DELAY_MINS = 1;
+    private static final int AWAIT_TERMINATION_SECS = 5;
+    private static final int PERIODIC_SHARD_SYNC_LEADER_POLLER_FREQUENCY_IN_MINS = 5;
+
+    ScheduledLeaseLeaderPoller(LeaderElectionStrategy<KinesisClientLease> leaderElectionStrategy,
+                               KinesisClientLibConfiguration config, ScheduledThreadPoolExecutor scheduledThreadPoolExecutor) {
+        this.leaderElectionStrategy = leaderElectionStrategy;
+        this.config = config;
+        this.scheduledExecutor = scheduledThreadPoolExecutor;
+    }
+
+    @Override
+    public void pollForLeaders() {
+        scheduledExecutor.scheduleWithFixedDelay(leaderElectionStrategy, POLLER_INITIAL_DELAY_MINS,
+                                                 PERIODIC_SHARD_SYNC_LEADER_POLLER_FREQUENCY_IN_MINS, TimeUnit.MINUTES);
+    }
+
+    @Override
+    public LeaderElectionStrategy<KinesisClientLease> getLeaderElectionStrategy() {
+        return leaderElectionStrategy;
+    }
+
+    @Override
+    public synchronized void stop() {
+        try {
+            scheduledExecutor.shutdown();
+            if (scheduledExecutor.awaitTermination(AWAIT_TERMINATION_SECS, TimeUnit.SECONDS)) {
+                LOG.info("Successfully stopped leader polling threads on the worker");
+            } else {
+                scheduledExecutor.shutdownNow();
+                LOG.info(String.format("Stopped leader polling threads after awaiting termination for %d seconds",
+                                       AWAIT_TERMINATION_SECS));
+            }
+        } catch (InterruptedException e) {
+            LOG.debug("Encountered InterruptedException while awaiting leader polling threadpool termination");
+        }
+    }
+}

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardConsumer.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardConsumer.java
@@ -64,7 +64,8 @@ class ShardConsumer {
     private ITask currentTask;
     private long currentTaskSubmitTime;
     private Future<TaskResult> future;
-
+    private ShardSyncStrategy shardSyncStrategy;
+    
     @Getter
     private final GetRecordsCache getRecordsCache;
 
@@ -117,7 +118,7 @@ class ShardConsumer {
             long backoffTimeMillis,
             boolean skipShardSyncAtWorkerInitializationIfLeasesExist,
             KinesisClientLibConfiguration config,
-            ShardSyncer shardSyncer) {
+            ShardSyncer shardSyncer, ShardSyncStrategy shardSyncStrategy) {
         this(shardInfo,
                 streamConfig,
                 checkpoint,
@@ -132,7 +133,7 @@ class ShardConsumer {
                 Optional.empty(),
                 Optional.empty(),
                 config,
-                shardSyncer);
+                shardSyncer, shardSyncStrategy);
     }
 
     /**
@@ -165,8 +166,7 @@ class ShardConsumer {
             Optional<Integer> retryGetRecordsInSeconds,
             Optional<Integer> maxGetRecordsThreadPool,
             KinesisClientLibConfiguration config,
-            ShardSyncer shardSyncer) {
-
+            ShardSyncer shardSyncer, ShardSyncStrategy shardSyncStrategy) {
         this(
                 shardInfo,
                 streamConfig,
@@ -191,7 +191,7 @@ class ShardConsumer {
                 retryGetRecordsInSeconds,
                 maxGetRecordsThreadPool,
                 config,
-                shardSyncer
+                shardSyncer, shardSyncStrategy
         );
     }
 
@@ -230,7 +230,7 @@ class ShardConsumer {
             Optional<Integer> retryGetRecordsInSeconds,
             Optional<Integer> maxGetRecordsThreadPool,
             KinesisClientLibConfiguration config,
-            ShardSyncer shardSyncer) {
+            ShardSyncer shardSyncer, ShardSyncStrategy shardSyncStrategy) {
         this.shardInfo = shardInfo;
         this.streamConfig = streamConfig;
         this.checkpoint = checkpoint;
@@ -249,6 +249,7 @@ class ShardConsumer {
                 makeStrategy(this.dataFetcher, retryGetRecordsInSeconds, maxGetRecordsThreadPool, this.shardInfo),
                 this.getShardInfo().getShardId(), this.metricsFactory, this.config.getMaxRecords());
         this.shardSyncer = shardSyncer;
+        this.shardSyncStrategy = shardSyncStrategy;
     }
 
     /**
@@ -511,5 +512,9 @@ class ShardConsumer {
 
     ShutdownNotification getShutdownNotification() {
         return shutdownNotification;
+    }
+
+    ShardSyncStrategy getShardSyncStrategy() {
+        return shardSyncStrategy;
     }
 }

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardSyncStrategy.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardSyncStrategy.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates.
+ * Licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.amazonaws.services.kinesis.clientlibrary.lib.worker;
+
+/**
+ * Strategy for ShardSyncs. Can be either of the ones mentioned below.
+ *
+ */
+public enum ShardSyncStrategy {
+    PERIODIC, // Sync shards periodically in the background
+    SHARD_END // Sync shards on encountering shard ends while processing the shards
+}

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardSyncStrategyDecider.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardSyncStrategyDecider.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates.
+ * Licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.amazonaws.services.kinesis.clientlibrary.lib.worker;
+
+/**
+ * Interface to decide the {@code ShardSyncStrategy}
+ *
+ */
+public interface ShardSyncStrategyDecider {
+    /**
+     * @return Returns the decided ShardSyncStrategy
+     * @throws Exception
+     */
+    ShardSyncStrategy getShardSyncStrategy() throws Exception;
+}

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardSyncTask.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardSyncTask.java
@@ -27,7 +27,7 @@ import com.amazonaws.services.kinesis.leases.interfaces.ILeaseManager;
  * It will clean up leases/activities for shards that have been completely processed (if
  * cleanupLeasesUponShardCompletion is true).
  */
-class ShardSyncTask implements ITask {
+class ShardSyncTask implements ITask, Runnable {
 
     private static final Log LOG = LogFactory.getLog(ShardSyncTask.class);
 
@@ -100,4 +100,8 @@ class ShardSyncTask implements ITask {
         return taskType;
     }
 
+    @Override
+    public void run() {
+        call();
+    }
 }

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShutdownTask.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShutdownTask.java
@@ -49,6 +49,7 @@ class ShutdownTask implements ITask {
     private final long backoffTimeMillis;
     private final GetRecordsCache getRecordsCache;
     private final ShardSyncer shardSyncer;
+    private final ShardSyncStrategy shardSyncStrategy;
 
     /**
      * Constructor.
@@ -65,7 +66,7 @@ class ShutdownTask implements ITask {
             ILeaseManager<KinesisClientLease> leaseManager,
             long backoffTimeMillis,
             GetRecordsCache getRecordsCache,
-            ShardSyncer shardSyncer) {
+            ShardSyncer shardSyncer, ShardSyncStrategy shardSyncStrategy) {
         this.shardInfo = shardInfo;
         this.recordProcessor = recordProcessor;
         this.recordProcessorCheckpointer = recordProcessorCheckpointer;
@@ -78,6 +79,7 @@ class ShutdownTask implements ITask {
         this.backoffTimeMillis = backoffTimeMillis;
         this.getRecordsCache = getRecordsCache;
         this.shardSyncer = shardSyncer;
+        this.shardSyncStrategy = shardSyncStrategy;
     }
 
     /*
@@ -127,7 +129,7 @@ class ShutdownTask implements ITask {
                         MetricsLevel.SUMMARY);
             }
 
-            if (reason == ShutdownReason.TERMINATE) {
+            if (reason == ShutdownReason.TERMINATE && ShardSyncStrategy.SHARD_END.equals(shardSyncStrategy)) {
                 LOG.debug("Looking for child shards of shard " + shardInfo.getShardId());
                 // create leases for the child shards
                 shardSyncer.checkAndCreateLeasesForNewShards(kinesisProxy,

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/WorkerState.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/WorkerState.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates.
+ * Licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.amazonaws.services.kinesis.clientlibrary.lib.worker;
+
+import java.util.Set;
+
+import com.amazonaws.services.kinesis.clientlibrary.lib.periodicshardsync.WorkerStateChangeListener;
+import com.amazonaws.util.CollectionUtils;
+
+/**
+ * Concrete WorkerState implementations represent the current state the worker
+ * is in. Each state has its own behaviour for leader/non leader state
+ * transition
+ */
+public abstract class WorkerState {
+    protected String workerId;
+    protected WorkerStateChangeListener workerStateChangeListener;
+
+    /**
+     * @param newLeaders current list of leaders
+     * @return returns <code>true</code> if the worker is one of the leaders else <code>false</code>
+     */
+    protected boolean isLeaderWorker(Set<String> newLeaders) {
+        if(CollectionUtils.isNullOrEmpty(newLeaders) || !newLeaders.contains(workerId)) {
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Refreshes the state based on the worker being a leader or not
+     *
+     * @param newLeaders
+     *            current list of leaders
+     */
+    protected void refresh(Set<String> newLeaders) {
+        if (isLeaderWorker(newLeaders)) {
+            leaderStateTransition();
+            return;
+        }
+        nonLeaderStateTransition();
+    }
+
+    protected abstract void leaderStateTransition();
+
+    protected abstract void nonLeaderStateTransition();
+}

--- a/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ActiveShardCountBasedShardSyncStrategyDeciderTest.java
+++ b/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ActiveShardCountBasedShardSyncStrategyDeciderTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates.
+ * Licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.amazonaws.services.kinesis.clientlibrary.lib.worker;
+
+import static com.amazonaws.services.kinesis.clientlibrary.lib.worker.ActiveShardCountBasedShardSyncStrategyDecider.MIN_ACTIVE_SHARDS_FOR_PERIODIC_SYNC;
+
+import static org.junit.Assert.assertEquals;
+
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import com.amazonaws.services.kinesis.leases.impl.KinesisClientLease;
+import com.amazonaws.services.kinesis.leases.interfaces.ILeaseManager;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ActiveShardCountBasedShardSyncStrategyDeciderTest extends PeriodicShardSyncTestBase {
+    @Mock
+    private ILeaseManager<KinesisClientLease> leaseManager;
+
+    @Test
+    public void testShardEndStrategyResultReturnedWhenActiveLeasesLessThanRequired()
+            throws Exception {
+        List<KinesisClientLease> leases = getLeases(MIN_ACTIVE_SHARDS_FOR_PERIODIC_SYNC - 1,
+                false /* duplicateLeaseOwner */, true /* activeLeases */);
+        when(leaseManager.listLeases()).thenReturn(leases);
+        ShardSyncStrategyDecider shardSyncStrategyDecider = new ActiveShardCountBasedShardSyncStrategyDecider(leaseManager);
+        ShardSyncStrategy actualShardSyncStrategy = shardSyncStrategyDecider.getShardSyncStrategy();
+        assertEquals(String.format("%s Shard sync strategy expected", ShardSyncStrategy.SHARD_END.toString()), ShardSyncStrategy.SHARD_END,
+                actualShardSyncStrategy);
+    }
+
+    @Test
+    public void testPeriodicStrategyResultReturnedWhenActiveLeasesGreaterThanRequired() throws Exception {
+        List<KinesisClientLease> leases = getLeases(MIN_ACTIVE_SHARDS_FOR_PERIODIC_SYNC + 1,
+                false /* duplicateLeaseOwner */, true /* activeLeases */);
+        when(leaseManager.listLeases()).thenReturn(leases);
+        ShardSyncStrategyDecider shardSyncStrategyDecider = new ActiveShardCountBasedShardSyncStrategyDecider(
+                leaseManager);
+        ShardSyncStrategy actualShardSyncStrategy = shardSyncStrategyDecider.getShardSyncStrategy();
+        assertEquals(String.format("%s Shard sync strategy expected", ShardSyncStrategy.PERIODIC.toString()),
+                ShardSyncStrategy.PERIODIC, actualShardSyncStrategy);
+    }
+
+    @Test
+    public void testPeriodicStrategyResultReturnedWhenActiveLeasesEqualToRequired() throws Exception {
+        List<KinesisClientLease> leases = getLeases(MIN_ACTIVE_SHARDS_FOR_PERIODIC_SYNC,
+                false /* duplicateLeaseOwner */, true /* activeLeases */);
+        when(leaseManager.listLeases()).thenReturn(leases);
+        ShardSyncStrategyDecider shardSyncStrategyDecider = new ActiveShardCountBasedShardSyncStrategyDecider(
+                leaseManager);
+        ShardSyncStrategy actualShardSyncStrategy = shardSyncStrategyDecider.getShardSyncStrategy();
+        assertEquals(String.format("%s Shard sync strategy expected", ShardSyncStrategy.PERIODIC.toString()),
+                ShardSyncStrategy.PERIODIC, actualShardSyncStrategy);
+    }
+
+
+}

--- a/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ConfigBasedPeriodicSyncSchedulerTest.java
+++ b/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ConfigBasedPeriodicSyncSchedulerTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates.
+ * Licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.amazonaws.services.kinesis.clientlibrary.lib.worker;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyLong;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+import com.amazonaws.services.kinesis.clientlibrary.proxies.IKinesisProxy;
+import com.amazonaws.services.kinesis.leases.impl.KinesisClientLease;
+import com.amazonaws.services.kinesis.leases.interfaces.ILeaseManager;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ConfigBasedPeriodicSyncSchedulerTest {
+    @Mock
+    private IKinesisProxy kinesisProxy;
+    @Mock
+    private ILeaseManager<KinesisClientLease> leaseManager;
+    @Mock
+    private InitialPositionInStreamExtended initialPosition;
+    @Mock
+    private KinesisClientLibConfiguration config;
+    @Mock
+    private ScheduledThreadPoolExecutor scheduledExecutor;
+    @Mock
+    private ShardSyncer shardSyncer;
+    
+    @Test
+    public void testStartSchedulesTask() {
+        ConfigBasedPeriodicSyncScheduler scheduler = spy(new ConfigBasedPeriodicSyncScheduler(kinesisProxy,
+                leaseManager, initialPosition, config, scheduledExecutor, shardSyncer));
+        scheduler.start();
+        verify(scheduler, times(1)).scheduleTask(any(ShardSyncTask.class));
+        verify(scheduledExecutor, times(1)).scheduleAtFixedRate(any(ShardSyncTask.class), anyLong(), anyLong(),
+                any(TimeUnit.class));
+    }
+
+    @Test
+    public void testShutdownWithAwaitTerminationTrue() throws InterruptedException {
+        ConfigBasedPeriodicSyncScheduler scheduler = spy(new ConfigBasedPeriodicSyncScheduler(kinesisProxy,
+                leaseManager, initialPosition, config, scheduledExecutor, shardSyncer));
+        when(scheduledExecutor.awaitTermination(anyLong(), any(TimeUnit.class))).thenReturn(true);
+        scheduler.start();
+        verify(scheduler, times(1)).scheduleTask(any(ShardSyncTask.class));
+        scheduler.shutdown();
+        verify(scheduledExecutor, times(1)).shutdown();
+        verify(scheduledExecutor, times(0)).shutdownNow();
+    }
+
+    @Test
+    public void testShutdownWithAwaitTerminationFalse() throws InterruptedException {
+        ConfigBasedPeriodicSyncScheduler scheduler = spy(new ConfigBasedPeriodicSyncScheduler(kinesisProxy,
+                leaseManager, initialPosition, config, scheduledExecutor, shardSyncer));
+        when(scheduledExecutor.awaitTermination(anyLong(), any(TimeUnit.class))).thenReturn(false);
+        scheduler.start();
+        verify(scheduler, times(1)).scheduleTask(any(ShardSyncTask.class));
+        scheduler.shutdown();
+        verify(scheduledExecutor, times(1)).shutdown();
+        verify(scheduledExecutor, times(1)).shutdownNow();
+    }
+}

--- a/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/DeterministicShuffleLeaderElectionTest.java
+++ b/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/DeterministicShuffleLeaderElectionTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates.
+ * Licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.amazonaws.services.kinesis.clientlibrary.lib.worker;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import com.amazonaws.services.kinesis.clientlibrary.lib.periodicshardsync.ILeasesCache;
+import com.amazonaws.services.kinesis.clientlibrary.lib.periodicshardsync.LeadersElectionListener;
+import com.amazonaws.services.kinesis.leases.impl.KinesisClientLease;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DeterministicShuffleLeaderElectionTest extends PeriodicShardSyncTestBase {
+    private static final Log LOG = LogFactory.getLog(DeterministicShuffleLeaderElectionTest.class);
+
+    private KinesisClientLibConfiguration config;
+    @Mock
+    private Set<LeadersElectionListener> leadersElectionListeners;
+    @Mock
+    private ILeasesCache<KinesisClientLease> leasesCache;
+
+    @Before
+    public void setup() {
+        config = spy(new KinesisClientLibConfiguration("Test", null, null, null));
+    }
+
+    @Test
+    public void testLeaderElectionWithNullLeases() {
+        DeterministicShuffleLeaderElection leaderElection = new DeterministicShuffleLeaderElection(config, leasesCache);
+        Set<String> leaders = leaderElection.electLeaders(null);
+        assertTrue("Leaders should not be null", leaders != null);
+        assertTrue("Leaders should be empty", leaders.isEmpty());
+    }
+
+    @Test
+    public void testLeaderElectionWithEmptyLeases() {
+        DeterministicShuffleLeaderElection leaderElection = new DeterministicShuffleLeaderElection(config, leasesCache);
+        Set<String> leaders = leaderElection.electLeaders(new ArrayList<KinesisClientLease>());
+        assertTrue("Leaders should not be null", leaders != null);
+        assertTrue("Leaders should be empty", leaders.isEmpty());
+    }
+
+    @Test
+    public void testElectedLeadersAsPerExpectedShufflingOrder() {
+        DeterministicShuffleLeaderElection leaderElection = new DeterministicShuffleLeaderElection(config, leasesCache);
+        List<KinesisClientLease> leases = getLeases(5, false /* duplicateLeaseOwner */, true /* activeLeases */);
+        Set<String> actualLeaders = leaderElection.electLeaders(leases);
+        Collections.shuffle(leases,
+                new Random(DeterministicShuffleLeaderElection.DETERMINISTIC_SHUFFLE_SEED));
+        Set<String> expectedLeaders = leases.stream().map(lease -> lease.getLeaseOwner()).collect(Collectors.toSet());
+
+        assertEquals("Expected and actual leaders are not same", expectedLeaders, actualLeaders);
+    }
+
+    public void testElectedLeadersAsPerExpectedShufflingOrderWhenUniqueWorkersLessThanMaxLeaders() {
+        DeterministicShuffleLeaderElection leaderElection = new DeterministicShuffleLeaderElection(config, leasesCache);
+        List<KinesisClientLease> leases = getLeases(3, false /* duplicateLeaseOwner */, true /* activeLeases */);
+        Set<String> actualLeaders = leaderElection.electLeaders(leases);
+
+        Collections.shuffle(leases, new Random(DeterministicShuffleLeaderElection.DETERMINISTIC_SHUFFLE_SEED));
+        Set<String> expectedLeaders = leases.stream().limit(3).map(lease -> lease.getLeaseOwner())
+                .collect(Collectors.toSet());
+
+        assertEquals("Expected and actual leaders are not same", expectedLeaders, actualLeaders);
+    }
+
+    public void testSingleLeaderElectedForLeasesWithSameOwner() {
+        DeterministicShuffleLeaderElection leaderElection = new DeterministicShuffleLeaderElection(config, leasesCache);
+        List<KinesisClientLease> leases = getLeases(3, true /* duplicateLeaseOwner */, true /* activeLeases */);
+        Set<String> actualLeaders = leaderElection.electLeaders(leases);
+
+        Collections.shuffle(leases, new Random(DeterministicShuffleLeaderElection.DETERMINISTIC_SHUFFLE_SEED));
+        Set<String> expectedLeaders = leases.stream().map(lease -> lease.getLeaseOwner())
+                .collect(Collectors.toSet());
+
+        assertEquals("Expected and actual leaders are not same", expectedLeaders, actualLeaders);
+    }
+}

--- a/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/IdleStateTest.java
+++ b/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/IdleStateTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates.
+ * Licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.amazonaws.services.kinesis.clientlibrary.lib.worker;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.util.Arrays;
+import java.util.HashSet;
+
+import com.amazonaws.services.kinesis.clientlibrary.lib.periodicshardsync.WorkerStateChangeListener;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class IdleStateTest {
+
+    private static final String WORKER_ID = "test_worker_id";
+
+    @Mock
+    WorkerStateChangeListener workerStateChangeListener;
+
+    @Test
+    public void testWorkerStateChangeListenerBehaviourOnLeaderStateTransition() {
+        IdleState idleState = new IdleState(WORKER_ID, workerStateChangeListener);
+        idleState.leaderStateTransition();
+        verify(workerStateChangeListener, times(1)).startLeader();
+        ArgumentCaptor<WorkerState> workerStateArgumentCaptor = ArgumentCaptor.forClass(WorkerState.class);
+        verify(workerStateChangeListener, times(1)).setWorkerState(workerStateArgumentCaptor.capture());
+        
+        WorkerState actualWorkerState = workerStateArgumentCaptor.getValue();
+        
+        assertTrue("New WorkerState should be RunningState", actualWorkerState instanceof RunningState);
+        assertEquals("Workerid doesn't match", WORKER_ID, actualWorkerState.workerId);
+        assertEquals(workerStateChangeListener, actualWorkerState.workerStateChangeListener);
+    }
+
+    @Test
+    public void testWorkerStateChangeListenerBehaviourOnNonLeaderStateTransition() {
+        IdleState idleState = new IdleState(WORKER_ID, workerStateChangeListener);
+        idleState.nonLeaderStateTransition();
+        verify(workerStateChangeListener, times(1)).noOp();
+        verify(workerStateChangeListener, times(0)).setWorkerState(any(WorkerState.class));
+    }
+
+    @Test
+    public void testIsLeader() {
+        IdleState idleState = new IdleState(WORKER_ID, workerStateChangeListener);
+        boolean actualIsLeaderWorker = idleState
+                .isLeaderWorker(new HashSet<String>(Arrays.asList("1", "2", WORKER_ID, "4")));
+        assertTrue(String.format("%s is a leader", WORKER_ID), actualIsLeaderWorker);
+    }
+
+    @Test
+    public void testIsLeaderWithEmptyNewLeaders() {
+        IdleState idleState = new IdleState(WORKER_ID, workerStateChangeListener);
+        boolean actualIsLeaderWorker = idleState
+                .isLeaderWorker(new HashSet<String>());
+        assertTrue(String.format("%s is not a leader", WORKER_ID), !actualIsLeaderWorker);
+    }
+
+    @Test
+    public void testIsLeaderWithNullNewLeaders() {
+        IdleState idleState = new IdleState(WORKER_ID, workerStateChangeListener);
+        boolean actualIsLeaderWorker = idleState.isLeaderWorker(null);
+        assertTrue(String.format("%s is not a leader", WORKER_ID), !actualIsLeaderWorker);
+    }
+
+    @Test
+    public void testLeaderRefresh() {
+        IdleState idleState = spy(new IdleState(WORKER_ID, workerStateChangeListener));
+        idleState.refresh(new HashSet<String>(Arrays.asList("1", "2", WORKER_ID, "4")));
+        verify(idleState, times(1)).leaderStateTransition();
+        verify(idleState, times(0)).nonLeaderStateTransition();
+    }
+
+    @Test
+    public void testNonLeaderRefresh() {
+        IdleState idleState = spy(new IdleState(WORKER_ID, workerStateChangeListener));
+        idleState.refresh(new HashSet<String>(Arrays.asList("1", "2", "3", "4")));
+        verify(idleState, times(1)).nonLeaderStateTransition();
+        verify(idleState, times(0)).leaderStateTransition();
+    }
+}

--- a/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/LeaderElectionStrategyFactoryTest.java
+++ b/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/LeaderElectionStrategyFactoryTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates.
+ * Licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.amazonaws.services.kinesis.clientlibrary.lib.worker;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
+
+import com.amazonaws.services.kinesis.leases.impl.KinesisClientLease;
+import com.amazonaws.services.kinesis.leases.interfaces.ILeaseManager;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class LeaderElectionStrategyFactoryTest {
+
+    @Mock
+    private ILeaseManager<KinesisClientLease> leaseManager;
+    @Mock
+    private KinesisClientLibConfiguration config;
+
+    LeaderElectionStrategyFactory factory;
+
+    @Before
+    public void setup() {
+        factory = new LeaderElectionStrategyFactory(config, leaseManager);
+    }
+
+    @Test
+    public void testStrategyTypeCreatedByFactory() {
+        assertTrue("LeaderElectionStrategyFactory should vend DeterministicShuffleLeaderElection instance",
+                factory.getLeaderElectionStrategy() instanceof DeterministicShuffleLeaderElection);
+    }
+
+    @Test
+    public void testSingletonInstanceVendedByFactory() throws InterruptedException {
+        Thread t1 = new Thread(new Runnable() {
+            public void run() {
+                factory.getLeaderElectionStrategy();
+            }
+        });
+
+        Thread t2 = new Thread(new Runnable() {
+            public void run() {
+                factory.getLeaderElectionStrategy();
+            }
+        });
+
+        t1.run();
+        t2.run();
+        t1.join(5);
+        t2.join(5);
+
+        assertEquals("LeaderElectionStrategyFactory must vend singleton LeaderElectionStrategy instance",
+                factory.vendedInstanceCount, 1);
+
+    }
+}

--- a/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/LeasesCacheTest.java
+++ b/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/LeasesCacheTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates.
+ * Licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.amazonaws.services.kinesis.clientlibrary.lib.worker;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import com.amazonaws.services.kinesis.clientlibrary.lib.periodicshardsync.ILeasesCache;
+import com.amazonaws.services.kinesis.leases.exceptions.DependencyException;
+import com.amazonaws.services.kinesis.leases.exceptions.InvalidStateException;
+import com.amazonaws.services.kinesis.leases.exceptions.ProvisionedThroughputException;
+import com.amazonaws.services.kinesis.leases.impl.KinesisClientLease;
+import com.amazonaws.services.kinesis.leases.interfaces.ILeaseManager;
+import org.hamcrest.core.IsInstanceOf;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class LeasesCacheTest extends PeriodicShardSyncTestBase {
+
+    private static final int TTL = 10;
+    private static final int SHORTER_TTL = 1;
+    private static final TimeUnit TTL_TIME_UNIT = TimeUnit.MILLISECONDS;
+
+    @Mock
+    ILeaseManager<KinesisClientLease> leaseManager;
+    
+    @Rule
+    public ExpectedException exceptionRule = ExpectedException.none();
+
+    @Test
+    public void testDependencyExceptionFromLeaseManager() throws Exception {
+        when(leaseManager.listLeases()).thenThrow(DependencyException.class);
+        exceptionRule.expect(LeasesCacheException.class);
+        exceptionRule.expectCause(IsInstanceOf.<Throwable> instanceOf(DependencyException.class));
+        ILeasesCache<KinesisClientLease> leasesCache = new LeasesCache(leaseManager, TTL, TTL_TIME_UNIT);
+        leasesCache.getLeases(DeterministicShuffleLeaderElection.LEAES_CACHE_KEY);
+    }
+
+    @Test
+    public void testInvalidStateExceptionFromLeaseManager() throws Exception {
+        when(leaseManager.listLeases()).thenThrow(InvalidStateException.class);
+        exceptionRule.expect(LeasesCacheException.class);
+        exceptionRule.expectCause(IsInstanceOf.<Throwable> instanceOf(InvalidStateException.class));
+        ILeasesCache<KinesisClientLease> leasesCache = new LeasesCache(leaseManager, TTL, TTL_TIME_UNIT);
+        leasesCache.getLeases(DeterministicShuffleLeaderElection.LEAES_CACHE_KEY);
+    }
+
+    @Test
+    public void testProvisionedThroughputExceptionFromLeaseManager() throws Exception {
+        when(leaseManager.listLeases()).thenThrow(ProvisionedThroughputException.class);
+        exceptionRule.expect(LeasesCacheException.class);
+        exceptionRule.expectCause(IsInstanceOf.<Throwable> instanceOf(ProvisionedThroughputException.class));
+        ILeasesCache<KinesisClientLease> leasesCache = new LeasesCache(leaseManager, TTL, TTL_TIME_UNIT);
+        leasesCache.getLeases(DeterministicShuffleLeaderElection.LEAES_CACHE_KEY);
+    }
+
+    @Test
+    public void testCacheMiss() throws Exception {
+        List<KinesisClientLease> expectedLeases = getLeases(5, false /* duplicateLeaseOwner */,
+                true /* activeLeases */);
+        when(leaseManager.listLeases()).thenReturn(expectedLeases);
+        ILeasesCache<KinesisClientLease> leasesCache = new LeasesCache(leaseManager, TTL, TTL_TIME_UNIT);
+
+        List<KinesisClientLease> actualLeases;
+        actualLeases = leasesCache.getLeases(DeterministicShuffleLeaderElection.LEAES_CACHE_KEY);
+        assertEquals("Expected and Actual leases are not equal", expectedLeases, actualLeases);
+
+        // verify cached value used and lease manger not invoked. 1 list leases
+        // call from the previous getLeases invocation
+        actualLeases = leasesCache.getLeases(DeterministicShuffleLeaderElection.LEAES_CACHE_KEY);
+        assertEquals("Expected and Actual leases are not equal", expectedLeases, actualLeases);
+        verify(leaseManager, times(1)).listLeases();
+    }
+
+    @Test
+    public void testCachedvalueExpiresAfterTTL() throws Exception {
+        List<KinesisClientLease> expectedLeases = getLeases(5, false /* duplicateLeaseOwner */,
+                true /* activeLeases */);
+        when(leaseManager.listLeases()).thenReturn(expectedLeases);
+        ILeasesCache<KinesisClientLease> leasesCache = new LeasesCache(leaseManager, SHORTER_TTL, TTL_TIME_UNIT);
+
+        List<KinesisClientLease> actualLeases;
+        actualLeases = leasesCache.getLeases(DeterministicShuffleLeaderElection.LEAES_CACHE_KEY);
+        assertEquals("Expected and Actual leases are not equal", expectedLeases, actualLeases);
+
+        // Sleep so that the next cache access is after the cache ttl passes and
+        // the cached entry is expired
+        Thread.sleep(SHORTER_TTL);
+        actualLeases = leasesCache.getLeases(DeterministicShuffleLeaderElection.LEAES_CACHE_KEY);
+        assertEquals("Expected and Actual leases are not equal", expectedLeases, actualLeases);
+        verify(leaseManager, times(2)).listLeases();
+
+    }
+
+}

--- a/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/PeriodicShardSyncManagerTest.java
+++ b/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/PeriodicShardSyncManagerTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates.
+ * Licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.amazonaws.services.kinesis.clientlibrary.lib.worker;
+
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+import com.amazonaws.services.kinesis.clientlibrary.lib.periodicshardsync.LeaderPoller;
+import com.amazonaws.services.kinesis.clientlibrary.lib.periodicshardsync.TaskSchedulerStrategy;
+import com.amazonaws.services.kinesis.leases.impl.KinesisClientLease;
+import com.amazonaws.services.kinesis.metrics.interfaces.IMetricsFactory;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class PeriodicShardSyncManagerTest {
+
+    private static final String WORKER_ID = "test_worker_id";
+    @Mock
+    private IMetricsFactory metricsFactory;
+    @Mock
+    private TaskSchedulerStrategy taskSchedulerStrategy;
+    @Mock
+    private LeaderPoller<KinesisClientLease> leaderPoller;
+    
+    @Before
+    public void setup() {
+    }
+    
+    public PeriodicShardSyncManager getPeriodicShardSyncManager() {
+        PeriodicShardSyncManager periodicShardSyncManager = PeriodicShardSyncManager.getBuilder().withLeaderPoller(leaderPoller).withMetricsFactory(metricsFactory)
+                .withTaskSchedulerStrategy(taskSchedulerStrategy).withWorkerId(WORKER_ID).build();
+        return periodicShardSyncManager;
+    }
+
+    @Test
+    public void testPollingStarts() {
+        PeriodicShardSyncManager periodicShardSyncManager = getPeriodicShardSyncManager();
+        periodicShardSyncManager.start();
+        assertTrue("isRunning should be true", periodicShardSyncManager.isRunning());
+        verify(leaderPoller, times(1)).pollForLeaders();
+    }
+
+    @Test
+    public void testPollingNotRestartedIfAlreadyRunnig() {
+        PeriodicShardSyncManager periodicShardSyncManager = getPeriodicShardSyncManager();
+        periodicShardSyncManager.start();
+        assertTrue("isRunning should be true", periodicShardSyncManager.isRunning());
+        verify(leaderPoller, times(1)).pollForLeaders();
+
+        periodicShardSyncManager.start();
+        assertTrue("isRunning should be true", periodicShardSyncManager.isRunning());
+        // 1 accounts for the previous invocation
+        verify(leaderPoller, times(1)).pollForLeaders();
+    }
+
+    @Test
+    public void testPollerAndTaskSchedulerStop() {
+        PeriodicShardSyncManager periodicShardSyncManager = getPeriodicShardSyncManager();
+        periodicShardSyncManager.start();
+        assertTrue("isRunning should be true", periodicShardSyncManager.isRunning());
+        verify(leaderPoller, times(1)).pollForLeaders();
+
+        periodicShardSyncManager.stop();
+        assertTrue("isRunning should be false", !periodicShardSyncManager.isRunning());
+        verify(leaderPoller, times(1)).stop();
+        verify(taskSchedulerStrategy, times(1)).shutdown();
+    }
+
+    @Test
+    public void testPollerAndTaskSchedulerNotStoppedIfShardSyncManagerNotAlreadyRunning() {
+        PeriodicShardSyncManager periodicShardSyncManager = getPeriodicShardSyncManager();
+        periodicShardSyncManager.stop();
+        assertTrue("isRunning should be false", !periodicShardSyncManager.isRunning());
+        verify(leaderPoller, times(0)).stop();
+        verify(taskSchedulerStrategy, times(0)).stop();
+    }
+
+    @Test
+    public void testStartLeaderUponLeaderElection() {
+        PeriodicShardSyncManager periodicShardSyncManager = getPeriodicShardSyncManager();
+        Set<String> newLeaders = new HashSet<String>(Arrays.asList("1", "2", WORKER_ID, "4"));
+        periodicShardSyncManager.leadersElected(newLeaders);
+        assertTrue("Running worker state expected", periodicShardSyncManager.getWorkerState() instanceof RunningState);
+    }
+
+    @Test
+    public void testStopLeaderUponLeaderElection() {
+        PeriodicShardSyncManager periodicShardSyncManager = getPeriodicShardSyncManager();
+        Set<String> newLeaders = new HashSet<String>(Arrays.asList("1", "2", "3", "4"));
+        periodicShardSyncManager.leadersElected(newLeaders);
+        assertTrue("Idle worker state expected", periodicShardSyncManager.getWorkerState() instanceof IdleState);
+    }
+
+    @Test
+    public void testStartLeaderStartsTaskScheduling() {
+        PeriodicShardSyncManager periodicShardSyncManager = getPeriodicShardSyncManager();
+        periodicShardSyncManager.startLeader();
+        verify(taskSchedulerStrategy, times(1)).start();
+    }
+
+    @Test
+    public void testStopLeaderStopsTaskScheduling() {
+        PeriodicShardSyncManager periodicShardSyncManager = getPeriodicShardSyncManager();
+        periodicShardSyncManager.startLeader();
+        verify(taskSchedulerStrategy, times(1)).start();
+
+        periodicShardSyncManager.stopLeader();
+        verify(taskSchedulerStrategy, times(1)).stop();
+    }
+
+}

--- a/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/PeriodicShardSyncTestBase.java
+++ b/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/PeriodicShardSyncTestBase.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates.
+ * Licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.amazonaws.services.kinesis.clientlibrary.lib.worker;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+import com.amazonaws.services.kinesis.clientlibrary.types.ExtendedSequenceNumber;
+import com.amazonaws.services.kinesis.leases.impl.KinesisClientLease;
+
+public class PeriodicShardSyncTestBase {
+
+    private static final String LEASE_KEY = "lease_key";
+    private static final String LEASE_OWNER = "lease_owner";
+
+    protected List<KinesisClientLease> getLeases(int count, boolean duplicateLeaseOwner, boolean activeLeases) {
+        List<KinesisClientLease> leases = new ArrayList<KinesisClientLease>();
+        for (int i=0;i<count;i++) {
+            KinesisClientLease lease = new KinesisClientLease();
+            lease.setLeaseKey(LEASE_KEY + i);
+            lease.setCheckpoint(activeLeases ? ExtendedSequenceNumber.LATEST : ExtendedSequenceNumber.SHARD_END);
+            lease.setLeaseCounter(new Random().nextLong());
+            lease.setLeaseOwner(LEASE_OWNER + (duplicateLeaseOwner ? "" : i));
+            leases.add(lease);
+        }
+        return leases;
+    }
+}

--- a/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/RunningStateTest.java
+++ b/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/RunningStateTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates.
+ * Licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.amazonaws.services.kinesis.clientlibrary.lib.worker;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.util.Arrays;
+import java.util.HashSet;
+
+import com.amazonaws.services.kinesis.clientlibrary.lib.periodicshardsync.WorkerStateChangeListener;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class RunningStateTest {
+    private static final String WORKER_ID = "test_worker_id";
+
+    @Mock
+    WorkerStateChangeListener workerStateChangeListener;
+
+    @Test
+    public void testWorkerStateChangeListenerBehaviourOnNonLeaderStateTransition() {
+        RunningState runningState = new RunningState(WORKER_ID, workerStateChangeListener);
+        runningState.nonLeaderStateTransition();
+        verify(workerStateChangeListener, times(1)).stopLeader();
+        ArgumentCaptor<WorkerState> workerStateArgumentCaptor = ArgumentCaptor.forClass(WorkerState.class);
+        verify(workerStateChangeListener, times(1)).setWorkerState(workerStateArgumentCaptor.capture());
+
+        WorkerState actualWorkerState = workerStateArgumentCaptor.getValue();
+
+        assertTrue("New WorkerState should be IdleState", actualWorkerState instanceof IdleState);
+        assertEquals("Workerid doesn't match", WORKER_ID, actualWorkerState.workerId);
+        assertEquals(workerStateChangeListener, actualWorkerState.workerStateChangeListener);
+    }
+
+    @Test
+    public void testWorkerStateChangeListenerBehaviourOnLeaderStateTransition() {
+        RunningState runningState = new RunningState(WORKER_ID, workerStateChangeListener);
+        runningState.leaderStateTransition();
+        verify(workerStateChangeListener, times(1)).noOp();
+        verify(workerStateChangeListener, times(0)).setWorkerState(any(WorkerState.class));
+    }
+
+    @Test
+    public void testIsLeader() {
+        RunningState runningState = new RunningState(WORKER_ID, workerStateChangeListener);
+        boolean actualIsLeaderWorker = runningState
+                .isLeaderWorker(new HashSet<String>(Arrays.asList("1", "2", WORKER_ID, "4")));
+        assertTrue(String.format("%s is a leader", WORKER_ID), actualIsLeaderWorker);
+    }
+
+    @Test
+    public void testIsLeaderWithEmptyNewLeaders() {
+        RunningState runningState = new RunningState(WORKER_ID, workerStateChangeListener);
+        boolean actualIsLeaderWorker = runningState.isLeaderWorker(new HashSet<String>());
+        assertTrue(String.format("%s is not a leader", WORKER_ID), !actualIsLeaderWorker);
+    }
+
+    @Test
+    public void testIsLeaderWithNullNewLeaders() {
+        RunningState runningState = new RunningState(WORKER_ID, workerStateChangeListener);
+        boolean actualIsLeaderWorker = runningState.isLeaderWorker(null);
+        assertTrue(String.format("%s is not a leader", WORKER_ID), !actualIsLeaderWorker);
+    }
+
+    @Test
+    public void testLeaderRefresh() {
+        RunningState runningState = spy(new RunningState(WORKER_ID, workerStateChangeListener));
+        runningState.refresh(new HashSet<String>(Arrays.asList("1", "2", WORKER_ID, "4")));
+        verify(runningState, times(1)).leaderStateTransition();
+        verify(runningState, times(0)).nonLeaderStateTransition();
+    }
+
+    @Test
+    public void testNonLeaderRefresh() {
+        RunningState runningState = spy(new RunningState(WORKER_ID, workerStateChangeListener));
+        runningState.refresh(new HashSet<String>(Arrays.asList("1", "2", "3", "4")));
+        verify(runningState, times(1)).nonLeaderStateTransition();
+        verify(runningState, times(0)).leaderStateTransition();
+    }
+}

--- a/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ScheduledLeaseLeaderPollerTest.java
+++ b/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ScheduledLeaseLeaderPollerTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates.
+ * Licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.amazonaws.services.kinesis.clientlibrary.lib.worker;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyLong;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+import com.amazonaws.services.kinesis.clientlibrary.lib.periodicshardsync.LeaderElectionStrategy;
+import com.amazonaws.services.kinesis.leases.impl.KinesisClientLease;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ScheduledLeaseLeaderPollerTest {
+    @Mock
+    private LeaderElectionStrategy<KinesisClientLease> leaderElectionStrategy;
+    @Mock
+    private KinesisClientLibConfiguration config;
+    @Mock
+    private ScheduledThreadPoolExecutor scheduledExecutor;
+
+    @Test
+    public void testLeaderPollingScheduled() {
+        ScheduledLeaseLeaderPoller leaderPoller = new ScheduledLeaseLeaderPoller(leaderElectionStrategy, config,
+                scheduledExecutor);
+        leaderPoller.pollForLeaders();
+        verify(scheduledExecutor, times(1)).scheduleWithFixedDelay(any(LeaderElectionStrategy.class), anyLong(), anyLong(),
+                any(TimeUnit.class));
+    }
+
+    @Test
+    public void testStopWithAwaitTerminationTrue() throws InterruptedException {
+        ScheduledLeaseLeaderPoller leaderPoller = new ScheduledLeaseLeaderPoller(leaderElectionStrategy, config,
+                scheduledExecutor);
+        when(scheduledExecutor.awaitTermination(anyLong(), any(TimeUnit.class))).thenReturn(true);
+        leaderPoller.pollForLeaders();
+        verify(scheduledExecutor, times(1)).scheduleWithFixedDelay(any(LeaderElectionStrategy.class), anyLong(),
+                anyLong(), any(TimeUnit.class));
+        leaderPoller.stop();
+        verify(scheduledExecutor, times(1)).shutdown();
+        verify(scheduledExecutor, times(0)).shutdownNow();
+    }
+
+    @Test
+    public void testStopWithAwaitTerminationFalse() throws InterruptedException {
+        ScheduledLeaseLeaderPoller leaderPoller = new ScheduledLeaseLeaderPoller(leaderElectionStrategy, config,
+                scheduledExecutor);
+        when(scheduledExecutor.awaitTermination(anyLong(), any(TimeUnit.class))).thenReturn(false);
+        leaderPoller.pollForLeaders();
+        verify(scheduledExecutor, times(1)).scheduleWithFixedDelay(any(LeaderElectionStrategy.class), anyLong(),
+                anyLong(), any(TimeUnit.class));
+        leaderPoller.stop();
+        verify(scheduledExecutor, times(1)).shutdown();
+        verify(scheduledExecutor, times(1)).shutdownNow();
+    }
+
+}

--- a/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardConsumerTest.java
+++ b/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardConsumerTest.java
@@ -163,8 +163,8 @@ public class ShardConsumerTest {
                         taskBackoffTimeMillis,
                         KinesisClientLibConfiguration.DEFAULT_SKIP_SHARD_SYNC_AT_STARTUP_IF_LEASES_EXIST,
                         config,
-                        shardSyncer);
-
+                        shardSyncer,
+                        ShardSyncStrategy.SHARD_END);
         assertThat(consumer.getCurrentState(), is(equalTo(ConsumerStates.ShardConsumerState.WAITING_ON_PARENT_SHARDS)));
         consumer.consumeShard(); // initialize
         Thread.sleep(50L);
@@ -212,7 +212,8 @@ public class ShardConsumerTest {
                         taskBackoffTimeMillis,
                         KinesisClientLibConfiguration.DEFAULT_SKIP_SHARD_SYNC_AT_STARTUP_IF_LEASES_EXIST,
                         config,
-                        shardSyncer);
+                        shardSyncer,
+                        ShardSyncStrategy.SHARD_END);
 
         assertThat(consumer.getCurrentState(), is(equalTo(ConsumerStates.ShardConsumerState.WAITING_ON_PARENT_SHARDS)));
         consumer.consumeShard(); // initialize
@@ -255,7 +256,8 @@ public class ShardConsumerTest {
                         taskBackoffTimeMillis,
                         KinesisClientLibConfiguration.DEFAULT_SKIP_SHARD_SYNC_AT_STARTUP_IF_LEASES_EXIST,
                         config,
-                        shardSyncer);
+                        shardSyncer,
+                        ShardSyncStrategy.SHARD_END);
 
         final ExtendedSequenceNumber checkpointSequenceNumber = new ExtendedSequenceNumber("123");
         final ExtendedSequenceNumber pendingCheckpointSequenceNumber = null;
@@ -375,7 +377,8 @@ public class ShardConsumerTest {
                         Optional.empty(),
                         Optional.empty(),
                         config,
-                        shardSyncer);
+                        shardSyncer,
+                        ShardSyncStrategy.SHARD_END);
 
         assertThat(consumer.getCurrentState(), is(equalTo(ConsumerStates.ShardConsumerState.WAITING_ON_PARENT_SHARDS)));
         consumer.consumeShard(); // check on parent shards
@@ -520,7 +523,8 @@ public class ShardConsumerTest {
                         Optional.empty(),
                         Optional.empty(),
                         config,
-                        shardSyncer);
+                        shardSyncer,
+                        ShardSyncStrategy.SHARD_END);
 
         assertThat(consumer.getCurrentState(), is(equalTo(ConsumerStates.ShardConsumerState.WAITING_ON_PARENT_SHARDS)));
         consumer.consumeShard(); // check on parent shards
@@ -658,7 +662,8 @@ public class ShardConsumerTest {
                         Optional.empty(),
                         Optional.empty(),
                         config,
-                        shardSyncer);
+                        shardSyncer,
+                        ShardSyncStrategy.SHARD_END);
 
         assertThat(consumer.getCurrentState(), is(equalTo(ConsumerStates.ShardConsumerState.WAITING_ON_PARENT_SHARDS)));
         consumer.consumeShard(); // check on parent shards
@@ -729,7 +734,8 @@ public class ShardConsumerTest {
                         taskBackoffTimeMillis,
                         KinesisClientLibConfiguration.DEFAULT_SKIP_SHARD_SYNC_AT_STARTUP_IF_LEASES_EXIST,
                         config,
-                        shardSyncer);
+                        shardSyncer,
+                        ShardSyncStrategy.SHARD_END);
 
         GetRecordsCache getRecordsCache = spy(consumer.getGetRecordsCache());
 
@@ -783,7 +789,8 @@ public class ShardConsumerTest {
                         Optional.empty(),
                         Optional.empty(),
                         config,
-                        shardSyncer);
+                        shardSyncer,
+                        ShardSyncStrategy.SHARD_END);
 
         assertEquals(shardConsumer.getGetRecordsCache().getGetRecordsRetrievalStrategy().getClass(),
                 SynchronousGetRecordsRetrievalStrategy.class);
@@ -814,7 +821,8 @@ public class ShardConsumerTest {
                         Optional.of(1),
                         Optional.of(2),
                         config,
-                        shardSyncer);
+                        shardSyncer,
+                        ShardSyncStrategy.SHARD_END);
 
         assertEquals(shardConsumer.getGetRecordsCache().getGetRecordsRetrievalStrategy().getClass(),
                 AsynchronousGetRecordsRetrievalStrategy.class);
@@ -854,8 +862,8 @@ public class ShardConsumerTest {
                 taskBackoffTimeMillis,
                 KinesisClientLibConfiguration.DEFAULT_SKIP_SHARD_SYNC_AT_STARTUP_IF_LEASES_EXIST,
                 config,
-                shardSyncer);
-
+                shardSyncer,
+                ShardSyncStrategy.SHARD_END);
         shardConsumer.consumeShard();
 
         Thread.sleep(sleepTime);

--- a/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShutdownTaskTest.java
+++ b/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShutdownTaskTest.java
@@ -113,7 +113,8 @@ public class ShutdownTaskTest {
                 leaseManager,
                 TASK_BACKOFF_TIME_MILLIS,
                 getRecordsCache,
-                shardSyncer);
+                shardSyncer,
+                ShardSyncStrategy.SHARD_END);
         TaskResult result = task.call();
         Assert.assertNotNull(result.getException());
         Assert.assertTrue(result.getException() instanceof IllegalArgumentException);
@@ -142,7 +143,8 @@ public class ShutdownTaskTest {
                 leaseManager,
                 TASK_BACKOFF_TIME_MILLIS,
                 getRecordsCache,
-                shardSyncer);
+                shardSyncer,
+                ShardSyncStrategy.SHARD_END);
         TaskResult result = task.call();
         Assert.assertNotNull(result.getException());
         Assert.assertTrue(result.getException() instanceof KinesisClientLibIOException);
@@ -154,7 +156,7 @@ public class ShutdownTaskTest {
      */
     @Test
     public final void testGetTaskType() {
-        ShutdownTask task = new ShutdownTask(null, null, null, null, null, null, false, false, null, 0, getRecordsCache, shardSyncer);
+        ShutdownTask task = new ShutdownTask(null, null, null, null, null, null, false, false, null, 0, getRecordsCache, shardSyncer, ShardSyncStrategy.SHARD_END);
         Assert.assertEquals(TaskType.SHUTDOWN, task.getTaskType());
     }
 


### PR DESCRIPTION
Presently KCL does shard syncs on each shard end event. Due to the shard growth issue in ddb streams, the shard end events are very frequent, resulting in describe streams calls for each such event across workers. This causes throttling for large customers. This throttling delays the shard discovery process, customer's processing and causes other inconsistency issues. This can be avoided if instead of shard syncs being done at shard end events on each worker, periodic shard sync are done and on a limited set of hosts, so that horizontal scaling is feasible for customers. This commit enables the option for periodic shard syncs on a selected set of leader hosts to solve the above problems.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
