### PR TITLE
Fix to prevent the onNext event going to stale subscription when restart happens in poller

### DIFF
--- a/amazon-kinesis-client/src/test/java/software/amazon/kinesis/retrieval/polling/PrefetchRecordsPublisherIntegrationTest.java
+++ b/amazon-kinesis-client/src/test/java/software/amazon/kinesis/retrieval/polling/PrefetchRecordsPublisherIntegrationTest.java
@@ -122,14 +122,14 @@ public class PrefetchRecordsPublisherIntegrationTest {
         getRecordsCache.start(extendedSequenceNumber, initialPosition);
         sleep(IDLE_MILLIS_BETWEEN_CALLS);
 
-        ProcessRecordsInput processRecordsInput1 = blockUntilRecordsAvailable(getRecordsCache::pollNextResultAndUpdatePrefetchCounters, 1000L)
+        ProcessRecordsInput processRecordsInput1 = blockUntilRecordsAvailable(getRecordsCache::evictPublishedEvent, 1000L)
                 .processRecordsInput();
 
         assertTrue(processRecordsInput1.records().isEmpty());
         assertEquals(processRecordsInput1.millisBehindLatest(), new Long(1000));
         assertNotNull(processRecordsInput1.cacheEntryTime());
 
-        ProcessRecordsInput processRecordsInput2 = blockUntilRecordsAvailable(getRecordsCache::pollNextResultAndUpdatePrefetchCounters, 1000L)
+        ProcessRecordsInput processRecordsInput2 = blockUntilRecordsAvailable(getRecordsCache::evictPublishedEvent, 1000L)
                 .processRecordsInput();
 
         assertNotEquals(processRecordsInput1, processRecordsInput2);
@@ -140,11 +140,11 @@ public class PrefetchRecordsPublisherIntegrationTest {
         getRecordsCache.start(extendedSequenceNumber, initialPosition);
         sleep(MAX_SIZE * IDLE_MILLIS_BETWEEN_CALLS);
 
-        assertEquals(getRecordsCache.getRecordsResultQueue.size(), MAX_SIZE);
+        assertEquals(getRecordsCache.getPublisherSession().prefetchRecordsQueue().size(), MAX_SIZE);
 
-        ProcessRecordsInput processRecordsInput1 = blockUntilRecordsAvailable(getRecordsCache::pollNextResultAndUpdatePrefetchCounters, 1000L)
+        ProcessRecordsInput processRecordsInput1 = blockUntilRecordsAvailable(getRecordsCache::evictPublishedEvent, 1000L)
                 .processRecordsInput();
-        ProcessRecordsInput processRecordsInput2 = blockUntilRecordsAvailable(getRecordsCache::pollNextResultAndUpdatePrefetchCounters, 1000L)
+        ProcessRecordsInput processRecordsInput2 = blockUntilRecordsAvailable(getRecordsCache::evictPublishedEvent, 1000L)
                 .processRecordsInput();
 
         assertNotEquals(processRecordsInput1, processRecordsInput2);
@@ -184,9 +184,9 @@ public class PrefetchRecordsPublisherIntegrationTest {
 
         sleep(IDLE_MILLIS_BETWEEN_CALLS);
 
-        ProcessRecordsInput p1 = getRecordsCache.pollNextResultAndUpdatePrefetchCounters().processRecordsInput();
+        ProcessRecordsInput p1 = getRecordsCache.evictPublishedEvent().processRecordsInput();
 
-        ProcessRecordsInput p2 = recordsPublisher2.pollNextResultAndUpdatePrefetchCounters().processRecordsInput();
+        ProcessRecordsInput p2 = recordsPublisher2.evictPublishedEvent().processRecordsInput();
 
         assertNotEquals(p1, p2);
         assertTrue(p1.records().isEmpty());
@@ -212,7 +212,7 @@ public class PrefetchRecordsPublisherIntegrationTest {
         getRecordsCache.start(extendedSequenceNumber, initialPosition);
         sleep(IDLE_MILLIS_BETWEEN_CALLS);
 
-        ProcessRecordsInput processRecordsInput = blockUntilRecordsAvailable(getRecordsCache::pollNextResultAndUpdatePrefetchCounters, 1000L)
+        ProcessRecordsInput processRecordsInput = blockUntilRecordsAvailable(getRecordsCache::evictPublishedEvent, 1000L)
                 .processRecordsInput();
 
         assertNotNull(processRecordsInput);

--- a/amazon-kinesis-client/src/test/java/software/amazon/kinesis/retrieval/polling/PrefetchRecordsPublisherTest.java
+++ b/amazon-kinesis-client/src/test/java/software/amazon/kinesis/retrieval/polling/PrefetchRecordsPublisherTest.java
@@ -276,7 +276,7 @@ public class PrefetchRecordsPublisherTest {
         assertThat(records.processRecordsInput().millisBehindLatest(), equalTo(response.millisBehindLatest()));
     }
 
-    @Test(timeout = 20000L)
+    @Test(timeout = 10000L)
     public void testNoDeadlockOnFullQueue() {
         //
         // Fixes https://github.com/awslabs/amazon-kinesis-client/issues/448
@@ -304,7 +304,7 @@ public class PrefetchRecordsPublisherTest {
 
         log.info("Queue is currently at {} starting subscriber", getRecordsCache.getRecordsResultQueue.size());
         AtomicInteger receivedItems = new AtomicInteger(0);
-        final int expectedItems = MAX_SIZE * 1000;
+        final int expectedItems = MAX_SIZE * 20;
 
         Object lock = new Object();
 
@@ -359,7 +359,7 @@ public class PrefetchRecordsPublisherTest {
         assertThat(receivedItems.get(), equalTo(expectedItems));
     }
 
-    @Test(timeout = 20000L)
+    @Test(timeout = 10000L)
     public void testNoDeadlockOnFullQueueAndLossOfNotification() {
         //
         // Fixes https://github.com/awslabs/amazon-kinesis-client/issues/602
@@ -383,7 +383,7 @@ public class PrefetchRecordsPublisherTest {
 
         log.info("Queue is currently at {} starting subscriber", getRecordsCache.getRecordsResultQueue.size());
         AtomicInteger receivedItems = new AtomicInteger(0);
-        final int expectedItems = MAX_SIZE * 100;
+        final int expectedItems = MAX_SIZE * 50;
 
         Object lock = new Object();
 
@@ -521,7 +521,7 @@ public class PrefetchRecordsPublisherTest {
 
     private static class LossyNotificationSubscriber extends ShardConsumerNotifyingSubscriber {
 
-        private static final int LOSS_EVERY_NTH_RECORD = 100;
+        private static final int LOSS_EVERY_NTH_RECORD = 50;
         private static int recordCounter = 0;
         private static final ScheduledExecutorService consumerHealthChecker = Executors.newScheduledThreadPool(1);
 


### PR DESCRIPTION
Fix to prevent the onNext event going to stale subscription when restart happens in poller

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
