### PR TITLE
KCL 2.2.4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+
+### Release 2.2.4 (September 23, 2019)
+
+[Milestone#39](https://github.com/awslabs/amazon-kinesis-client/milestone/39)
+* Making FanoutRecordsPublisher test cases resilient to delayed thread operations
+  * [PR#612](https://github.com/awslabs/amazon-kinesis-client/pull/612)
+* Drain delivery queue in the FanoutRecordsPublisher to make slow consumers consume events at their pace
+  * [PR#607](https://github.com/awslabs/amazon-kinesis-client/pull/607)
+* Fix to prevent the onNext event going to stale subscription when restart happens in PrefetchRecordsPublisher
+  * [PR#606](https://github.com/awslabs/amazon-kinesis-client/pull/606)
+
 ### Release 2.2.3 (September 04, 2019)
 
 [Milestone#38](https://github.com/awslabs/amazon-kinesis-client/milestone/38)

--- a/README.md
+++ b/README.md
@@ -60,7 +60,16 @@ The recommended way to use the KCL for Java is to consume it from Maven.
 
 ## Release Notes
 
-### Latest Release (2.2.3 - September 04, 2019)
+### Latest Release (2.2.4 - September 23, 2019)
+[Milestone#39](https://github.com/awslabs/amazon-kinesis-client/milestone/39)
+* Making FanoutRecordsPublisher test cases resilient to delayed thread operations
+  * [PR#612](https://github.com/awslabs/amazon-kinesis-client/pull/612)
+* Drain delivery queue in the FanoutRecordsPublisher to make slow consumers consume events at their pace
+  * [PR#607](https://github.com/awslabs/amazon-kinesis-client/pull/607)
+* Fix to prevent the onNext event going to stale subscription when restart happens in PrefetchRecordsPublisher
+  * [PR#606](https://github.com/awslabs/amazon-kinesis-client/pull/606)
+
+### Related Prior Release (2.2.3 - September 04, 2019)
 [Milestone#38](https://github.com/awslabs/amazon-kinesis-client/milestone/38)
 * Fix to prevent data loss and stuck shards in the event of failed records delivery in Polling readers
   * [PR#603](https://github.com/awslabs/amazon-kinesis-client/pull/603)

--- a/amazon-kinesis-client-multilang/pom.xml
+++ b/amazon-kinesis-client-multilang/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>amazon-kinesis-client-pom</artifactId>
     <groupId>software.amazon.kinesis</groupId>
-    <version>2.2.4-SNAPSHOT</version>
+    <version>2.2.4</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/amazon-kinesis-client/pom.xml
+++ b/amazon-kinesis-client/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>software.amazon.kinesis</groupId>
     <artifactId>amazon-kinesis-client-pom</artifactId>
-    <version>2.2.4-SNAPSHOT</version>
+    <version>2.2.4</version>
   </parent>
 
   <artifactId>amazon-kinesis-client</artifactId>

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/RetrievalConfig.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/RetrievalConfig.java
@@ -34,7 +34,7 @@ public class RetrievalConfig {
      */
     public static final String KINESIS_CLIENT_LIB_USER_AGENT = "amazon-kinesis-client-library-java";
 
-    public static final String KINESIS_CLIENT_LIB_USER_AGENT_VERSION = "2.2.4-SNAPSHOT";
+    public static final String KINESIS_CLIENT_LIB_USER_AGENT_VERSION = "2.2.4";
 
     /**
      * Client used to make calls to Kinesis for records retrieval

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
   <artifactId>amazon-kinesis-client-pom</artifactId>
   <packaging>pom</packaging>
   <name>Amazon Kinesis Client Library</name>
-  <version>2.2.4-SNAPSHOT</version>
+  <version>2.2.4</version>
   <description>The Amazon Kinesis Client Library for Java enables Java developers to easily consume and process data
     from Amazon Kinesis.
   </description>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

### Release 2.2.4 (September 23, 2019)

[Milestone#39](https://github.com/awslabs/amazon-kinesis-client/milestone/39)
* Making FanoutRecordsPublisher test cases resilient to delayed thread operations
  * [PR#612](https://github.com/awslabs/amazon-kinesis-client/pull/612)
* Drain delivery queue in the FanoutRecordsPublisher to make slow consumers consume events at their pace
  * [PR#607](https://github.com/awslabs/amazon-kinesis-client/pull/607)
* Fix to prevent the onNext event going to stale subscription when restart happens in PrefetchRecordsPublisher
  * [PR#606](https://github.com/awslabs/amazon-kinesis-client/pull/606)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
