### PR TITLE
Preventing duplicate delivery due to unacknowledged event while completing the subscription

### DIFF
--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/fanout/FanOutRecordsPublisher.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/fanout/FanOutRecordsPublisher.java
@@ -170,7 +170,7 @@ public class FanOutRecordsPublisher implements RecordsPublisher {
             // Update the triggering flow for post scheduling upstream request.
             flowToBeReturned = recordsRetrievedContext.getRecordFlow();
             // Try scheduling the next event in the queue, if available.
-            if (recordsDeliveryQueue.peek() != null) {
+            if (!recordsDeliveryQueue.isEmpty()) {
                 scheduleNextEvent(recordsDeliveryQueue.peek().getRecordsRetrieved());
             }
         } else {


### PR DESCRIPTION
Preventing duplicate delivery due to unacknowledged event while completing the subscription

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
