### PR TITLE
Updated protobuf to 3.9.0.

### DIFF
--- a/amazon-kinesis-client/pom.xml
+++ b/amazon-kinesis-client/pom.xml
@@ -82,7 +82,7 @@
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
-      <version>2.6.1</version>
+      <version>3.9.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
This updates google protobuf to 3.9.0. The current version is out of date and has some reported security vulnerabilities such as https://github.com/protocolbuffers/protobuf/issues/760

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
