### PR TITLE
handling completed and blocked tasks better during graceful shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,17 @@
 # Changelog
+## Release 1.12.0 (October 17, 2019)
+[Milestone#41](https://github.com/awslabs/amazon-kinesis-client/milestone/41)
+* Adding logging around shard end codepaths.
+  * [PR #585](https://github.com/awslabs/amazon-kinesis-client/pull/585)
+* Updating checkpointing failure message to refer to javadocs.
+  * [PR #590](https://github.com/awslabs/amazon-kinesis-client/pull/590)
+* Updating Sonatype to dedicated AWS endpoint.
+  * [PR #618](https://github.com/awslabs/amazon-kinesis-client/pull/618)
+* Introducing a validation step to verify if ShardEnd is reached, to prevent shard consumer stuck scenarios in the event of malformed response from service.
+  * [PR #623](https://github.com/awslabs/amazon-kinesis-client/pull/623)
+* Updating AWS SDK to 1.11.655
+  * [PR #626](https://github.com/awslabs/amazon-kinesis-client/pull/626)
+
 ## Release 1.11.2 (August 15, 2019)
 [Milestone#35](https://github.com/awslabs/amazon-kinesis-client/milestone/35)
 * Added support for metrics emission in `PeriodicShardSyncer`.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,20 @@ To make it easier for developers to write record processors in other languages, 
 
 ## Release Notes
 
-## Latest Release (1.11.2 - August 15, 2019)
+## Latest Release (1.12.0 October 17, 2019)
+[Milestone#41](https://github.com/awslabs/amazon-kinesis-client/milestone/41)
+* Adding logging around shard end codepaths
+  * [PR #585](https://github.com/awslabs/amazon-kinesis-client/pull/585)
+* Updating checkpointing failure message to refer to javadocs
+  * [PR #590](https://github.com/awslabs/amazon-kinesis-client/pull/590)
+* Updating Sonatype to dedicated AWS endpoint.
+  * [PR #618](https://github.com/awslabs/amazon-kinesis-client/pull/618)
+* Introducing a validation step to verify if ShardEnd is reached, to prevent shard consumer stuck scenarios in the event of malformed response from service.
+  * [PR #623](https://github.com/awslabs/amazon-kinesis-client/pull/623)
+* Updating AWS SDK to 1.11.655
+  * [PR #626](https://github.com/awslabs/amazon-kinesis-client/pull/626)
+
+## Release 1.11.2 (August 15, 2019)
 [Milestone#35](https://github.com/awslabs/amazon-kinesis-client/milestone/35)
 * Added support for metrics emission in `PeriodicShardSyncer`.
   * [PR #592](https://github.com/awslabs/amazon-kinesis-client/pull/592)

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <artifactId>amazon-kinesis-client</artifactId>
   <packaging>jar</packaging>
   <name>Amazon Kinesis Client Library for Java</name>
-  <version>1.11.3-SNAPSHOT</version>
+  <version>1.13.0-SNAPSHOT</version>
   <description>The Amazon Kinesis Client Library for Java enables Java developers to easily consume and process data
     from Amazon Kinesis.
   </description>
@@ -25,7 +25,7 @@
   </licenses>
 
   <properties>
-    <aws-java-sdk.version>1.11.603</aws-java-sdk.version>
+    <aws-java-sdk.version>1.11.655</aws-java-sdk.version>
     <sqlite4java.version>1.0.392</sqlite4java.version>
     <sqlite4java.native>libsqlite4java</sqlite4java.native>
     <sqlite4java.libpath>${project.build.directory}/test-lib</sqlite4java.libpath>

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ConsumerStates.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ConsumerStates.java
@@ -528,7 +528,7 @@ class ConsumerStates {
                     consumer.getStreamConfig().getInitialPositionInStream(),
                     consumer.isCleanupLeasesOfCompletedShards(),
                     consumer.isIgnoreUnexpectedChildShards(),
-                    consumer.getLeaseManager(),
+                    consumer.getLeaseCoordinator(),
                     consumer.getTaskBackoffTimeMillis(),
                     consumer.getGetRecordsCache(), consumer.getShardSyncer(), consumer.getShardSyncStrategy());
         }

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/KinesisClientLibConfiguration.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/KinesisClientLibConfiguration.java
@@ -125,7 +125,7 @@ public class KinesisClientLibConfiguration {
     /**
      * User agent set when Amazon Kinesis Client Library makes AWS requests.
      */
-    public static final String KINESIS_CLIENT_LIB_USER_AGENT = "amazon-kinesis-client-library-java-1.11.3-SNAPSHOT";
+    public static final String KINESIS_CLIENT_LIB_USER_AGENT = "amazon-kinesis-client-library-java-1.13.0-SNAPSHOT";
 
     /**
      * KCL will validate client provided sequence numbers with a call to Amazon Kinesis before checkpointing for calls

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/PeriodicShardSyncStrategy.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/PeriodicShardSyncStrategy.java
@@ -1,5 +1,6 @@
 package com.amazonaws.services.kinesis.clientlibrary.lib.worker;
 
+
 /**
  * An implementation of ShardSyncStrategy.
  */

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardConsumer.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardConsumer.java
@@ -423,6 +423,8 @@ class ShardConsumer {
         }
         if (isShutdownRequested() && taskOutcome != TaskOutcome.FAILURE) {
             currentState = currentState.shutdownTransition(shutdownReason);
+        } else if (isShutdownRequested() && ConsumerStates.ShardConsumerState.WAITING_ON_PARENT_SHARDS.equals(currentState.getState())) {
+            currentState = currentState.shutdownTransition(shutdownReason);
         } else if (taskOutcome == TaskOutcome.SUCCESSFUL) {
             if (currentState.getTaskType() == currentTask.getTaskType()) {
                 currentState = currentState.successTransition();

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardEndShardSyncStrategy.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardEndShardSyncStrategy.java
@@ -1,8 +1,10 @@
 package com.amazonaws.services.kinesis.clientlibrary.lib.worker;
 
+import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 
+import com.amazonaws.services.kinesis.model.Shard;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -53,6 +55,12 @@ class ShardEndShardSyncStrategy implements ShardSyncStrategy {
     @Override
     public TaskResult onShardConsumerShutDown() {
         return onFoundCompletedShard();
+    }
+
+    @Override
+    public TaskResult onShardConsumerShutDown(List<Shard> latestShards) {
+        shardSyncTaskManager.syncShardAndLeaseInfo(latestShards);
+        return new TaskResult(null);
     }
 
     @Override

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardSyncStrategy.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardSyncStrategy.java
@@ -1,5 +1,9 @@
 package com.amazonaws.services.kinesis.clientlibrary.lib.worker;
 
+import com.amazonaws.services.kinesis.model.Shard;
+
+import java.util.List;
+
 /**
  * Facade of methods that can be invoked at different points
  * in KCL application execution to perform certain actions related to shard-sync.
@@ -40,6 +44,16 @@ public interface ShardSyncStrategy {
      * @return
      */
     TaskResult onShardConsumerShutDown();
+
+    /**
+     * Invoked when ShardConsumer is shutdown and all shards are provided.
+     *
+     * @param latestShards latest snapshot of shards to reuse
+     * @return
+     */
+    default TaskResult onShardConsumerShutDown(List<Shard> latestShards) {
+        return onShardConsumerShutDown();
+    }
 
     /**
      * Invoked when worker is shutdown.

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardSyncTaskManager.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardSyncTaskManager.java
@@ -14,11 +14,13 @@
  */
 package com.amazonaws.services.kinesis.clientlibrary.lib.worker;
 
+import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 
+import com.amazonaws.services.kinesis.model.Shard;
 import lombok.Getter;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -85,11 +87,11 @@ class ShardSyncTaskManager {
         this.shardSyncer = shardSyncer;
     }
 
-    synchronized Future<TaskResult> syncShardAndLeaseInfo(Set<String> closedShardIds) {
-        return checkAndSubmitNextTask(closedShardIds);
+    synchronized Future<TaskResult> syncShardAndLeaseInfo(List<Shard> latestShards) {
+        return checkAndSubmitNextTask(latestShards);
     }
 
-    private synchronized Future<TaskResult> checkAndSubmitNextTask(Set<String> closedShardIds) {
+    private synchronized Future<TaskResult> checkAndSubmitNextTask(List<Shard> latestShards) {
         Future<TaskResult> submittedTaskFuture = null;
         if ((future == null) || future.isCancelled() || future.isDone()) {
             if ((future != null) && future.isDone()) {
@@ -111,7 +113,7 @@ class ShardSyncTaskManager {
                             cleanupLeasesUponShardCompletion,
                             ignoreUnexpectedChildShards,
                             shardSyncIdleTimeMillis,
-                            shardSyncer), metricsFactory);
+                            shardSyncer, latestShards), metricsFactory);
             future = executorService.submit(currentTask);
             if (LOG.isDebugEnabled()) {
                 LOG.debug("Submitted new " + currentTask.getTaskType() + " task.");

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardSyncer.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardSyncer.java
@@ -21,12 +21,23 @@ import com.amazonaws.services.kinesis.leases.exceptions.InvalidStateException;
 import com.amazonaws.services.kinesis.leases.exceptions.ProvisionedThroughputException;
 import com.amazonaws.services.kinesis.leases.impl.KinesisClientLease;
 import com.amazonaws.services.kinesis.leases.interfaces.ILeaseManager;
+import com.amazonaws.services.kinesis.model.Shard;
+
+import java.util.List;
 
 public interface ShardSyncer {
 
     void checkAndCreateLeasesForNewShards(IKinesisProxy kinesisProxy, ILeaseManager<KinesisClientLease> leaseManager,
-            InitialPositionInStreamExtended initialPositionInStream, boolean cleanupLeasesOfCompletedShards,
-            boolean ignoreUnexpectedChildShards)
+                                          InitialPositionInStreamExtended initialPositionInStream, boolean cleanupLeasesOfCompletedShards,
+                                          boolean ignoreUnexpectedChildShards)
             throws DependencyException, InvalidStateException, ProvisionedThroughputException,
             KinesisClientLibIOException;
+
+    default void checkAndCreateLeasesForNewShards(IKinesisProxy kinesisProxy, ILeaseManager<KinesisClientLease> leaseManager,
+                                          InitialPositionInStreamExtended initialPositionInStream, boolean cleanupLeasesOfCompletedShards,
+                                          boolean ignoreUnexpectedChildShards, List<Shard> latestShards)
+            throws DependencyException, InvalidStateException, ProvisionedThroughputException,
+            KinesisClientLibIOException {
+        checkAndCreateLeasesForNewShards(kinesisProxy, leaseManager, initialPositionInStream, cleanupLeasesOfCompletedShards, ignoreUnexpectedChildShards);
+    }
 }

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/Worker.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/Worker.java
@@ -905,6 +905,13 @@ public class Worker implements Runnable {
                 ShardConsumer consumer = shardInfoShardConsumerMap.get(shardInfo);
 
                 if (consumer == null || ConsumerStates.ShardConsumerState.SHUTDOWN_COMPLETE.equals(consumer.getCurrentState())) {
+                    //
+                    // CASE1: There is a race condition between retrieving the current assignments, and creating the
+                    // notification. If the a lease is lost in between these two points, we explicitly decrement the
+                    // notification latches to clear the shutdown.
+                    //
+                    // CASE2: The shard consumer is in SHUTDOWN_COMPLETE state and will not decrement the latches by itself.
+                    //
                     notificationCompleteLatch.countDown();
                     shutdownCompleteLatch.countDown();
                 } else {

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/Worker.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/Worker.java
@@ -679,7 +679,7 @@ public class Worker implements Runnable {
                     LOG.info("Syncing Kinesis shard info");
                     ShardSyncTask shardSyncTask = new ShardSyncTask(streamConfig.getStreamProxy(),
                             leaseCoordinator.getLeaseManager(), initialPosition, cleanupLeasesUponShardCompletion,
-                            config.shouldIgnoreUnexpectedChildShards(), 0L, shardSyncer);
+                            config.shouldIgnoreUnexpectedChildShards(), 0L, shardSyncer, null);
                     result = new MetricsCollectingTaskDecorator(shardSyncTask, metricsFactory).call();
                 } else {
                     LOG.info("Skipping shard sync per config setting (and lease table is not empty)");
@@ -1045,7 +1045,7 @@ public class Worker implements Runnable {
                 streamConfig,
                 checkpointTracker,
                 recordProcessor,
-                leaseCoordinator.getLeaseManager(),
+                leaseCoordinator,
                 parentShardPollIntervalMillis,
                 cleanupLeasesUponShardCompletion,
                 executorService,
@@ -1170,7 +1170,7 @@ public class Worker implements Runnable {
                         new ShardSyncTask(kinesisProxy, leaseManager, config.getInitialPositionInStreamExtended(),
                                 config.shouldCleanupLeasesUponShardCompletion(),
                                 config.shouldIgnoreUnexpectedChildShards(), SHARD_SYNC_SLEEP_FOR_PERIODIC_SHARD_SYNC,
-                                shardSyncer), metricsFactory));
+                                shardSyncer, null), metricsFactory));
     }
 
     private ShardEndShardSyncStrategy createShardEndShardSyncStrategy(ShardSyncTaskManager shardSyncTaskManager) {

--- a/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ConsumerStatesTest.java
+++ b/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ConsumerStatesTest.java
@@ -35,6 +35,7 @@ import org.hamcrest.TypeSafeDiagnosingMatcher;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
@@ -66,6 +67,8 @@ public class ConsumerStatesTest {
     private KinesisDataFetcher dataFetcher;
     @Mock
     private ILeaseManager<KinesisClientLease> leaseManager;
+    @InjectMocks
+    private KinesisClientLibLeaseCoordinator leaseCoordinator = new KinesisClientLibLeaseCoordinator(leaseManager, "testCoordinator", 1000, 1000);
     @Mock
     private ICheckpoint checkpoint;
     @Mock
@@ -93,6 +96,7 @@ public class ConsumerStatesTest {
         when(consumer.getShardInfo()).thenReturn(shardInfo);
         when(consumer.getDataFetcher()).thenReturn(dataFetcher);
         when(consumer.getLeaseManager()).thenReturn(leaseManager);
+        when(consumer.getLeaseCoordinator()).thenReturn(leaseCoordinator);
         when(consumer.getCheckpoint()).thenReturn(checkpoint);
         when(consumer.getFuture()).thenReturn(future);
         when(consumer.getShutdownNotification()).thenReturn(shutdownNotification);
@@ -294,7 +298,7 @@ public class ConsumerStatesTest {
                 equalTo(recordProcessorCheckpointer)));
         assertThat(task, shutdownTask(ShutdownReason.class, "reason", equalTo(reason)));
         assertThat(task, shutdownTask(IKinesisProxy.class, "kinesisProxy", equalTo(kinesisProxy)));
-        assertThat(task, shutdownTask(LEASE_MANAGER_CLASS, "leaseManager", equalTo(leaseManager)));
+        assertThat(task, shutdownTask(KinesisClientLibLeaseCoordinator.class, "leaseCoordinator", equalTo(leaseCoordinator)));
         assertThat(task, shutdownTask(InitialPositionInStreamExtended.class, "initialPositionInStream",
                 equalTo(initialPositionInStream)));
         assertThat(task,

--- a/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardConsumerTest.java
+++ b/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardConsumerTest.java
@@ -470,15 +470,17 @@ public class ShardConsumerTest {
         final KinesisClientLease parentLease = mock(KinesisClientLease.class);
         when(shardInfo.getShardId()).thenReturn(shardId);
         when(shardInfo.getParentShardIds()).thenReturn(Arrays.asList(parentShardId));
+        when(leaseCoordinator.getLeaseManager()).thenReturn(leaseManager);
         when(leaseManager.getLease(eq(parentShardId))).thenReturn(parentLease);
         when(parentLease.getCheckpoint()).thenReturn(ExtendedSequenceNumber.TRIM_HORIZON);
 
-        final ShardConsumer consumer = new ShardConsumer(shardInfo,
+        final ShardConsumer consumer =
+                new ShardConsumer(shardInfo,
                         streamConfig,
                         checkpoint,
                         processor,
                         recordProcessorCheckpointer,
-                        leaseManager,
+                        leaseCoordinator,
                         parentShardPollIntervalMillis,
                         cleanupLeasesOfCompletedShards,
                         executorService,

--- a/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardSyncTaskIntegrationTest.java
+++ b/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardSyncTaskIntegrationTest.java
@@ -127,7 +127,8 @@ public class ShardSyncTaskIntegrationTest {
                 false,
                 false,
                 0L,
-                shardSyncer);
+                shardSyncer,
+                null);
         syncTask.call();
         List<KinesisClientLease> leases = leaseManager.listLeases();
         Set<String> leaseKeys = new HashSet<String>();

--- a/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardSyncerTest.java
+++ b/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardSyncerTest.java
@@ -25,6 +25,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClient;
 import com.amazonaws.services.dynamodbv2.local.embedded.DynamoDBEmbedded;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -34,7 +37,6 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
 import com.amazonaws.services.kinesis.clientlibrary.exceptions.internal.KinesisClientLibIOException;
 import com.amazonaws.services.kinesis.clientlibrary.lib.worker.ExceptionThrowingLeaseManager.ExceptionThrowingLeaseManagerMethods;
 import com.amazonaws.services.kinesis.clientlibrary.proxies.IKinesisProxy;
@@ -230,7 +232,7 @@ public class ShardSyncerTest {
         IKinesisProxy kinesisProxy = new KinesisLocalFileProxy(dataFile.getAbsolutePath());
 
         shardSyncer.checkAndCreateLeasesForNewShards(kinesisProxy, leaseManager, INITIAL_POSITION_LATEST,
-                cleanupLeasesOfCompletedShards, false);
+                cleanupLeasesOfCompletedShards, false, shards);
         List<KinesisClientLease> newLeases = leaseManager.listLeases();
         Set<String> expectedLeaseShardIds = new HashSet<String>();
         expectedLeaseShardIds.add("shardId-4");
@@ -262,7 +264,7 @@ public class ShardSyncerTest {
         IKinesisProxy kinesisProxy = new KinesisLocalFileProxy(dataFile.getAbsolutePath());
 
         shardSyncer.checkAndCreateLeasesForNewShards(kinesisProxy, leaseManager, INITIAL_POSITION_TRIM_HORIZON,
-                cleanupLeasesOfCompletedShards, false);
+                cleanupLeasesOfCompletedShards, false, shards);
         List<KinesisClientLease> newLeases = leaseManager.listLeases();
         Set<String> expectedLeaseShardIds = new HashSet<String>();
         for (int i = 0; i < 11; i++) {
@@ -293,7 +295,7 @@ public class ShardSyncerTest {
         IKinesisProxy kinesisProxy = new KinesisLocalFileProxy(dataFile.getAbsolutePath());
 
         shardSyncer.checkAndCreateLeasesForNewShards(kinesisProxy, leaseManager, INITIAL_POSITION_AT_TIMESTAMP,
-                cleanupLeasesOfCompletedShards, false);
+                cleanupLeasesOfCompletedShards, false, shards);
         List<KinesisClientLease> newLeases = leaseManager.listLeases();
         Set<String> expectedLeaseShardIds = new HashSet<String>();
         for (int i = 0; i < 11; i++) {
@@ -327,7 +329,7 @@ public class ShardSyncerTest {
         IKinesisProxy kinesisProxy = new KinesisLocalFileProxy(dataFile.getAbsolutePath());
 
         shardSyncer.checkAndCreateLeasesForNewShards(kinesisProxy, leaseManager, INITIAL_POSITION_TRIM_HORIZON,
-                cleanupLeasesOfCompletedShards, false);
+                cleanupLeasesOfCompletedShards, false, shards);
         dataFile.delete();
     }
 
@@ -352,7 +354,7 @@ public class ShardSyncerTest {
         dataFile.deleteOnExit();
         IKinesisProxy kinesisProxy = new KinesisLocalFileProxy(dataFile.getAbsolutePath());
         shardSyncer.checkAndCreateLeasesForNewShards(kinesisProxy, leaseManager, INITIAL_POSITION_LATEST,
-                cleanupLeasesOfCompletedShards, true);
+                cleanupLeasesOfCompletedShards, true, shards);
         List<KinesisClientLease> newLeases = leaseManager.listLeases();
         Set<String> expectedLeaseShardIds = new HashSet<String>();
         expectedLeaseShardIds.add("shardId-4");
@@ -467,7 +469,7 @@ public class ShardSyncerTest {
                             exceptionThrowingLeaseManager,
                             position,
                             cleanupLeasesOfCompletedShards,
-                            false);
+                            false, null);
                     return;
                 } catch (LeasingException e) {
                     LOG.debug("Catch leasing exception", e);
@@ -480,7 +482,7 @@ public class ShardSyncerTest {
                     leaseManager,
                     position,
                     cleanupLeasesOfCompletedShards,
-                    false);
+                    false, null);
         }
     }
 

--- a/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShutdownTaskTest.java
+++ b/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShutdownTaskTest.java
@@ -14,16 +14,22 @@
  */
 package com.amazonaws.services.kinesis.clientlibrary.lib.worker;
 
+import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
-import java.util.concurrent.ExecutorService;
 
-import com.amazonaws.services.kinesis.metrics.interfaces.IMetricsFactory;
+import com.amazonaws.services.kinesis.model.HashKeyRange;
+import com.amazonaws.services.kinesis.model.SequenceNumberRange;
+import com.amazonaws.services.kinesis.model.Shard;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -53,7 +59,7 @@ public class ShutdownTaskTest {
 
     Set<String> defaultParentShardIds = new HashSet<>();
     String defaultConcurrencyToken = "testToken4398";
-    String defaultShardId = "shardId-0000397840";
+    String defaultShardId = "shardId-0";
     ShardInfo defaultShardInfo = new ShardInfo(defaultShardId,
             defaultConcurrencyToken,
             defaultParentShardIds,
@@ -104,7 +110,11 @@ public class ShutdownTaskTest {
         RecordProcessorCheckpointer checkpointer = mock(RecordProcessorCheckpointer.class);
         when(checkpointer.getLastCheckpointValue()).thenReturn(new ExtendedSequenceNumber("3298"));
         IKinesisProxy kinesisProxy = mock(IKinesisProxy.class);
+        List<Shard> shards = constructShardListForGraphA();
+        when(kinesisProxy.getShardList()).thenReturn(shards);
+        KinesisClientLibLeaseCoordinator leaseCoordinator = mock(KinesisClientLibLeaseCoordinator.class);
         ILeaseManager<KinesisClientLease> leaseManager = mock(KinesisClientLeaseManager.class);
+        when(leaseCoordinator.getLeaseManager()).thenReturn(leaseManager);
         boolean cleanupLeasesOfCompletedShards = false;
         boolean ignoreUnexpectedChildShards = false;
         ShutdownTask task = new ShutdownTask(defaultShardInfo,
@@ -115,7 +125,7 @@ public class ShutdownTaskTest {
                 INITIAL_POSITION_TRIM_HORIZON,
                 cleanupLeasesOfCompletedShards,
                 ignoreUnexpectedChildShards,
-                leaseManager,
+                leaseCoordinator,
                 TASK_BACKOFF_TIME_MILLIS,
                 getRecordsCache,
                 shardSyncer,
@@ -132,12 +142,17 @@ public class ShutdownTaskTest {
     public final void testCallWhenSyncingShardsThrows() {
         RecordProcessorCheckpointer checkpointer = mock(RecordProcessorCheckpointer.class);
         when(checkpointer.getLastCheckpointValue()).thenReturn(ExtendedSequenceNumber.SHARD_END);
+        List<Shard> shards = constructShardListForGraphA();
         IKinesisProxy kinesisProxy = mock(IKinesisProxy.class);
-        when(kinesisProxy.getShardList()).thenReturn(null);
+        when(kinesisProxy.getShardList()).thenReturn(shards);
+        KinesisClientLibLeaseCoordinator leaseCoordinator = mock(KinesisClientLibLeaseCoordinator.class);
         ILeaseManager<KinesisClientLease> leaseManager = mock(KinesisClientLeaseManager.class);
+        when(leaseCoordinator.getLeaseManager()).thenReturn(leaseManager);
+        when(leaseCoordinator.getLeaseManager()).thenReturn(leaseManager);
         boolean cleanupLeasesOfCompletedShards = false;
         boolean ignoreUnexpectedChildShards = false;
-        when(shardSyncStrategy.onShardConsumerShutDown()).thenReturn(new TaskResult(new KinesisClientLibIOException("")));
+
+        when(shardSyncStrategy.onShardConsumerShutDown(shards)).thenReturn(new TaskResult(new KinesisClientLibIOException("")));
         ShutdownTask task = new ShutdownTask(defaultShardInfo,
                 defaultRecordProcessor,
                 checkpointer,
@@ -146,16 +161,129 @@ public class ShutdownTaskTest {
                 INITIAL_POSITION_TRIM_HORIZON,
                 cleanupLeasesOfCompletedShards,
                 ignoreUnexpectedChildShards,
-                leaseManager,
+                leaseCoordinator,
                 TASK_BACKOFF_TIME_MILLIS,
                 getRecordsCache,
                 shardSyncer,
                 shardSyncStrategy);
         TaskResult result = task.call();
-        verify(shardSyncStrategy).onShardConsumerShutDown();
+        verify(shardSyncStrategy).onShardConsumerShutDown(shards);
         Assert.assertNotNull(result.getException());
         Assert.assertTrue(result.getException() instanceof KinesisClientLibIOException);
         verify(getRecordsCache).shutdown();
+    }
+
+    @Test
+    public final void testCallWhenShardEnd() {
+        RecordProcessorCheckpointer checkpointer = mock(RecordProcessorCheckpointer.class);
+        when(checkpointer.getLastCheckpointValue()).thenReturn(ExtendedSequenceNumber.SHARD_END);
+        List<Shard> shards = constructShardListForGraphA();
+        IKinesisProxy kinesisProxy = mock(IKinesisProxy.class);
+        when(kinesisProxy.getShardList()).thenReturn(shards);
+        KinesisClientLibLeaseCoordinator leaseCoordinator = mock(KinesisClientLibLeaseCoordinator.class);
+        ILeaseManager<KinesisClientLease> leaseManager = mock(KinesisClientLeaseManager.class);
+        when(leaseCoordinator.getLeaseManager()).thenReturn(leaseManager);
+        when(leaseCoordinator.getLeaseManager()).thenReturn(leaseManager);
+        boolean cleanupLeasesOfCompletedShards = false;
+        boolean ignoreUnexpectedChildShards = false;
+
+        when(shardSyncStrategy.onShardConsumerShutDown(shards)).thenReturn(new TaskResult(null));
+        ShutdownTask task = new ShutdownTask(defaultShardInfo,
+                                             defaultRecordProcessor,
+                                             checkpointer,
+                                             ShutdownReason.TERMINATE,
+                                             kinesisProxy,
+                                             INITIAL_POSITION_TRIM_HORIZON,
+                                             cleanupLeasesOfCompletedShards,
+                                             ignoreUnexpectedChildShards,
+                                             leaseCoordinator,
+                                             TASK_BACKOFF_TIME_MILLIS,
+                                             getRecordsCache,
+                                             shardSyncer,
+                                             shardSyncStrategy);
+        TaskResult result = task.call();
+        verify(shardSyncStrategy).onShardConsumerShutDown(shards);
+        verify(kinesisProxy, times(1)).getShardList();
+        Assert.assertNull(result.getException());
+        verify(getRecordsCache).shutdown();
+        verify(leaseCoordinator, never()).dropLease(any());
+    }
+
+    @Test
+    public final void testCallWhenFalseShardEnd() {
+        ShardInfo shardInfo = new ShardInfo("shardId-4",
+                                                   defaultConcurrencyToken,
+                                                   defaultParentShardIds,
+                                                   ExtendedSequenceNumber.LATEST);
+        RecordProcessorCheckpointer checkpointer = mock(RecordProcessorCheckpointer.class);
+        when(checkpointer.getLastCheckpointValue()).thenReturn(ExtendedSequenceNumber.SHARD_END);
+        List<Shard> shards = constructShardListForGraphA();
+        IKinesisProxy kinesisProxy = mock(IKinesisProxy.class);
+        when(kinesisProxy.getShardList()).thenReturn(shards);
+        KinesisClientLibLeaseCoordinator leaseCoordinator = mock(KinesisClientLibLeaseCoordinator.class);
+        ILeaseManager<KinesisClientLease> leaseManager = mock(KinesisClientLeaseManager.class);
+        when(leaseCoordinator.getLeaseManager()).thenReturn(leaseManager);
+        when(leaseCoordinator.getCurrentlyHeldLease(shardInfo.getShardId())).thenReturn(new KinesisClientLease());
+        boolean cleanupLeasesOfCompletedShards = false;
+        boolean ignoreUnexpectedChildShards = false;
+
+        when(shardSyncStrategy.onShardConsumerShutDown(shards)).thenReturn(new TaskResult(null));
+
+        ShutdownTask task = new ShutdownTask(shardInfo,
+                                             defaultRecordProcessor,
+                                             checkpointer,
+                                             ShutdownReason.TERMINATE,
+                                             kinesisProxy,
+                                             INITIAL_POSITION_TRIM_HORIZON,
+                                             cleanupLeasesOfCompletedShards,
+                                             ignoreUnexpectedChildShards,
+                                             leaseCoordinator,
+                                             TASK_BACKOFF_TIME_MILLIS,
+                                             getRecordsCache,
+                                             shardSyncer,
+                                             shardSyncStrategy);
+        TaskResult result = task.call();
+        verify(shardSyncStrategy, never()).onShardConsumerShutDown(shards);
+        verify(kinesisProxy, times(1)).getShardList();
+        Assert.assertNull(result.getException());
+        verify(getRecordsCache).shutdown();
+        verify(leaseCoordinator).dropLease(any());
+    }
+
+    @Test
+    public final void testCallWhenLeaseLost() {
+        RecordProcessorCheckpointer checkpointer = mock(RecordProcessorCheckpointer.class);
+        when(checkpointer.getLastCheckpointValue()).thenReturn(new ExtendedSequenceNumber("3298"));
+        List<Shard> shards = constructShardListForGraphA();
+        IKinesisProxy kinesisProxy = mock(IKinesisProxy.class);
+        when(kinesisProxy.getShardList()).thenReturn(shards);
+        KinesisClientLibLeaseCoordinator leaseCoordinator = mock(KinesisClientLibLeaseCoordinator.class);
+        ILeaseManager<KinesisClientLease> leaseManager = mock(KinesisClientLeaseManager.class);
+        when(leaseCoordinator.getLeaseManager()).thenReturn(leaseManager);
+        when(leaseCoordinator.getLeaseManager()).thenReturn(leaseManager);
+        boolean cleanupLeasesOfCompletedShards = false;
+        boolean ignoreUnexpectedChildShards = false;
+
+        when(shardSyncStrategy.onShardConsumerShutDown(shards)).thenReturn(new TaskResult(null));
+        ShutdownTask task = new ShutdownTask(defaultShardInfo,
+                                             defaultRecordProcessor,
+                                             checkpointer,
+                                             ShutdownReason.ZOMBIE,
+                                             kinesisProxy,
+                                             INITIAL_POSITION_TRIM_HORIZON,
+                                             cleanupLeasesOfCompletedShards,
+                                             ignoreUnexpectedChildShards,
+                                             leaseCoordinator,
+                                             TASK_BACKOFF_TIME_MILLIS,
+                                             getRecordsCache,
+                                             shardSyncer,
+                                             shardSyncStrategy);
+        TaskResult result = task.call();
+        verify(shardSyncStrategy, never()).onShardConsumerShutDown(shards);
+        verify(kinesisProxy, never()).getShardList();
+        Assert.assertNull(result.getException());
+        verify(getRecordsCache).shutdown();
+        verify(leaseCoordinator, never()).dropLease(any());
     }
 
     /**
@@ -163,8 +291,57 @@ public class ShutdownTaskTest {
      */
     @Test
     public final void testGetTaskType() {
-        ShutdownTask task = new ShutdownTask(null, null, null, null, null, null, false, false, null, 0, getRecordsCache, shardSyncer, shardSyncStrategy);
+        KinesisClientLibLeaseCoordinator leaseCoordinator = mock(KinesisClientLibLeaseCoordinator.class);
+        ShutdownTask task = new ShutdownTask(null, null, null, null, null, null, false, false, leaseCoordinator, 0, getRecordsCache, shardSyncer, shardSyncStrategy);
         Assert.assertEquals(TaskType.SHUTDOWN, task.getTaskType());
+    }
+
+
+    /*
+     * Helper method to construct a shard list for graph A. Graph A is defined below.
+     * Shard structure (y-axis is epochs):
+     * 0 1 2 3 4   5- shards till epoch 102
+     * \ / \ / |  |
+     *  6   7  4   5- shards from epoch 103 - 205
+     *   \ /   |  /\
+     *    8    4 9 10 - shards from epoch 206 (open - no ending sequenceNumber)
+     */
+    private List<Shard> constructShardListForGraphA() {
+        List<Shard> shards = new ArrayList<Shard>();
+
+        SequenceNumberRange range0 = ShardObjectHelper.newSequenceNumberRange("11", "102");
+        SequenceNumberRange range1 = ShardObjectHelper.newSequenceNumberRange("11", null);
+        SequenceNumberRange range2 = ShardObjectHelper.newSequenceNumberRange("11", "210");
+        SequenceNumberRange range3 = ShardObjectHelper.newSequenceNumberRange("103", "210");
+        SequenceNumberRange range4 = ShardObjectHelper.newSequenceNumberRange("211", null);
+
+        HashKeyRange hashRange0 = ShardObjectHelper.newHashKeyRange("0", "99");
+        HashKeyRange hashRange1 = ShardObjectHelper.newHashKeyRange("100", "199");
+        HashKeyRange hashRange2 = ShardObjectHelper.newHashKeyRange("200", "299");
+        HashKeyRange hashRange3 = ShardObjectHelper.newHashKeyRange("300", "399");
+        HashKeyRange hashRange4 = ShardObjectHelper.newHashKeyRange("400", "499");
+        HashKeyRange hashRange5 = ShardObjectHelper.newHashKeyRange("500", ShardObjectHelper.MAX_HASH_KEY);
+        HashKeyRange hashRange6 = ShardObjectHelper.newHashKeyRange("0", "199");
+        HashKeyRange hashRange7 = ShardObjectHelper.newHashKeyRange("200", "399");
+        HashKeyRange hashRange8 = ShardObjectHelper.newHashKeyRange("0", "399");
+        HashKeyRange hashRange9 = ShardObjectHelper.newHashKeyRange("500", "799");
+        HashKeyRange hashRange10 = ShardObjectHelper.newHashKeyRange("800", ShardObjectHelper.MAX_HASH_KEY);
+
+        shards.add(ShardObjectHelper.newShard("shardId-0", null, null, range0, hashRange0));
+        shards.add(ShardObjectHelper.newShard("shardId-1", null, null, range0, hashRange1));
+        shards.add(ShardObjectHelper.newShard("shardId-2", null, null, range0, hashRange2));
+        shards.add(ShardObjectHelper.newShard("shardId-3", null, null, range0, hashRange3));
+        shards.add(ShardObjectHelper.newShard("shardId-4", null, null, range1, hashRange4));
+        shards.add(ShardObjectHelper.newShard("shardId-5", null, null, range2, hashRange5));
+
+        shards.add(ShardObjectHelper.newShard("shardId-6", "shardId-0", "shardId-1", range3, hashRange6));
+        shards.add(ShardObjectHelper.newShard("shardId-7", "shardId-2", "shardId-3", range3, hashRange7));
+
+        shards.add(ShardObjectHelper.newShard("shardId-8", "shardId-6", "shardId-7", range4, hashRange8));
+        shards.add(ShardObjectHelper.newShard("shardId-9", "shardId-5", null, range4, hashRange9));
+        shards.add(ShardObjectHelper.newShard("shardId-10", null, "shardId-5", range4, hashRange10));
+
+        return shards;
     }
 
 }

--- a/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/WorkerTest.java
+++ b/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/WorkerTest.java
@@ -21,7 +21,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
@@ -53,7 +52,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.Callable;
@@ -1098,6 +1096,63 @@ public class WorkerTest {
 
         assertThat(worker.shouldShutdown(), equalTo(true));
 
+    }
+
+    private String randomShardId() {
+        return UUID.randomUUID().toString();
+    }
+
+    @Test
+    public void testShutdownDoesNotBlockOnCompletedLeases() throws Exception {
+        final String shardId = randomShardId();
+        final String parentShardId = randomShardId();
+        final KinesisClientLease completedLease = mock(KinesisClientLease.class);
+        when(completedLease.getLeaseKey()).thenReturn(shardId);
+        when(completedLease.getParentShardIds()).thenReturn(Collections.singleton(parentShardId));
+        when(completedLease.getCheckpoint()).thenReturn(ExtendedSequenceNumber.SHARD_END);
+        when(completedLease.getConcurrencyToken()).thenReturn(UUID.randomUUID());
+        final StreamConfig streamConfig = mock(StreamConfig.class);
+        final IMetricsFactory metricsFactory = mock(IMetricsFactory.class);
+        final List<KinesisClientLease> leases = Collections.singletonList(completedLease);
+        final List<ShardInfo> currentAssignments = new ArrayList<>();
+
+        when(leaseCoordinator.getAssignments()).thenAnswer((Answer<List<KinesisClientLease>>) invocation -> leases);
+        when(leaseCoordinator.getCurrentAssignments()).thenAnswer((Answer<List<ShardInfo>>) invocation -> currentAssignments);
+
+        final IRecordProcessorFactory recordProcessorFactory = mock(IRecordProcessorFactory.class);
+        final IRecordProcessor processor = mock(IRecordProcessor.class);
+        when(recordProcessorFactory.createProcessor()).thenReturn(processor);
+
+        Worker worker = new Worker("testShutdownWithCompletedLeases",
+                recordProcessorFactory,
+                config,
+                streamConfig,
+                INITIAL_POSITION_TRIM_HORIZON,
+                parentShardPollIntervalMillis,
+                shardSyncIntervalMillis,
+                cleanupLeasesUponShardCompletion,
+                leaseCoordinator,
+                leaseCoordinator,
+                executorService,
+                metricsFactory,
+                taskBackoffTimeMillis,
+                failoverTimeMillis,
+                false,
+                shardPrioritization);
+
+        final Map<ShardInfo, ShardConsumer> shardInfoShardConsumerMap = worker.getShardInfoShardConsumerMap();
+        final ShardInfo completedShardInfo = KinesisClientLibLeaseCoordinator.convertLeaseToAssignment(completedLease);
+        final ShardConsumer completedShardConsumer = mock(ShardConsumer.class);
+        shardInfoShardConsumerMap.put(completedShardInfo, completedShardConsumer);
+        when(completedShardConsumer.getCurrentState()).thenReturn(ConsumerStates.ShardConsumerState.SHUTDOWN_COMPLETE);
+
+        Callable<GracefulShutdownContext> callable = worker.createWorkerShutdownCallable();
+        assertThat(worker.hasGracefulShutdownStarted(), equalTo(false));
+
+        GracefulShutdownContext gracefulShutdownContext = callable.call();
+        assertThat(gracefulShutdownContext.getShutdownCompleteLatch().getCount(), equalTo(0L));
+        assertThat(gracefulShutdownContext.getNotificationCompleteLatch().getCount(), equalTo(0L));
+        assertThat(worker.hasGracefulShutdownStarted(), equalTo(true));
     }
 
     @Test


### PR DESCRIPTION
*Description of changes:*
Graceful shutdown gets blocked by shard consumers that are either already in shutdown state or are blocked on parent tasks. This change avoids over-counting consumers in the graceful shutdown latch, and allows blocked tasks to transition to shutdown state when shutdown is requested.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
