### PR TITLE
Add logging around shard end codepaths

### DIFF
--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/KinesisDataFetcher.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/KinesisDataFetcher.java
@@ -71,12 +71,15 @@ class KinesisDataFetcher {
         
         if (nextIterator != null) {
             try {
-                return new AdvancingResult(kinesisProxy.get(nextIterator, maxRecords));
+                GetRecordsResult getRecordsResult = kinesisProxy.get(nextIterator, maxRecords);
+                LOG.info("Successfully fetched records from Kinesis for shard " + shardId + ": " + getRecordsResult);
+                return new AdvancingResult(getRecordsResult);
             } catch (ResourceNotFoundException e) {
                 LOG.info("Caught ResourceNotFoundException when fetching records for shard " + shardId);
                 return TERMINAL_RESULT;
             }
         } else {
+            LOG.info("Cannot fetch records from Kinesis for shard " + shardId + ": nextIterator is null.");
             return TERMINAL_RESULT;
         }
     }
@@ -117,6 +120,7 @@ class KinesisDataFetcher {
                 lastKnownSequenceNumber = Iterables.getLast(result.getRecords()).getSequenceNumber();
             }
             if (nextIterator == null) {
+                LOG.info("Reached shard end: nextIterator is null in AdvancingResult.accept for shard " + shardId);
                 isShardEndReached = true;
             }
             return getResult();
@@ -167,6 +171,7 @@ class KinesisDataFetcher {
             nextIterator = getIterator(ShardIteratorType.AT_SEQUENCE_NUMBER.toString(), sequenceNumber);
         }
         if (nextIterator == null) {
+            LOG.info("Reached shard end: cannot advance iterator for shard " + shardId);
             isShardEndReached = true;
         }
         this.lastKnownSequenceNumber = sequenceNumber;

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/KinesisDataFetcher.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/KinesisDataFetcher.java
@@ -71,15 +71,13 @@ class KinesisDataFetcher {
         
         if (nextIterator != null) {
             try {
-                GetRecordsResult getRecordsResult = kinesisProxy.get(nextIterator, maxRecords);
-                LOG.info("Successfully fetched records from Kinesis for shard " + shardId + ": " + getRecordsResult);
-                return new AdvancingResult(getRecordsResult);
+                return new AdvancingResult(kinesisProxy.get(nextIterator, maxRecords));
             } catch (ResourceNotFoundException e) {
                 LOG.info("Caught ResourceNotFoundException when fetching records for shard " + shardId);
                 return TERMINAL_RESULT;
             }
         } else {
-            LOG.info("Cannot fetch records from Kinesis for shard " + shardId + ": nextIterator is null.");
+            LOG.info("Skipping fetching records from Kinesis for shard " + shardId + ": nextIterator is null.");
             return TERMINAL_RESULT;
         }
     }


### PR DESCRIPTION
KinesisDataFetcher can internally decide it's reached the end of a shard through 4 different codepaths. The logs currently do not provide insight into which codepath a shard end was reached from, making it difficult to debug. This PR adds unique logging items for each codepath where a KinesisDataFetcher can decide it has reached the end of a shard.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
