### PR TITLE
Shard end v1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <artifactId>amazon-kinesis-client</artifactId>
   <packaging>jar</packaging>
   <name>Amazon Kinesis Client Library for Java</name>
-  <version>1.11.3</version>
+  <version>1.11.3-SNAPSHOT</version>
   <description>The Amazon Kinesis Client Library for Java enables Java developers to easily consume and process data
     from Amazon Kinesis.
   </description>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <artifactId>amazon-kinesis-client</artifactId>
   <packaging>jar</packaging>
   <name>Amazon Kinesis Client Library for Java</name>
-  <version>1.11.3-SNAPSHOT</version>
+  <version>1.11.3</version>
   <description>The Amazon Kinesis Client Library for Java enables Java developers to easily consume and process data
     from Amazon Kinesis.
   </description>

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ConsumerStates.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ConsumerStates.java
@@ -528,7 +528,7 @@ class ConsumerStates {
                     consumer.getStreamConfig().getInitialPositionInStream(),
                     consumer.isCleanupLeasesOfCompletedShards(),
                     consumer.isIgnoreUnexpectedChildShards(),
-                    consumer.getLeaseManager(),
+                    consumer.getLeaseCoordinator(),
                     consumer.getTaskBackoffTimeMillis(),
                     consumer.getGetRecordsCache(), consumer.getShardSyncer(), consumer.getShardSyncStrategy());
         }

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/KinesisShardSyncer.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/KinesisShardSyncer.java
@@ -63,50 +63,50 @@ class KinesisShardSyncer implements ShardSyncer {
             boolean ignoreUnexpectedChildShards)
             throws DependencyException, InvalidStateException, ProvisionedThroughputException,
             KinesisClientLibIOException {
-        syncShardLeases(null, kinesisProxy, leaseManager, initialPositionInStream, cleanupLeasesOfCompletedShards,
-                ignoreUnexpectedChildShards);
+        syncShardLeases(kinesisProxy, leaseManager, initialPositionInStream, cleanupLeasesOfCompletedShards,
+                ignoreUnexpectedChildShards, null);
     }
 
     /**
      * Check and create leases for any new shards (e.g. following a reshard operation).
      *
-     * @param shards
      * @param kinesisProxy
      * @param leaseManager
      * @param initialPositionInStream
      * @param cleanupLeasesOfCompletedShards
      * @param ignoreUnexpectedChildShards
+     * @param shards This parameter is to reuse the listShards result from Shutdown Task
      * @throws DependencyException
      * @throws InvalidStateException
      * @throws ProvisionedThroughputException
      * @throws KinesisClientLibIOException
      */
-    public synchronized void checkAndCreateLeasesForNewShards(List<Shard> shards, IKinesisProxy kinesisProxy,
+    public synchronized void checkAndCreateLeasesForNewShards(IKinesisProxy kinesisProxy,
             ILeaseManager<KinesisClientLease> leaseManager, InitialPositionInStreamExtended initialPositionInStream,
-            boolean cleanupLeasesOfCompletedShards, boolean ignoreUnexpectedChildShards)
+            boolean cleanupLeasesOfCompletedShards, boolean ignoreUnexpectedChildShards, List<Shard> shards)
             throws DependencyException, InvalidStateException, ProvisionedThroughputException,
             KinesisClientLibIOException {
-        syncShardLeases(shards, kinesisProxy, leaseManager, initialPositionInStream, cleanupLeasesOfCompletedShards, ignoreUnexpectedChildShards);
+        syncShardLeases(kinesisProxy, leaseManager, initialPositionInStream, cleanupLeasesOfCompletedShards, ignoreUnexpectedChildShards, shards);
     }
 
     /**
      * Sync leases with Kinesis shards (e.g. at startup, or when we reach end of a shard).
      *
-     * @param allShards
      * @param kinesisProxy
      * @param leaseManager
      * @param initialPosition
      * @param cleanupLeasesOfCompletedShards
      * @param ignoreUnexpectedChildShards
+     * @param allShards This parameter is to reuse the listShards result from Shutdown Task
      * @throws DependencyException
      * @throws InvalidStateException
      * @throws ProvisionedThroughputException
      * @throws KinesisClientLibIOException
      */
     // CHECKSTYLE:OFF CyclomaticComplexity
-    private synchronized void syncShardLeases(List<Shard> allShards, IKinesisProxy kinesisProxy,
+    private synchronized void syncShardLeases(IKinesisProxy kinesisProxy,
             ILeaseManager<KinesisClientLease> leaseManager, InitialPositionInStreamExtended initialPosition,
-            boolean cleanupLeasesOfCompletedShards, boolean ignoreUnexpectedChildShards)
+            boolean cleanupLeasesOfCompletedShards, boolean ignoreUnexpectedChildShards, List<Shard> allShards)
             throws DependencyException, InvalidStateException, ProvisionedThroughputException,
             KinesisClientLibIOException {
         List<Shard> shards;
@@ -115,7 +115,7 @@ class KinesisShardSyncer implements ShardSyncer {
         } else {
             shards = allShards;
         }
-        LOG.debug("Start shard syncing... The total number of shards found: " + shards.size());
+        LOG.debug("Num Shards: " + shards.size());
 
         Map<String, Shard> shardIdToShardMap = constructShardIdToShardMap(shards);
         Map<String, Set<String>> shardIdToChildShardIdsMap = constructShardIdToChildShardIdsMap(shardIdToShardMap);

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/KinesisShardSyncer.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/KinesisShardSyncer.java
@@ -115,7 +115,7 @@ class KinesisShardSyncer implements ShardSyncer {
         } else {
             shards = allShards;
         }
-        LOG.debug("Num shards: " + shards.size());
+        LOG.debug("Start shard syncing... The total number of shards found: " + shards.size());
 
         Map<String, Shard> shardIdToShardMap = constructShardIdToShardMap(shards);
         Map<String, Set<String>> shardIdToChildShardIdsMap = constructShardIdToChildShardIdsMap(shardIdToShardMap);

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/KinesisShardSyncer.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/KinesisShardSyncer.java
@@ -345,7 +345,7 @@ class KinesisShardSyncer implements ShardSyncer {
         return shardIdToChildShardIdsMap;
     }
 
-    public List<Shard> getShardList(IKinesisProxy kinesisProxy) throws KinesisClientLibIOException {
+    private List<Shard> getShardList(IKinesisProxy kinesisProxy) throws KinesisClientLibIOException {
         List<Shard> shards = kinesisProxy.getShardList();
         if (shards == null) {
             throw new KinesisClientLibIOException(

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/KinesisShardSyncer.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/KinesisShardSyncer.java
@@ -70,6 +70,7 @@ class KinesisShardSyncer implements ShardSyncer {
     /**
      * Check and create leases for any new shards (e.g. following a reshard operation).
      *
+     * @param shards
      * @param kinesisProxy
      * @param leaseManager
      * @param initialPositionInStream
@@ -91,6 +92,7 @@ class KinesisShardSyncer implements ShardSyncer {
     /**
      * Sync leases with Kinesis shards (e.g. at startup, or when we reach end of a shard).
      *
+     * @param allShards
      * @param kinesisProxy
      * @param leaseManager
      * @param initialPosition
@@ -108,12 +110,12 @@ class KinesisShardSyncer implements ShardSyncer {
             throws DependencyException, InvalidStateException, ProvisionedThroughputException,
             KinesisClientLibIOException {
         List<Shard> shards;
-        if(!CollectionUtils.isNullOrEmpty(allShards)) {
-            shards = allShards;
-        } else {
+        if(CollectionUtils.isNullOrEmpty(allShards)) {
             shards = getShardList((kinesisProxy));
+        } else {
+            shards = allShards;
         }
-        //LOG.debug("Num shards: " + shards.size());
+        LOG.debug("Num shards: " + shards.size());
 
         Map<String, Shard> shardIdToShardMap = constructShardIdToShardMap(shards);
         Map<String, Set<String>> shardIdToChildShardIdsMap = constructShardIdToChildShardIdsMap(shardIdToShardMap);

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/KinesisShardSyncer.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/KinesisShardSyncer.java
@@ -80,6 +80,7 @@ class KinesisShardSyncer implements ShardSyncer {
      * @throws ProvisionedThroughputException
      * @throws KinesisClientLibIOException
      */
+    @Override
     public synchronized void checkAndCreateLeasesForNewShards(IKinesisProxy kinesisProxy, ILeaseManager<KinesisClientLease> leaseManager,
                                           InitialPositionInStreamExtended initialPositionInStream, boolean cleanupLeasesOfCompletedShards,
                                           boolean ignoreUnexpectedChildShards)
@@ -96,7 +97,7 @@ class KinesisShardSyncer implements ShardSyncer {
      * @param initialPositionInStream
      * @param cleanupLeasesOfCompletedShards
      * @param ignoreUnexpectedChildShards
-     * @param latestShards latestShards latest snapshot of shards to reuse
+     * @param latestShards latest snapshot of shards to reuse
      * @throws DependencyException
      * @throws InvalidStateException
      * @throws ProvisionedThroughputException
@@ -141,7 +142,7 @@ class KinesisShardSyncer implements ShardSyncer {
      * @param initialPosition
      * @param cleanupLeasesOfCompletedShards
      * @param ignoreUnexpectedChildShards
-     * @param latestShards latestShards latest snapshot of shards to reuse
+     * @param latestShards latest snapshot of shards to reuse
      * @throws DependencyException
      * @throws InvalidStateException
      * @throws ProvisionedThroughputException

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/KinesisShardSyncer.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/KinesisShardSyncer.java
@@ -345,7 +345,7 @@ class KinesisShardSyncer implements ShardSyncer {
         return shardIdToChildShardIdsMap;
     }
 
-    private List<Shard> getShardList(IKinesisProxy kinesisProxy) throws KinesisClientLibIOException {
+    public List<Shard> getShardList(IKinesisProxy kinesisProxy) throws KinesisClientLibIOException {
         List<Shard> shards = kinesisProxy.getShardList();
         if (shards == null) {
             throw new KinesisClientLibIOException(

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/PeriodicShardSyncStrategy.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/PeriodicShardSyncStrategy.java
@@ -1,5 +1,9 @@
 package com.amazonaws.services.kinesis.clientlibrary.lib.worker;
 
+import com.amazonaws.services.kinesis.model.Shard;
+
+import java.util.List;
+
 /**
  * An implementation of ShardSyncStrategy.
  */
@@ -33,6 +37,11 @@ class PeriodicShardSyncStrategy implements ShardSyncStrategy {
 
     @Override
     public TaskResult onShardConsumerShutDown() {
+        return new TaskResult(null);
+    }
+
+    @Override
+    public TaskResult onShardConsumerShutDown(List<Shard> shards) {
         return new TaskResult(null);
     }
 

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/PeriodicShardSyncStrategy.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/PeriodicShardSyncStrategy.java
@@ -1,8 +1,5 @@
 package com.amazonaws.services.kinesis.clientlibrary.lib.worker;
 
-import com.amazonaws.services.kinesis.model.Shard;
-
-import java.util.List;
 
 /**
  * An implementation of ShardSyncStrategy.

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/PeriodicShardSyncStrategy.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/PeriodicShardSyncStrategy.java
@@ -41,11 +41,6 @@ class PeriodicShardSyncStrategy implements ShardSyncStrategy {
     }
 
     @Override
-    public TaskResult onShardConsumerShutDown(List<Shard> shards) {
-        return new TaskResult(null);
-    }
-
-    @Override
     public void onWorkerShutDown() {
         periodicShardSyncManager.stop();
     }

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardConsumer.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardConsumer.java
@@ -50,7 +50,6 @@ class ShardConsumer {
     private final ShardInfo shardInfo;
     private final KinesisDataFetcher dataFetcher;
     private final IMetricsFactory metricsFactory;
-    private final ILeaseManager<KinesisClientLease> leaseManager;
     private final KinesisClientLibLeaseCoordinator leaseCoordinator;
     private ICheckpoint checkpoint;
     // Backoff time when polling to check if application has finished processing parent shards
@@ -99,7 +98,7 @@ class ShardConsumer {
      * @param checkpoint Checkpoint tracker
      * @param recordProcessor Record processor used to process the data records for the shard
      * @param config Kinesis library configuration
-     * @param leaseCoordinator Used to create leases for new shards
+     * @param leaseCoordinator Used to pass in leaseManager and force losing lease for some shutdown scenarios
      * @param parentShardPollIntervalMillis Wait for this long if parent shards are not done (or we get an exception)
      * @param executorService ExecutorService used to execute process tasks for this shard
      * @param metricsFactory IMetricsFactory used to construct IMetricsScopes for this shard
@@ -232,7 +231,6 @@ class ShardConsumer {
         this.checkpoint = checkpoint;
         this.recordProcessor = recordProcessor;
         this.recordProcessorCheckpointer = recordProcessorCheckpointer;
-        this.leaseManager = leaseCoordinator.getLeaseManager();
         this.leaseCoordinator = leaseCoordinator;
         this.parentShardPollIntervalMillis = parentShardPollIntervalMillis;
         this.cleanupLeasesOfCompletedShards = cleanupLeasesOfCompletedShards;
@@ -480,7 +478,7 @@ class ShardConsumer {
     }
 
     ILeaseManager<KinesisClientLease> getLeaseManager() {
-        return leaseManager;
+        return leaseCoordinator.getLeaseManager();
     }
 
     KinesisClientLibLeaseCoordinator getLeaseCoordinator() {

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardConsumer.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardConsumer.java
@@ -98,7 +98,7 @@ class ShardConsumer {
      * @param checkpoint Checkpoint tracker
      * @param recordProcessor Record processor used to process the data records for the shard
      * @param config Kinesis library configuration
-     * @param leaseCoordinator Used to pass in leaseManager and force losing lease for some shutdown scenarios
+     * @param leaseCoordinator Used to manage the leases
      * @param parentShardPollIntervalMillis Wait for this long if parent shards are not done (or we get an exception)
      * @param executorService ExecutorService used to execute process tasks for this shard
      * @param metricsFactory IMetricsFactory used to construct IMetricsScopes for this shard

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardConsumer.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardConsumer.java
@@ -51,6 +51,7 @@ class ShardConsumer {
     private final KinesisDataFetcher dataFetcher;
     private final IMetricsFactory metricsFactory;
     private final ILeaseManager<KinesisClientLease> leaseManager;
+    private final KinesisClientLibLeaseCoordinator leaseCoordinator;
     private ICheckpoint checkpoint;
     // Backoff time when polling to check if application has finished processing parent shards
     private final long parentShardPollIntervalMillis;
@@ -98,7 +99,7 @@ class ShardConsumer {
      * @param checkpoint Checkpoint tracker
      * @param recordProcessor Record processor used to process the data records for the shard
      * @param config Kinesis library configuration
-     * @param leaseManager Used to create leases for new shards
+     * @param leaseCoordinator Used to create leases for new shards
      * @param parentShardPollIntervalMillis Wait for this long if parent shards are not done (or we get an exception)
      * @param executorService ExecutorService used to execute process tasks for this shard
      * @param metricsFactory IMetricsFactory used to construct IMetricsScopes for this shard
@@ -110,7 +111,7 @@ class ShardConsumer {
             StreamConfig streamConfig,
             ICheckpoint checkpoint,
             IRecordProcessor recordProcessor,
-            ILeaseManager<KinesisClientLease> leaseManager,
+            KinesisClientLibLeaseCoordinator leaseCoordinator,
             long parentShardPollIntervalMillis,
             boolean cleanupLeasesOfCompletedShards,
             ExecutorService executorService,
@@ -122,7 +123,7 @@ class ShardConsumer {
                 streamConfig,
                 checkpoint,
                 recordProcessor,
-                leaseManager,
+                leaseCoordinator,
                 parentShardPollIntervalMillis,
                 cleanupLeasesOfCompletedShards,
                 executorService,
@@ -139,7 +140,7 @@ class ShardConsumer {
      * @param streamConfig Stream configuration to use
      * @param checkpoint Checkpoint tracker
      * @param recordProcessor Record processor used to process the data records for the shard
-     * @param leaseManager Used to create leases for new shards
+     * @param leaseCoordinator Used to create leases for new shards
      * @param parentShardPollIntervalMillis Wait for this long if parent shards are not done (or we get an exception)
      * @param executorService ExecutorService used to execute process tasks for this shard
      * @param metricsFactory IMetricsFactory used to construct IMetricsScopes for this shard
@@ -154,7 +155,7 @@ class ShardConsumer {
             StreamConfig streamConfig,
             ICheckpoint checkpoint,
             IRecordProcessor recordProcessor,
-            ILeaseManager<KinesisClientLease> leaseManager,
+            KinesisClientLibLeaseCoordinator leaseCoordinator,
             long parentShardPollIntervalMillis,
             boolean cleanupLeasesOfCompletedShards,
             ExecutorService executorService,
@@ -177,7 +178,7 @@ class ShardConsumer {
                                 shardInfo.getShardId(),
                                 streamConfig.shouldValidateSequenceNumberBeforeCheckpointing()),
                         metricsFactory),
-                leaseManager,
+                leaseCoordinator,
                 parentShardPollIntervalMillis,
                 cleanupLeasesOfCompletedShards,
                 executorService,
@@ -197,7 +198,7 @@ class ShardConsumer {
      * @param checkpoint Checkpoint tracker
      * @param recordProcessor Record processor used to process the data records for the shard
      * @param recordProcessorCheckpointer RecordProcessorCheckpointer to use to checkpoint progress
-     * @param leaseManager Used to create leases for new shards
+     * @param leaseCoordinator Used to create leases for new shards
      * @param parentShardPollIntervalMillis Wait for this long if parent shards are not done (or we get an exception)
      * @param cleanupLeasesOfCompletedShards  clean up the leases of completed shards
      * @param executorService ExecutorService used to execute process tasks for this shard
@@ -215,7 +216,7 @@ class ShardConsumer {
             ICheckpoint checkpoint,
             IRecordProcessor recordProcessor,
             RecordProcessorCheckpointer recordProcessorCheckpointer,
-            ILeaseManager<KinesisClientLease> leaseManager,
+            KinesisClientLibLeaseCoordinator leaseCoordinator,
             long parentShardPollIntervalMillis,
             boolean cleanupLeasesOfCompletedShards,
             ExecutorService executorService,
@@ -231,7 +232,8 @@ class ShardConsumer {
         this.checkpoint = checkpoint;
         this.recordProcessor = recordProcessor;
         this.recordProcessorCheckpointer = recordProcessorCheckpointer;
-        this.leaseManager = leaseManager;
+        this.leaseManager = leaseCoordinator.getLeaseManager();
+        this.leaseCoordinator = leaseCoordinator;
         this.parentShardPollIntervalMillis = parentShardPollIntervalMillis;
         this.cleanupLeasesOfCompletedShards = cleanupLeasesOfCompletedShards;
         this.executorService = executorService;
@@ -479,6 +481,10 @@ class ShardConsumer {
 
     ILeaseManager<KinesisClientLease> getLeaseManager() {
         return leaseManager;
+    }
+
+    KinesisClientLibLeaseCoordinator getLeaseCoordinator() {
+        return leaseCoordinator;
     }
 
     ICheckpoint getCheckpoint() {

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardConsumer.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardConsumer.java
@@ -98,7 +98,7 @@ class ShardConsumer {
      * @param checkpoint Checkpoint tracker
      * @param recordProcessor Record processor used to process the data records for the shard
      * @param config Kinesis library configuration
-     * @param leaseCoordinator Used to manage the leases
+     * @param leaseCoordinator Used to manage leases for current worker
      * @param parentShardPollIntervalMillis Wait for this long if parent shards are not done (or we get an exception)
      * @param executorService ExecutorService used to execute process tasks for this shard
      * @param metricsFactory IMetricsFactory used to construct IMetricsScopes for this shard
@@ -139,7 +139,7 @@ class ShardConsumer {
      * @param streamConfig Stream configuration to use
      * @param checkpoint Checkpoint tracker
      * @param recordProcessor Record processor used to process the data records for the shard
-     * @param leaseCoordinator Used to create leases for new shards
+     * @param leaseCoordinator Used to manage leases for current worker
      * @param parentShardPollIntervalMillis Wait for this long if parent shards are not done (or we get an exception)
      * @param executorService ExecutorService used to execute process tasks for this shard
      * @param metricsFactory IMetricsFactory used to construct IMetricsScopes for this shard
@@ -197,7 +197,7 @@ class ShardConsumer {
      * @param checkpoint Checkpoint tracker
      * @param recordProcessor Record processor used to process the data records for the shard
      * @param recordProcessorCheckpointer RecordProcessorCheckpointer to use to checkpoint progress
-     * @param leaseCoordinator Used to create leases for new shards
+     * @param leaseCoordinator Used to manage leases for current worker
      * @param parentShardPollIntervalMillis Wait for this long if parent shards are not done (or we get an exception)
      * @param cleanupLeasesOfCompletedShards  clean up the leases of completed shards
      * @param executorService ExecutorService used to execute process tasks for this shard

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardEndShardSyncStrategy.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardEndShardSyncStrategy.java
@@ -58,8 +58,8 @@ class ShardEndShardSyncStrategy implements ShardSyncStrategy {
     }
 
     @Override
-    public TaskResult onShardConsumerShutDown(List<Shard> shards) {
-        shardSyncTaskManager.syncShardAndLeaseInfo(shards);
+    public TaskResult onShardConsumerShutDown(List<Shard> latestShards) {
+        shardSyncTaskManager.syncShardAndLeaseInfo(latestShards);
         return new TaskResult(null);
     }
 

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardEndShardSyncStrategy.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardEndShardSyncStrategy.java
@@ -57,6 +57,7 @@ class ShardEndShardSyncStrategy implements ShardSyncStrategy {
         return onFoundCompletedShard();
     }
 
+    @Override
     public TaskResult onShardConsumerShutDown(List<Shard> shards) {
         shardSyncTaskManager.syncShardAndLeaseInfo(shards);
         return new TaskResult(null);

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardEndShardSyncStrategy.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardEndShardSyncStrategy.java
@@ -1,8 +1,10 @@
 package com.amazonaws.services.kinesis.clientlibrary.lib.worker;
 
+import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 
+import com.amazonaws.services.kinesis.model.Shard;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -53,6 +55,11 @@ class ShardEndShardSyncStrategy implements ShardSyncStrategy {
     @Override
     public TaskResult onShardConsumerShutDown() {
         return onFoundCompletedShard();
+    }
+
+    public TaskResult onShardConsumerShutDown(List<Shard> shards) {
+        shardSyncTaskManager.syncShardAndLeaseInfo(shards);
+        return new TaskResult(null);
     }
 
     @Override

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardSyncStrategy.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardSyncStrategy.java
@@ -48,7 +48,7 @@ public interface ShardSyncStrategy {
     /**
      * Invoked when ShardConsumer is shutdown and all shards are provided.
      *
-     * @param latestShards - Optional parameter, can be null. Pass in parameter to reuse output from ListShards API.
+     * @param latestShards latest snapshot of shards to reuse
      * @return
      */
     default TaskResult onShardConsumerShutDown(List<Shard> latestShards) {

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardSyncStrategy.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardSyncStrategy.java
@@ -47,6 +47,9 @@ public interface ShardSyncStrategy {
 
     /**
      * Invoked when ShardConsumer is shutdown and all shards are provided.
+     * Shards can be passed in from a previous listShards call.
+     *
+     * @param shards
      *
      * @return
      */

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardSyncStrategy.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardSyncStrategy.java
@@ -47,9 +47,8 @@ public interface ShardSyncStrategy {
 
     /**
      * Invoked when ShardConsumer is shutdown and all shards are provided.
-     * Shards can be passed in from a previous listShards call.
      *
-     * @param shards
+     * @param shards - Optional parameter, can be null. Pass in parameter to reuse output from ListShards API.
      *
      * @return
      */

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardSyncStrategy.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardSyncStrategy.java
@@ -1,5 +1,9 @@
 package com.amazonaws.services.kinesis.clientlibrary.lib.worker;
 
+import com.amazonaws.services.kinesis.model.Shard;
+
+import java.util.List;
+
 /**
  * Facade of methods that can be invoked at different points
  * in KCL application execution to perform certain actions related to shard-sync.
@@ -40,6 +44,13 @@ public interface ShardSyncStrategy {
      * @return
      */
     TaskResult onShardConsumerShutDown();
+
+    /**
+     * Invoked when ShardConsumer is shutdown and all shards are provided.
+     *
+     * @return
+     */
+    TaskResult onShardConsumerShutDown(List<Shard> shards);
 
     /**
      * Invoked when worker is shutdown.

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardSyncStrategy.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardSyncStrategy.java
@@ -48,11 +48,10 @@ public interface ShardSyncStrategy {
     /**
      * Invoked when ShardConsumer is shutdown and all shards are provided.
      *
-     * @param shards - Optional parameter, can be null. Pass in parameter to reuse output from ListShards API.
-     *
+     * @param latestShards - Optional parameter, can be null. Pass in parameter to reuse output from ListShards API.
      * @return
      */
-    default TaskResult onShardConsumerShutDown(List<Shard> shards) {
+    default TaskResult onShardConsumerShutDown(List<Shard> latestShards) {
         return onShardConsumerShutDown();
     }
 

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardSyncStrategy.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardSyncStrategy.java
@@ -52,7 +52,9 @@ public interface ShardSyncStrategy {
      *
      * @return
      */
-    TaskResult onShardConsumerShutDown(List<Shard> shards);
+    default TaskResult onShardConsumerShutDown(List<Shard> shards) {
+        return new TaskResult(null);
+    }
 
     /**
      * Invoked when worker is shutdown.

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardSyncStrategy.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardSyncStrategy.java
@@ -53,7 +53,7 @@ public interface ShardSyncStrategy {
      * @return
      */
     default TaskResult onShardConsumerShutDown(List<Shard> shards) {
-        return new TaskResult(null);
+        return onShardConsumerShutDown();
     }
 
     /**

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardSyncTask.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardSyncTask.java
@@ -45,6 +45,7 @@ class ShardSyncTask implements ITask {
     private final List<Shard> shards;
 
     /**
+     * @param shards Used to provide a list of all shards
      * @param kinesisProxy Used to fetch information about the stream (e.g. shard list)
      * @param leaseManager Used to fetch and create leases
      * @param initialPositionInStream One of LATEST, TRIM_HORIZON or AT_TIMESTAMP. Amazon Kinesis Client Library will

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardSyncTask.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardSyncTask.java
@@ -54,7 +54,7 @@ class ShardSyncTask implements ITask {
      *        in Kinesis)
      * @param shardSyncTaskIdleTimeMillis shardSync task idle time in millis
      * @param shardSyncer shardSyncer instance used to check and create new leases
-     * @param latestShards Used to provide a list of all shards
+     * @param latestShards latest snapshot of shards to reuse
      */
     ShardSyncTask(IKinesisProxy kinesisProxy,
             ILeaseManager<KinesisClientLease> leaseManager,

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardSyncTask.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardSyncTask.java
@@ -42,10 +42,9 @@ class ShardSyncTask implements ITask {
     private final long shardSyncTaskIdleTimeMillis;
     private final TaskType taskType = TaskType.SHARDSYNC;
     private final ShardSyncer shardSyncer;
-    private final List<Shard> shards;
+    private final List<Shard> latestShards;
 
     /**
-     * @param shards Used to provide a list of all shards
      * @param kinesisProxy Used to fetch information about the stream (e.g. shard list)
      * @param leaseManager Used to fetch and create leases
      * @param initialPositionInStream One of LATEST, TRIM_HORIZON or AT_TIMESTAMP. Amazon Kinesis Client Library will
@@ -55,6 +54,7 @@ class ShardSyncTask implements ITask {
      *        in Kinesis)
      * @param shardSyncTaskIdleTimeMillis shardSync task idle time in millis
      * @param shardSyncer shardSyncer instance used to check and create new leases
+     * @param latestShards Used to provide a list of all shards
      */
     ShardSyncTask(IKinesisProxy kinesisProxy,
             ILeaseManager<KinesisClientLease> leaseManager,
@@ -62,8 +62,8 @@ class ShardSyncTask implements ITask {
             boolean cleanupLeasesUponShardCompletion,
             boolean ignoreUnexpectedChildShards,
             long shardSyncTaskIdleTimeMillis,
-            ShardSyncer shardSyncer, List<Shard> shards) {
-        this.shards = shards;
+            ShardSyncer shardSyncer, List<Shard> latestShards) {
+        this.latestShards = latestShards;
         this.kinesisProxy = kinesisProxy;
         this.leaseManager = leaseManager;
         this.initialPosition = initialPositionInStream;
@@ -86,7 +86,7 @@ class ShardSyncTask implements ITask {
                     initialPosition,
                     cleanupLeasesUponShardCompletion,
                     ignoreUnexpectedChildShards,
-                    shards);
+                    latestShards);
             if (shardSyncTaskIdleTimeMillis > 0) {
                 Thread.sleep(shardSyncTaskIdleTimeMillis);
             }

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardSyncTask.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardSyncTask.java
@@ -56,13 +56,13 @@ class ShardSyncTask implements ITask {
      * @param shardSyncTaskIdleTimeMillis shardSync task idle time in millis
      * @param shardSyncer shardSyncer instance used to check and create new leases
      */
-    ShardSyncTask(List<Shard> shards, IKinesisProxy kinesisProxy,
+    ShardSyncTask(IKinesisProxy kinesisProxy,
             ILeaseManager<KinesisClientLease> leaseManager,
             InitialPositionInStreamExtended initialPositionInStream,
             boolean cleanupLeasesUponShardCompletion,
             boolean ignoreUnexpectedChildShards,
             long shardSyncTaskIdleTimeMillis,
-            ShardSyncer shardSyncer) {
+            ShardSyncer shardSyncer, List<Shard> shards) {
         this.shards = shards;
         this.kinesisProxy = kinesisProxy;
         this.leaseManager = leaseManager;
@@ -81,11 +81,12 @@ class ShardSyncTask implements ITask {
         Exception exception = null;
 
         try {
-            shardSyncer.checkAndCreateLeasesForNewShards(shards, kinesisProxy,
+            shardSyncer.checkAndCreateLeasesForNewShards(kinesisProxy,
                     leaseManager,
                     initialPosition,
                     cleanupLeasesUponShardCompletion,
-                    ignoreUnexpectedChildShards);
+                    ignoreUnexpectedChildShards,
+                    shards);
             if (shardSyncTaskIdleTimeMillis > 0) {
                 Thread.sleep(shardSyncTaskIdleTimeMillis);
             }

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardSyncTask.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardSyncTask.java
@@ -14,12 +14,15 @@
  */
 package com.amazonaws.services.kinesis.clientlibrary.lib.worker;
 
+import com.amazonaws.services.kinesis.model.Shard;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
 import com.amazonaws.services.kinesis.clientlibrary.proxies.IKinesisProxy;
 import com.amazonaws.services.kinesis.leases.impl.KinesisClientLease;
 import com.amazonaws.services.kinesis.leases.interfaces.ILeaseManager;
+
+import java.util.List;
 
 /**
  * This task syncs leases/activies with shards of the stream.
@@ -39,6 +42,7 @@ class ShardSyncTask implements ITask {
     private final long shardSyncTaskIdleTimeMillis;
     private final TaskType taskType = TaskType.SHARDSYNC;
     private final ShardSyncer shardSyncer;
+    private final List<Shard> shards;
 
     /**
      * @param kinesisProxy Used to fetch information about the stream (e.g. shard list)
@@ -51,13 +55,14 @@ class ShardSyncTask implements ITask {
      * @param shardSyncTaskIdleTimeMillis shardSync task idle time in millis
      * @param shardSyncer shardSyncer instance used to check and create new leases
      */
-    ShardSyncTask(IKinesisProxy kinesisProxy,
+    ShardSyncTask(List<Shard> shards, IKinesisProxy kinesisProxy,
             ILeaseManager<KinesisClientLease> leaseManager,
             InitialPositionInStreamExtended initialPositionInStream,
             boolean cleanupLeasesUponShardCompletion,
             boolean ignoreUnexpectedChildShards,
             long shardSyncTaskIdleTimeMillis,
             ShardSyncer shardSyncer) {
+        this.shards = shards;
         this.kinesisProxy = kinesisProxy;
         this.leaseManager = leaseManager;
         this.initialPosition = initialPositionInStream;
@@ -75,7 +80,7 @@ class ShardSyncTask implements ITask {
         Exception exception = null;
 
         try {
-            shardSyncer.checkAndCreateLeasesForNewShards(kinesisProxy,
+            shardSyncer.checkAndCreateLeasesForNewShards(shards, kinesisProxy,
                     leaseManager,
                     initialPosition,
                     cleanupLeasesUponShardCompletion,

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardSyncTaskManager.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardSyncTaskManager.java
@@ -87,11 +87,11 @@ class ShardSyncTaskManager {
         this.shardSyncer = shardSyncer;
     }
 
-    synchronized Future<TaskResult> syncShardAndLeaseInfo(List<Shard> shards) {
-        return checkAndSubmitNextTask(shards);
+    synchronized Future<TaskResult> syncShardAndLeaseInfo(List<Shard> latestShards) {
+        return checkAndSubmitNextTask(latestShards);
     }
 
-    private synchronized Future<TaskResult> checkAndSubmitNextTask(List<Shard> shards) {
+    private synchronized Future<TaskResult> checkAndSubmitNextTask(List<Shard> latestShards) {
         Future<TaskResult> submittedTaskFuture = null;
         if ((future == null) || future.isCancelled() || future.isDone()) {
             if ((future != null) && future.isDone()) {
@@ -113,7 +113,7 @@ class ShardSyncTaskManager {
                             cleanupLeasesUponShardCompletion,
                             ignoreUnexpectedChildShards,
                             shardSyncIdleTimeMillis,
-                            shardSyncer, shards), metricsFactory);
+                            shardSyncer, latestShards), metricsFactory);
             future = executorService.submit(currentTask);
             if (LOG.isDebugEnabled()) {
                 LOG.debug("Submitted new " + currentTask.getTaskType() + " task.");

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardSyncTaskManager.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardSyncTaskManager.java
@@ -107,13 +107,13 @@ class ShardSyncTaskManager {
             }
 
             currentTask =
-                    new MetricsCollectingTaskDecorator(new ShardSyncTask(shards, kinesisProxy,
+                    new MetricsCollectingTaskDecorator(new ShardSyncTask(kinesisProxy,
                             leaseManager,
                             initialPositionInStream,
                             cleanupLeasesUponShardCompletion,
                             ignoreUnexpectedChildShards,
                             shardSyncIdleTimeMillis,
-                            shardSyncer), metricsFactory);
+                            shardSyncer, shards), metricsFactory);
             future = executorService.submit(currentTask);
             if (LOG.isDebugEnabled()) {
                 LOG.debug("Submitted new " + currentTask.getTaskType() + " task.");

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardSyncTaskManager.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardSyncTaskManager.java
@@ -14,11 +14,13 @@
  */
 package com.amazonaws.services.kinesis.clientlibrary.lib.worker;
 
+import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 
+import com.amazonaws.services.kinesis.model.Shard;
 import lombok.Getter;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -85,11 +87,11 @@ class ShardSyncTaskManager {
         this.shardSyncer = shardSyncer;
     }
 
-    synchronized Future<TaskResult> syncShardAndLeaseInfo(Set<String> closedShardIds) {
-        return checkAndSubmitNextTask(closedShardIds);
+    synchronized Future<TaskResult> syncShardAndLeaseInfo(List<Shard> shards) {
+        return checkAndSubmitNextTask(shards);
     }
 
-    private synchronized Future<TaskResult> checkAndSubmitNextTask(Set<String> closedShardIds) {
+    private synchronized Future<TaskResult> checkAndSubmitNextTask(List<Shard> shards) {
         Future<TaskResult> submittedTaskFuture = null;
         if ((future == null) || future.isCancelled() || future.isDone()) {
             if ((future != null) && future.isDone()) {
@@ -105,7 +107,7 @@ class ShardSyncTaskManager {
             }
 
             currentTask =
-                    new MetricsCollectingTaskDecorator(new ShardSyncTask(kinesisProxy,
+                    new MetricsCollectingTaskDecorator(new ShardSyncTask(shards, kinesisProxy,
                             leaseManager,
                             initialPositionInStream,
                             cleanupLeasesUponShardCompletion,

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardSyncer.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardSyncer.java
@@ -29,7 +29,15 @@ public interface ShardSyncer {
 
     void checkAndCreateLeasesForNewShards(IKinesisProxy kinesisProxy, ILeaseManager<KinesisClientLease> leaseManager,
                                           InitialPositionInStreamExtended initialPositionInStream, boolean cleanupLeasesOfCompletedShards,
-                                          boolean ignoreUnexpectedChildShards, List<Shard> shards)
+                                          boolean ignoreUnexpectedChildShards)
             throws DependencyException, InvalidStateException, ProvisionedThroughputException,
             KinesisClientLibIOException;
+
+    default void checkAndCreateLeasesForNewShards(IKinesisProxy kinesisProxy, ILeaseManager<KinesisClientLease> leaseManager,
+                                          InitialPositionInStreamExtended initialPositionInStream, boolean cleanupLeasesOfCompletedShards,
+                                          boolean ignoreUnexpectedChildShards, List<Shard> latestShards)
+            throws DependencyException, InvalidStateException, ProvisionedThroughputException,
+            KinesisClientLibIOException {
+        checkAndCreateLeasesForNewShards(kinesisProxy, leaseManager, initialPositionInStream, cleanupLeasesOfCompletedShards, ignoreUnexpectedChildShards);
+    }
 }

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardSyncer.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardSyncer.java
@@ -27,9 +27,9 @@ import java.util.List;
 
 public interface ShardSyncer {
 
-    void checkAndCreateLeasesForNewShards(List<Shard> shards, IKinesisProxy kinesisProxy, ILeaseManager<KinesisClientLease> leaseManager,
+    void checkAndCreateLeasesForNewShards(IKinesisProxy kinesisProxy, ILeaseManager<KinesisClientLease> leaseManager,
                                           InitialPositionInStreamExtended initialPositionInStream, boolean cleanupLeasesOfCompletedShards,
-                                          boolean ignoreUnexpectedChildShards)
+                                          boolean ignoreUnexpectedChildShards, List<Shard> shards)
             throws DependencyException, InvalidStateException, ProvisionedThroughputException,
             KinesisClientLibIOException;
 }

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardSyncer.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardSyncer.java
@@ -21,12 +21,15 @@ import com.amazonaws.services.kinesis.leases.exceptions.InvalidStateException;
 import com.amazonaws.services.kinesis.leases.exceptions.ProvisionedThroughputException;
 import com.amazonaws.services.kinesis.leases.impl.KinesisClientLease;
 import com.amazonaws.services.kinesis.leases.interfaces.ILeaseManager;
+import com.amazonaws.services.kinesis.model.Shard;
+
+import java.util.List;
 
 public interface ShardSyncer {
 
-    void checkAndCreateLeasesForNewShards(IKinesisProxy kinesisProxy, ILeaseManager<KinesisClientLease> leaseManager,
-            InitialPositionInStreamExtended initialPositionInStream, boolean cleanupLeasesOfCompletedShards,
-            boolean ignoreUnexpectedChildShards)
+    void checkAndCreateLeasesForNewShards(List<Shard> shards, IKinesisProxy kinesisProxy, ILeaseManager<KinesisClientLease> leaseManager,
+                                          InitialPositionInStreamExtended initialPositionInStream, boolean cleanupLeasesOfCompletedShards,
+                                          boolean ignoreUnexpectedChildShards)
             throws DependencyException, InvalidStateException, ProvisionedThroughputException,
             KinesisClientLibIOException;
 }

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShutdownTask.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShutdownTask.java
@@ -109,7 +109,7 @@ class ShutdownTask implements ITask {
             if(localReason == ShutdownReason.TERMINATE) {
                 allShards = kinesisProxy.getShardList();
 
-                if(!CollectionUtils.isNullOrEmpty(allShards) && !validateShardEnd(allShards)) {
+                if(!CollectionUtils.isNullOrEmpty(allShards) && !isShardInContextParentOfAny(allShards)) {
                     localReason = ShutdownReason.ZOMBIE;
                     dropLease();
                     LOG.info("Forcing the lease to be lost before shutting down the consumer for Shard: " + shardInfo.getShardId());
@@ -199,16 +199,16 @@ class ShutdownTask implements ITask {
         return reason;
     }
 
-    private boolean validateShardEnd(List<Shard> shards) {
+    private boolean isShardInContextParentOfAny(List<Shard> shards) {
         for(Shard shard : shards) {
-            if (isChildShardOfCurrentShard(shard)) {
+            if (isChildShardOfShardInContext(shard)) {
                 return true;
             }
         }
         return false;
     }
 
-    private boolean isChildShardOfCurrentShard(Shard shard) {
+    private boolean isChildShardOfShardInContext(Shard shard) {
         return (StringUtils.equals(shard.getParentShardId(), shardInfo.getShardId())
                 || StringUtils.equals(shard.getAdjacentParentShardId(), shardInfo.getShardId()));
     }

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/Worker.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/Worker.java
@@ -677,9 +677,9 @@ public class Worker implements Runnable {
                 if (!skipShardSyncAtWorkerInitializationIfLeasesExist
                         || leaseCoordinator.getLeaseManager().isLeaseTableEmpty()) {
                     LOG.info("Syncing Kinesis shard info");
-                    ShardSyncTask shardSyncTask = new ShardSyncTask(null, streamConfig.getStreamProxy(),
+                    ShardSyncTask shardSyncTask = new ShardSyncTask(streamConfig.getStreamProxy(),
                             leaseCoordinator.getLeaseManager(), initialPosition, cleanupLeasesUponShardCompletion,
-                            config.shouldIgnoreUnexpectedChildShards(), 0L, shardSyncer);
+                            config.shouldIgnoreUnexpectedChildShards(), 0L, shardSyncer, null);
                     result = new MetricsCollectingTaskDecorator(shardSyncTask, metricsFactory).call();
                 } else {
                     LOG.info("Skipping shard sync per config setting (and lease table is not empty)");
@@ -1164,10 +1164,10 @@ public class Worker implements Runnable {
             ILeaseManager<KinesisClientLease> leaseManager) {
         return new PeriodicShardSyncStrategy(
                 new PeriodicShardSyncManager(config.getWorkerIdentifier(), leaderDecider,
-                        new ShardSyncTask(null, kinesisProxy, leaseManager, config.getInitialPositionInStreamExtended(),
+                        new ShardSyncTask(kinesisProxy, leaseManager, config.getInitialPositionInStreamExtended(),
                                 config.shouldCleanupLeasesUponShardCompletion(),
                                 config.shouldIgnoreUnexpectedChildShards(), SHARD_SYNC_SLEEP_FOR_PERIODIC_SHARD_SYNC,
-                                shardSyncer), metricsFactory));
+                                shardSyncer,null), metricsFactory));
     }
 
     private ShardEndShardSyncStrategy createShardEndShardSyncStrategy(ShardSyncTaskManager shardSyncTaskManager) {

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/Worker.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/Worker.java
@@ -1167,7 +1167,7 @@ public class Worker implements Runnable {
                         new ShardSyncTask(kinesisProxy, leaseManager, config.getInitialPositionInStreamExtended(),
                                 config.shouldCleanupLeasesUponShardCompletion(),
                                 config.shouldIgnoreUnexpectedChildShards(), SHARD_SYNC_SLEEP_FOR_PERIODIC_SHARD_SYNC,
-                                shardSyncer,null), metricsFactory));
+                                shardSyncer, null), metricsFactory));
     }
 
     private ShardEndShardSyncStrategy createShardEndShardSyncStrategy(ShardSyncTaskManager shardSyncTaskManager) {

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/Worker.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/Worker.java
@@ -1042,7 +1042,7 @@ public class Worker implements Runnable {
                 streamConfig,
                 checkpointTracker,
                 recordProcessor,
-                leaseCoordinator.getLeaseManager(),
+                leaseCoordinator,
                 parentShardPollIntervalMillis,
                 cleanupLeasesUponShardCompletion,
                 executorService,

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/Worker.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/Worker.java
@@ -677,7 +677,7 @@ public class Worker implements Runnable {
                 if (!skipShardSyncAtWorkerInitializationIfLeasesExist
                         || leaseCoordinator.getLeaseManager().isLeaseTableEmpty()) {
                     LOG.info("Syncing Kinesis shard info");
-                    ShardSyncTask shardSyncTask = new ShardSyncTask(streamConfig.getStreamProxy(),
+                    ShardSyncTask shardSyncTask = new ShardSyncTask(null, streamConfig.getStreamProxy(),
                             leaseCoordinator.getLeaseManager(), initialPosition, cleanupLeasesUponShardCompletion,
                             config.shouldIgnoreUnexpectedChildShards(), 0L, shardSyncer);
                     result = new MetricsCollectingTaskDecorator(shardSyncTask, metricsFactory).call();
@@ -1164,7 +1164,7 @@ public class Worker implements Runnable {
             ILeaseManager<KinesisClientLease> leaseManager) {
         return new PeriodicShardSyncStrategy(
                 new PeriodicShardSyncManager(config.getWorkerIdentifier(), leaderDecider,
-                        new ShardSyncTask(kinesisProxy, leaseManager, config.getInitialPositionInStreamExtended(),
+                        new ShardSyncTask(null, kinesisProxy, leaseManager, config.getInitialPositionInStreamExtended(),
                                 config.shouldCleanupLeasesUponShardCompletion(),
                                 config.shouldIgnoreUnexpectedChildShards(), SHARD_SYNC_SLEEP_FOR_PERIODIC_SHARD_SYNC,
                                 shardSyncer), metricsFactory));

--- a/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ConsumerStatesTest.java
+++ b/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ConsumerStatesTest.java
@@ -35,6 +35,7 @@ import org.hamcrest.TypeSafeDiagnosingMatcher;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
@@ -66,6 +67,8 @@ public class ConsumerStatesTest {
     private KinesisDataFetcher dataFetcher;
     @Mock
     private ILeaseManager<KinesisClientLease> leaseManager;
+    @InjectMocks
+    private KinesisClientLibLeaseCoordinator leaseCoordinator = new KinesisClientLibLeaseCoordinator(leaseManager, "testCoordinator", 1000, 1000);
     @Mock
     private ICheckpoint checkpoint;
     @Mock
@@ -93,6 +96,7 @@ public class ConsumerStatesTest {
         when(consumer.getShardInfo()).thenReturn(shardInfo);
         when(consumer.getDataFetcher()).thenReturn(dataFetcher);
         when(consumer.getLeaseManager()).thenReturn(leaseManager);
+        when(consumer.getLeaseCoordinator()).thenReturn(leaseCoordinator);
         when(consumer.getCheckpoint()).thenReturn(checkpoint);
         when(consumer.getFuture()).thenReturn(future);
         when(consumer.getShutdownNotification()).thenReturn(shutdownNotification);
@@ -294,7 +298,7 @@ public class ConsumerStatesTest {
                 equalTo(recordProcessorCheckpointer)));
         assertThat(task, shutdownTask(ShutdownReason.class, "reason", equalTo(reason)));
         assertThat(task, shutdownTask(IKinesisProxy.class, "kinesisProxy", equalTo(kinesisProxy)));
-        assertThat(task, shutdownTask(LEASE_MANAGER_CLASS, "leaseManager", equalTo(leaseManager)));
+        assertThat(task, shutdownTask(KinesisClientLibLeaseCoordinator.class, "leaseCoordinator", equalTo(leaseCoordinator)));
         assertThat(task, shutdownTask(InitialPositionInStreamExtended.class, "initialPositionInStream",
                 equalTo(initialPositionInStream)));
         assertThat(task,

--- a/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardConsumerTest.java
+++ b/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardConsumerTest.java
@@ -50,8 +50,6 @@ import java.util.concurrent.Future;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 
-import com.amazonaws.services.kinesis.model.HashKeyRange;
-import com.amazonaws.services.kinesis.model.SequenceNumberRange;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.hamcrest.Description;
@@ -60,6 +58,7 @@ import org.hamcrest.TypeSafeMatcher;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
@@ -118,6 +117,8 @@ public class ShardConsumerTest {
     private IKinesisProxy streamProxy;
     @Mock
     private ILeaseManager<KinesisClientLease> leaseManager;
+    @InjectMocks
+    private KinesisClientLibLeaseCoordinator leaseCoordinator = new KinesisClientLibLeaseCoordinator(leaseManager, "testCoordinator", 1000, 1000);
     @Mock
     private ICheckpoint checkpoint;
     @Mock
@@ -159,7 +160,7 @@ public class ShardConsumerTest {
                         streamConfig,
                         checkpoint,
                         processor,
-                        null,
+                        leaseCoordinator,
                         parentShardPollIntervalMillis,
                         cleanupLeasesOfCompletedShards,
                         executorService,
@@ -208,7 +209,7 @@ public class ShardConsumerTest {
                         streamConfig,
                         checkpoint,
                         processor,
-                        null,
+                        leaseCoordinator,
                         parentShardPollIntervalMillis,
                         cleanupLeasesOfCompletedShards,
                         spyExecutorService,
@@ -252,7 +253,7 @@ public class ShardConsumerTest {
                         streamConfig,
                         checkpoint,
                         processor,
-                        null,
+                        leaseCoordinator,
                         parentShardPollIntervalMillis,
                         cleanupLeasesOfCompletedShards,
                         executorService,
@@ -370,7 +371,7 @@ public class ShardConsumerTest {
                         checkpoint,
                         processor,
                         recordProcessorCheckpointer,
-                        leaseManager,
+                        leaseCoordinator,
                         parentShardPollIntervalMillis,
                         cleanupLeasesOfCompletedShards,
                         executorService,
@@ -516,7 +517,7 @@ public class ShardConsumerTest {
                         checkpoint,
                         processor,
                         recordProcessorCheckpointer,
-                        leaseManager,
+                        leaseCoordinator,
                         parentShardPollIntervalMillis,
                         cleanupLeasesOfCompletedShards,
                         executorService,
@@ -658,7 +659,7 @@ public class ShardConsumerTest {
                                   checkpoint,
                                   processor,
                                   recordProcessorCheckpointer,
-                                  leaseManager,
+                                  leaseCoordinator,
                                   parentShardPollIntervalMillis,
                                   cleanupLeasesOfCompletedShards,
                                   executorService,
@@ -799,7 +800,7 @@ public class ShardConsumerTest {
                         checkpoint,
                         processor,
                         recordProcessorCheckpointer,
-                        leaseManager,
+                        leaseCoordinator,
                         parentShardPollIntervalMillis,
                         cleanupLeasesOfCompletedShards,
                         executorService,
@@ -874,7 +875,7 @@ public class ShardConsumerTest {
                         streamConfig,
                         checkpoint,
                         processor,
-                        null,
+                        leaseCoordinator,
                         parentShardPollIntervalMillis,
                         cleanupLeasesOfCompletedShards,
                         executorService,
@@ -927,7 +928,7 @@ public class ShardConsumerTest {
                         streamConfig,
                         checkpoint,
                         processor,
-                        null,
+                        leaseCoordinator,
                         parentShardPollIntervalMillis,
                         cleanupLeasesOfCompletedShards,
                         executorService,
@@ -959,7 +960,7 @@ public class ShardConsumerTest {
                         streamConfig,
                         checkpoint,
                         processor,
-                        null,
+                        leaseCoordinator,
                         parentShardPollIntervalMillis,
                         cleanupLeasesOfCompletedShards,
                         executorService,
@@ -1002,7 +1003,7 @@ public class ShardConsumerTest {
                 streamConfig,
                 checkpoint,
                 processor,
-                null,
+                leaseCoordinator,
                 parentShardPollIntervalMillis,
                 cleanupLeasesOfCompletedShards,
                 mockExecutorService,

--- a/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardConsumerTest.java
+++ b/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardConsumerTest.java
@@ -458,7 +458,7 @@ public class ShardConsumerTest {
 
     /**
      * Test method for {@link ShardConsumer#consumeShard()} that ensures a transient error thrown from the record
-     * processor's shutdown method with reason terminate will be retried.
+     * processor's shutdown method with reason zombie will be retried.
      */
     @Test
     public final void testConsumeShardWithTransientTerminateError() throws Exception {
@@ -595,6 +595,11 @@ public class ShardConsumerTest {
     }
 
 
+
+    /**
+     * Test method for {@link ShardConsumer#consumeShard()} that ensures the shardConsumer gets shutdown with shutdown
+     * reason TERMINATE when the shard end is reached.
+     */
     @Test
     public final void testConsumeShardWithShardEnd() throws Exception {
         int numRecs = 10;

--- a/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardConsumerTest.java
+++ b/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardConsumerTest.java
@@ -117,8 +117,8 @@ public class ShardConsumerTest {
     private IKinesisProxy streamProxy;
     @Mock
     private ILeaseManager<KinesisClientLease> leaseManager;
-    @InjectMocks
-    private KinesisClientLibLeaseCoordinator leaseCoordinator = new KinesisClientLibLeaseCoordinator(leaseManager, "testCoordinator", 1000, 1000);
+    @Mock
+    private KinesisClientLibLeaseCoordinator leaseCoordinator;
     @Mock
     private ICheckpoint checkpoint;
     @Mock
@@ -148,6 +148,7 @@ public class ShardConsumerTest {
         when(checkpoint.getCheckpointObject(anyString())).thenThrow(NullPointerException.class);
 
         when(leaseManager.getLease(anyString())).thenReturn(null);
+        when(leaseCoordinator.getLeaseManager()).thenReturn(leaseManager);
         StreamConfig streamConfig =
                 new StreamConfig(streamProxy,
                         1,
@@ -197,6 +198,7 @@ public class ShardConsumerTest {
         when(checkpoint.getCheckpoint(anyString())).thenThrow(NullPointerException.class);
         when(checkpoint.getCheckpointObject(anyString())).thenThrow(NullPointerException.class);
         when(leaseManager.getLease(anyString())).thenReturn(null);
+        when(leaseCoordinator.getLeaseManager()).thenReturn(leaseManager);
         StreamConfig streamConfig =
                 new StreamConfig(streamProxy,
                         1,
@@ -267,6 +269,7 @@ public class ShardConsumerTest {
         final ExtendedSequenceNumber checkpointSequenceNumber = new ExtendedSequenceNumber("123");
         final ExtendedSequenceNumber pendingCheckpointSequenceNumber = null;
         when(leaseManager.getLease(anyString())).thenReturn(null);
+        when(leaseCoordinator.getLeaseManager()).thenReturn(leaseManager);
         when(checkpoint.getCheckpointObject(anyString())).thenReturn(
                 new Checkpoint(checkpointSequenceNumber, pendingCheckpointSequenceNumber));
 
@@ -335,6 +338,7 @@ public class ShardConsumerTest {
         ICheckpoint checkpoint = new InMemoryCheckpointImpl(startSeqNum.toString());
         checkpoint.setCheckpoint(streamShardId, ExtendedSequenceNumber.TRIM_HORIZON, testConcurrencyToken);
         when(leaseManager.getLease(anyString())).thenReturn(null);
+        when(leaseCoordinator.getLeaseManager()).thenReturn(leaseManager);
         TestStreamlet processor = new TestStreamlet();
 
         StreamConfig streamConfig =
@@ -479,7 +483,7 @@ public class ShardConsumerTest {
         final int idleTimeMS = 0; // keep unit tests fast
         ICheckpoint checkpoint = new InMemoryCheckpointImpl(startSeqNum.toString());
         checkpoint.setCheckpoint(streamShardId, ExtendedSequenceNumber.TRIM_HORIZON, testConcurrencyToken);
-        when(leaseManager.getLease(anyString())).thenReturn(null);
+
 
         TransientShutdownErrorTestStreamlet processor = new TransientShutdownErrorTestStreamlet();
 
@@ -499,6 +503,9 @@ public class ShardConsumerTest {
         when(recordsFetcherFactory.createRecordsFetcher(any(GetRecordsRetrievalStrategy.class), anyString(),
                 any(IMetricsFactory.class), anyInt()))
                 .thenReturn(getRecordsCache);
+        when(leaseManager.getLease(anyString())).thenReturn(null);
+        when(leaseCoordinator.getLeaseManager()).thenReturn(leaseManager);
+        when(leaseCoordinator.getCurrentlyHeldLease(shardInfo.getShardId())).thenReturn(new KinesisClientLease());
 
         RecordProcessorCheckpointer recordProcessorCheckpointer = new RecordProcessorCheckpointer(
                 shardInfo,
@@ -622,6 +629,7 @@ public class ShardConsumerTest {
         ICheckpoint checkpoint = new InMemoryCheckpointImpl(startSeqNum.toString());
         checkpoint.setCheckpoint(streamShardId, ExtendedSequenceNumber.TRIM_HORIZON, testConcurrencyToken);
         when(leaseManager.getLease(anyString())).thenReturn(null);
+        when(leaseCoordinator.getLeaseManager()).thenReturn(leaseManager);
 
         TransientShutdownErrorTestStreamlet processor = new TransientShutdownErrorTestStreamlet();
 
@@ -763,6 +771,7 @@ public class ShardConsumerTest {
         ICheckpoint checkpoint = new InMemoryCheckpointImpl(startSeqNum.toString());
         checkpoint.setCheckpoint(streamShardId, ExtendedSequenceNumber.AT_TIMESTAMP, testConcurrencyToken);
         when(leaseManager.getLease(anyString())).thenReturn(null);
+        when(leaseCoordinator.getLeaseManager()).thenReturn(leaseManager);
         TestStreamlet processor = new TestStreamlet();
 
         StreamConfig streamConfig =
@@ -891,6 +900,7 @@ public class ShardConsumerTest {
         final ExtendedSequenceNumber checkpointSequenceNumber = new ExtendedSequenceNumber("123");
         final ExtendedSequenceNumber pendingCheckpointSequenceNumber = new ExtendedSequenceNumber("999");
         when(leaseManager.getLease(anyString())).thenReturn(null);
+        when(leaseCoordinator.getLeaseManager()).thenReturn(leaseManager);
         when(config.getRecordsFetcherFactory()).thenReturn(new SimpleRecordsFetcherFactory());
         when(checkpoint.getCheckpointObject(anyString())).thenReturn(
                 new Checkpoint(checkpointSequenceNumber, pendingCheckpointSequenceNumber));

--- a/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardSyncTaskIntegrationTest.java
+++ b/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardSyncTaskIntegrationTest.java
@@ -121,7 +121,7 @@ public class ShardSyncTaskIntegrationTest {
         }
         leaseManager.deleteAll();
         Set<String> shardIds = kinesisProxy.getAllShardIds();
-        ShardSyncTask syncTask = new ShardSyncTask(kinesisProxy,
+        ShardSyncTask syncTask = new ShardSyncTask(null, kinesisProxy,
                 leaseManager,
                 InitialPositionInStreamExtended.newInitialPosition(InitialPositionInStream.LATEST),
                 false,

--- a/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardSyncTaskIntegrationTest.java
+++ b/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardSyncTaskIntegrationTest.java
@@ -121,13 +121,14 @@ public class ShardSyncTaskIntegrationTest {
         }
         leaseManager.deleteAll();
         Set<String> shardIds = kinesisProxy.getAllShardIds();
-        ShardSyncTask syncTask = new ShardSyncTask(null, kinesisProxy,
+        ShardSyncTask syncTask = new ShardSyncTask(kinesisProxy,
                 leaseManager,
                 InitialPositionInStreamExtended.newInitialPosition(InitialPositionInStream.LATEST),
                 false,
                 false,
                 0L,
-                shardSyncer);
+                shardSyncer,
+                null);
         syncTask.call();
         List<KinesisClientLease> leases = leaseManager.listLeases();
         Set<String> leaseKeys = new HashSet<String>();

--- a/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardSyncerTest.java
+++ b/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardSyncerTest.java
@@ -230,8 +230,8 @@ public class ShardSyncerTest {
         dataFile.deleteOnExit();
         IKinesisProxy kinesisProxy = new KinesisLocalFileProxy(dataFile.getAbsolutePath());
 
-        shardSyncer.checkAndCreateLeasesForNewShards(shards, kinesisProxy, leaseManager, INITIAL_POSITION_LATEST,
-                cleanupLeasesOfCompletedShards, false);
+        shardSyncer.checkAndCreateLeasesForNewShards(kinesisProxy, leaseManager, INITIAL_POSITION_LATEST,
+                cleanupLeasesOfCompletedShards, false, shards);
         List<KinesisClientLease> newLeases = leaseManager.listLeases();
         Set<String> expectedLeaseShardIds = new HashSet<String>();
         expectedLeaseShardIds.add("shardId-4");
@@ -262,8 +262,8 @@ public class ShardSyncerTest {
         dataFile.deleteOnExit();
         IKinesisProxy kinesisProxy = new KinesisLocalFileProxy(dataFile.getAbsolutePath());
 
-        shardSyncer.checkAndCreateLeasesForNewShards(shards, kinesisProxy, leaseManager, INITIAL_POSITION_TRIM_HORIZON,
-                cleanupLeasesOfCompletedShards, false);
+        shardSyncer.checkAndCreateLeasesForNewShards(kinesisProxy, leaseManager, INITIAL_POSITION_TRIM_HORIZON,
+                cleanupLeasesOfCompletedShards, false, shards);
         List<KinesisClientLease> newLeases = leaseManager.listLeases();
         Set<String> expectedLeaseShardIds = new HashSet<String>();
         for (int i = 0; i < 11; i++) {
@@ -293,8 +293,8 @@ public class ShardSyncerTest {
         dataFile.deleteOnExit();
         IKinesisProxy kinesisProxy = new KinesisLocalFileProxy(dataFile.getAbsolutePath());
 
-        shardSyncer.checkAndCreateLeasesForNewShards(shards, kinesisProxy, leaseManager, INITIAL_POSITION_AT_TIMESTAMP,
-                cleanupLeasesOfCompletedShards, false);
+        shardSyncer.checkAndCreateLeasesForNewShards(kinesisProxy, leaseManager, INITIAL_POSITION_AT_TIMESTAMP,
+                cleanupLeasesOfCompletedShards, false, shards);
         List<KinesisClientLease> newLeases = leaseManager.listLeases();
         Set<String> expectedLeaseShardIds = new HashSet<String>();
         for (int i = 0; i < 11; i++) {
@@ -327,8 +327,8 @@ public class ShardSyncerTest {
         dataFile.deleteOnExit();
         IKinesisProxy kinesisProxy = new KinesisLocalFileProxy(dataFile.getAbsolutePath());
 
-        shardSyncer.checkAndCreateLeasesForNewShards(shards, kinesisProxy, leaseManager, INITIAL_POSITION_TRIM_HORIZON,
-                cleanupLeasesOfCompletedShards, false);
+        shardSyncer.checkAndCreateLeasesForNewShards(kinesisProxy, leaseManager, INITIAL_POSITION_TRIM_HORIZON,
+                cleanupLeasesOfCompletedShards, false, shards);
         dataFile.delete();
     }
 
@@ -352,8 +352,8 @@ public class ShardSyncerTest {
         File dataFile = KinesisLocalFileDataCreator.generateTempDataFile(shards, 2, "testBootstrap1");
         dataFile.deleteOnExit();
         IKinesisProxy kinesisProxy = new KinesisLocalFileProxy(dataFile.getAbsolutePath());
-        shardSyncer.checkAndCreateLeasesForNewShards(shards, kinesisProxy, leaseManager, INITIAL_POSITION_LATEST,
-                cleanupLeasesOfCompletedShards, true);
+        shardSyncer.checkAndCreateLeasesForNewShards(kinesisProxy, leaseManager, INITIAL_POSITION_LATEST,
+                cleanupLeasesOfCompletedShards, true, shards);
         List<KinesisClientLease> newLeases = leaseManager.listLeases();
         Set<String> expectedLeaseShardIds = new HashSet<String>();
         expectedLeaseShardIds.add("shardId-4");
@@ -464,11 +464,11 @@ public class ShardSyncerTest {
             // Only need to try two times.
             for (int i = 1; i <= 2; i++) {
                 try {
-                    shardSyncer.checkAndCreateLeasesForNewShards(null, kinesisProxy,
+                    shardSyncer.checkAndCreateLeasesForNewShards(kinesisProxy,
                             exceptionThrowingLeaseManager,
                             position,
                             cleanupLeasesOfCompletedShards,
-                            false);
+                            false, null);
                     return;
                 } catch (LeasingException e) {
                     LOG.debug("Catch leasing exception", e);
@@ -477,11 +477,11 @@ public class ShardSyncerTest {
                 exceptionThrowingLeaseManager.clearLeaseManagerThrowingExceptionScenario();
             }
         } else {
-            shardSyncer.checkAndCreateLeasesForNewShards(null, kinesisProxy,
+            shardSyncer.checkAndCreateLeasesForNewShards(kinesisProxy,
                     leaseManager,
                     position,
                     cleanupLeasesOfCompletedShards,
-                    false);
+                    false, null);
         }
     }
 

--- a/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardSyncerTest.java
+++ b/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardSyncerTest.java
@@ -26,7 +26,9 @@ import java.util.Map;
 import java.util.Set;
 
 import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClient;
+import com.amazonaws.services.dynamodbv2.local.embedded.DynamoDBEmbedded;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.junit.After;
@@ -67,8 +69,7 @@ public class ShardSyncerTest {
     private static final InitialPositionInStreamExtended INITIAL_POSITION_AT_TIMESTAMP =
             InitialPositionInStreamExtended.newInitialPositionAtTimestamp(new Date(1000L));
     private final boolean cleanupLeasesOfCompletedShards = true;
-    AmazonDynamoDBClient ddbClient =
-            new AmazonDynamoDBClient(new DefaultAWSCredentialsProviderChain());
+    AmazonDynamoDB ddbClient = DynamoDBEmbedded.create().amazonDynamoDB();
     LeaseManager<KinesisClientLease> leaseManager = new KinesisClientLeaseManager("tempTestTable", ddbClient);
     private static final int EXPONENT = 128;
     protected static final KinesisLeaseCleanupValidator leaseCleanupValidator = new KinesisLeaseCleanupValidator();

--- a/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShutdownTaskTest.java
+++ b/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShutdownTaskTest.java
@@ -14,6 +14,7 @@
  */
 package com.amazonaws.services.kinesis.clientlibrary.lib.worker;
 
+import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -147,6 +148,7 @@ public class ShutdownTaskTest {
         KinesisClientLibLeaseCoordinator leaseCoordinator = mock(KinesisClientLibLeaseCoordinator.class);
         ILeaseManager<KinesisClientLease> leaseManager = mock(KinesisClientLeaseManager.class);
         when(leaseCoordinator.getLeaseManager()).thenReturn(leaseManager);
+        when(leaseCoordinator.getLeaseManager()).thenReturn(leaseManager);
         boolean cleanupLeasesOfCompletedShards = false;
         boolean ignoreUnexpectedChildShards = false;
 
@@ -181,6 +183,7 @@ public class ShutdownTaskTest {
         KinesisClientLibLeaseCoordinator leaseCoordinator = mock(KinesisClientLibLeaseCoordinator.class);
         ILeaseManager<KinesisClientLease> leaseManager = mock(KinesisClientLeaseManager.class);
         when(leaseCoordinator.getLeaseManager()).thenReturn(leaseManager);
+        when(leaseCoordinator.getLeaseManager()).thenReturn(leaseManager);
         boolean cleanupLeasesOfCompletedShards = false;
         boolean ignoreUnexpectedChildShards = false;
 
@@ -203,7 +206,7 @@ public class ShutdownTaskTest {
         verify(kinesisProxy, times(1)).getShardList();
         Assert.assertNull(result.getException());
         verify(getRecordsCache).shutdown();
-        verify(leaseCoordinator, never()).getAssignments();
+        verify(leaseCoordinator, never()).dropLease(any());
     }
 
     @Test
@@ -220,6 +223,7 @@ public class ShutdownTaskTest {
         KinesisClientLibLeaseCoordinator leaseCoordinator = mock(KinesisClientLibLeaseCoordinator.class);
         ILeaseManager<KinesisClientLease> leaseManager = mock(KinesisClientLeaseManager.class);
         when(leaseCoordinator.getLeaseManager()).thenReturn(leaseManager);
+        when(leaseCoordinator.getCurrentlyHeldLease(shardInfo.getShardId())).thenReturn(new KinesisClientLease());
         boolean cleanupLeasesOfCompletedShards = false;
         boolean ignoreUnexpectedChildShards = false;
 
@@ -243,7 +247,7 @@ public class ShutdownTaskTest {
         verify(kinesisProxy, times(1)).getShardList();
         Assert.assertNull(result.getException());
         verify(getRecordsCache).shutdown();
-        verify(leaseCoordinator).getAssignments();
+        verify(leaseCoordinator).dropLease(any());
     }
 
     @Test
@@ -255,6 +259,7 @@ public class ShutdownTaskTest {
         when(kinesisProxy.getShardList()).thenReturn(shards);
         KinesisClientLibLeaseCoordinator leaseCoordinator = mock(KinesisClientLibLeaseCoordinator.class);
         ILeaseManager<KinesisClientLease> leaseManager = mock(KinesisClientLeaseManager.class);
+        when(leaseCoordinator.getLeaseManager()).thenReturn(leaseManager);
         when(leaseCoordinator.getLeaseManager()).thenReturn(leaseManager);
         boolean cleanupLeasesOfCompletedShards = false;
         boolean ignoreUnexpectedChildShards = false;
@@ -278,7 +283,7 @@ public class ShutdownTaskTest {
         verify(kinesisProxy, never()).getShardList();
         Assert.assertNull(result.getException());
         verify(getRecordsCache).shutdown();
-        verify(leaseCoordinator, never()).getAssignments();
+        verify(leaseCoordinator, never()).dropLease(any());
     }
 
     /**

--- a/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShutdownTaskTest.java
+++ b/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShutdownTaskTest.java
@@ -16,14 +16,19 @@ package com.amazonaws.services.kinesis.clientlibrary.lib.worker;
 
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
-import java.util.concurrent.ExecutorService;
 
-import com.amazonaws.services.kinesis.metrics.interfaces.IMetricsFactory;
+import com.amazonaws.services.kinesis.model.HashKeyRange;
+import com.amazonaws.services.kinesis.model.SequenceNumberRange;
+import com.amazonaws.services.kinesis.model.Shard;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -53,7 +58,7 @@ public class ShutdownTaskTest {
 
     Set<String> defaultParentShardIds = new HashSet<>();
     String defaultConcurrencyToken = "testToken4398";
-    String defaultShardId = "shardId-0000397840";
+    String defaultShardId = "shardId-0";
     ShardInfo defaultShardInfo = new ShardInfo(defaultShardId,
             defaultConcurrencyToken,
             defaultParentShardIds,
@@ -104,6 +109,8 @@ public class ShutdownTaskTest {
         RecordProcessorCheckpointer checkpointer = mock(RecordProcessorCheckpointer.class);
         when(checkpointer.getLastCheckpointValue()).thenReturn(new ExtendedSequenceNumber("3298"));
         IKinesisProxy kinesisProxy = mock(IKinesisProxy.class);
+        List<Shard> shards = constructShardListForGraphA();
+        when(kinesisProxy.getShardList()).thenReturn(shards);
         ILeaseManager<KinesisClientLease> leaseManager = mock(KinesisClientLeaseManager.class);
         boolean cleanupLeasesOfCompletedShards = false;
         boolean ignoreUnexpectedChildShards = false;
@@ -132,12 +139,14 @@ public class ShutdownTaskTest {
     public final void testCallWhenSyncingShardsThrows() {
         RecordProcessorCheckpointer checkpointer = mock(RecordProcessorCheckpointer.class);
         when(checkpointer.getLastCheckpointValue()).thenReturn(ExtendedSequenceNumber.SHARD_END);
+        List<Shard> shards = constructShardListForGraphA();
         IKinesisProxy kinesisProxy = mock(IKinesisProxy.class);
-        when(kinesisProxy.getShardList()).thenReturn(null);
+        when(kinesisProxy.getShardList()).thenReturn(shards);
         ILeaseManager<KinesisClientLease> leaseManager = mock(KinesisClientLeaseManager.class);
         boolean cleanupLeasesOfCompletedShards = false;
         boolean ignoreUnexpectedChildShards = false;
-        when(shardSyncStrategy.onShardConsumerShutDown()).thenReturn(new TaskResult(new KinesisClientLibIOException("")));
+
+        when(shardSyncStrategy.onShardConsumerShutDown(shards)).thenReturn(new TaskResult(new KinesisClientLibIOException("")));
         ShutdownTask task = new ShutdownTask(defaultShardInfo,
                 defaultRecordProcessor,
                 checkpointer,
@@ -152,9 +161,109 @@ public class ShutdownTaskTest {
                 shardSyncer,
                 shardSyncStrategy);
         TaskResult result = task.call();
-        verify(shardSyncStrategy).onShardConsumerShutDown();
+        verify(shardSyncStrategy).onShardConsumerShutDown(shards);
         Assert.assertNotNull(result.getException());
         Assert.assertTrue(result.getException() instanceof KinesisClientLibIOException);
+        verify(getRecordsCache).shutdown();
+    }
+
+    @Test
+    public final void testCallWhenShardEnd() {
+        RecordProcessorCheckpointer checkpointer = mock(RecordProcessorCheckpointer.class);
+        when(checkpointer.getLastCheckpointValue()).thenReturn(ExtendedSequenceNumber.SHARD_END);
+        List<Shard> shards = constructShardListForGraphA();
+        IKinesisProxy kinesisProxy = mock(IKinesisProxy.class);
+        when(kinesisProxy.getShardList()).thenReturn(shards);
+        ILeaseManager<KinesisClientLease> leaseManager = mock(KinesisClientLeaseManager.class);
+        boolean cleanupLeasesOfCompletedShards = false;
+        boolean ignoreUnexpectedChildShards = false;
+
+        when(shardSyncStrategy.onShardConsumerShutDown(shards)).thenReturn(new TaskResult(null));
+        ShutdownTask task = new ShutdownTask(defaultShardInfo,
+                                             defaultRecordProcessor,
+                                             checkpointer,
+                                             ShutdownReason.TERMINATE,
+                                             kinesisProxy,
+                                             INITIAL_POSITION_TRIM_HORIZON,
+                                             cleanupLeasesOfCompletedShards,
+                                             ignoreUnexpectedChildShards,
+                                             leaseManager,
+                                             TASK_BACKOFF_TIME_MILLIS,
+                                             getRecordsCache,
+                                             shardSyncer,
+                                             shardSyncStrategy);
+        TaskResult result = task.call();
+        verify(shardSyncStrategy).onShardConsumerShutDown(shards);
+        verify(kinesisProxy, times(1)).getShardList();
+        Assert.assertNull(result.getException());
+        verify(getRecordsCache).shutdown();
+    }
+
+    @Test
+    public final void testCallWhenFalseShardEnd() {
+        ShardInfo shardInfo = new ShardInfo("shardId-4",
+                                                   defaultConcurrencyToken,
+                                                   defaultParentShardIds,
+                                                   ExtendedSequenceNumber.LATEST);
+        RecordProcessorCheckpointer checkpointer = mock(RecordProcessorCheckpointer.class);
+        when(checkpointer.getLastCheckpointValue()).thenReturn(ExtendedSequenceNumber.SHARD_END);
+        List<Shard> shards = constructShardListForGraphA();
+        IKinesisProxy kinesisProxy = mock(IKinesisProxy.class);
+        when(kinesisProxy.getShardList()).thenReturn(shards);
+        ILeaseManager<KinesisClientLease> leaseManager = mock(KinesisClientLeaseManager.class);
+        boolean cleanupLeasesOfCompletedShards = false;
+        boolean ignoreUnexpectedChildShards = false;
+
+        when(shardSyncStrategy.onShardConsumerShutDown(shards)).thenReturn(new TaskResult(null));
+        ShutdownTask task = new ShutdownTask(shardInfo,
+                                             defaultRecordProcessor,
+                                             checkpointer,
+                                             ShutdownReason.TERMINATE,
+                                             kinesisProxy,
+                                             INITIAL_POSITION_TRIM_HORIZON,
+                                             cleanupLeasesOfCompletedShards,
+                                             ignoreUnexpectedChildShards,
+                                             leaseManager,
+                                             TASK_BACKOFF_TIME_MILLIS,
+                                             getRecordsCache,
+                                             shardSyncer,
+                                             shardSyncStrategy);
+        TaskResult result = task.call();
+        verify(shardSyncStrategy, never()).onShardConsumerShutDown(shards);
+        verify(kinesisProxy, times(1)).getShardList();
+        Assert.assertNull(result.getException());
+        verify(getRecordsCache).shutdown();
+    }
+
+    @Test
+    public final void testCallWhenLeaseLost() {
+        RecordProcessorCheckpointer checkpointer = mock(RecordProcessorCheckpointer.class);
+        when(checkpointer.getLastCheckpointValue()).thenReturn(new ExtendedSequenceNumber("3298"));
+        List<Shard> shards = constructShardListForGraphA();
+        IKinesisProxy kinesisProxy = mock(IKinesisProxy.class);
+        when(kinesisProxy.getShardList()).thenReturn(shards);
+        ILeaseManager<KinesisClientLease> leaseManager = mock(KinesisClientLeaseManager.class);
+        boolean cleanupLeasesOfCompletedShards = false;
+        boolean ignoreUnexpectedChildShards = false;
+
+        when(shardSyncStrategy.onShardConsumerShutDown(shards)).thenReturn(new TaskResult(null));
+        ShutdownTask task = new ShutdownTask(defaultShardInfo,
+                                             defaultRecordProcessor,
+                                             checkpointer,
+                                             ShutdownReason.ZOMBIE,
+                                             kinesisProxy,
+                                             INITIAL_POSITION_TRIM_HORIZON,
+                                             cleanupLeasesOfCompletedShards,
+                                             ignoreUnexpectedChildShards,
+                                             leaseManager,
+                                             TASK_BACKOFF_TIME_MILLIS,
+                                             getRecordsCache,
+                                             shardSyncer,
+                                             shardSyncStrategy);
+        TaskResult result = task.call();
+        verify(shardSyncStrategy, never()).onShardConsumerShutDown(shards);
+        verify(kinesisProxy, never()).getShardList();
+        Assert.assertNull(result.getException());
         verify(getRecordsCache).shutdown();
     }
 
@@ -165,6 +274,54 @@ public class ShutdownTaskTest {
     public final void testGetTaskType() {
         ShutdownTask task = new ShutdownTask(null, null, null, null, null, null, false, false, null, 0, getRecordsCache, shardSyncer, shardSyncStrategy);
         Assert.assertEquals(TaskType.SHUTDOWN, task.getTaskType());
+    }
+
+
+    /*
+     * Helper method to construct a shard list for graph A. Graph A is defined below.
+     * Shard structure (y-axis is epochs):
+     * 0 1 2 3 4   5- shards till epoch 102
+     * \ / \ / |  |
+     *  6   7  4   5- shards from epoch 103 - 205
+     *   \ /   |  /\
+     *    8    4 9 10 - shards from epoch 206 (open - no ending sequenceNumber)
+     */
+    private List<Shard> constructShardListForGraphA() {
+        List<Shard> shards = new ArrayList<Shard>();
+
+        SequenceNumberRange range0 = ShardObjectHelper.newSequenceNumberRange("11", "102");
+        SequenceNumberRange range1 = ShardObjectHelper.newSequenceNumberRange("11", null);
+        SequenceNumberRange range2 = ShardObjectHelper.newSequenceNumberRange("11", "210");
+        SequenceNumberRange range3 = ShardObjectHelper.newSequenceNumberRange("103", "210");
+        SequenceNumberRange range4 = ShardObjectHelper.newSequenceNumberRange("211", null);
+
+        HashKeyRange hashRange0 = ShardObjectHelper.newHashKeyRange("0", "99");
+        HashKeyRange hashRange1 = ShardObjectHelper.newHashKeyRange("100", "199");
+        HashKeyRange hashRange2 = ShardObjectHelper.newHashKeyRange("200", "299");
+        HashKeyRange hashRange3 = ShardObjectHelper.newHashKeyRange("300", "399");
+        HashKeyRange hashRange4 = ShardObjectHelper.newHashKeyRange("400", "499");
+        HashKeyRange hashRange5 = ShardObjectHelper.newHashKeyRange("500", ShardObjectHelper.MAX_HASH_KEY);
+        HashKeyRange hashRange6 = ShardObjectHelper.newHashKeyRange("0", "199");
+        HashKeyRange hashRange7 = ShardObjectHelper.newHashKeyRange("200", "399");
+        HashKeyRange hashRange8 = ShardObjectHelper.newHashKeyRange("0", "399");
+        HashKeyRange hashRange9 = ShardObjectHelper.newHashKeyRange("500", "799");
+        HashKeyRange hashRange10 = ShardObjectHelper.newHashKeyRange("800", ShardObjectHelper.MAX_HASH_KEY);
+
+        shards.add(ShardObjectHelper.newShard("shardId-0", null, null, range0, hashRange0));
+        shards.add(ShardObjectHelper.newShard("shardId-1", null, null, range0, hashRange1));
+        shards.add(ShardObjectHelper.newShard("shardId-2", null, null, range0, hashRange2));
+        shards.add(ShardObjectHelper.newShard("shardId-3", null, null, range0, hashRange3));
+        shards.add(ShardObjectHelper.newShard("shardId-4", null, null, range1, hashRange4));
+        shards.add(ShardObjectHelper.newShard("shardId-5", null, null, range2, hashRange5));
+
+        shards.add(ShardObjectHelper.newShard("shardId-6", "shardId-0", "shardId-1", range3, hashRange6));
+        shards.add(ShardObjectHelper.newShard("shardId-7", "shardId-2", "shardId-3", range3, hashRange7));
+
+        shards.add(ShardObjectHelper.newShard("shardId-8", "shardId-6", "shardId-7", range4, hashRange8));
+        shards.add(ShardObjectHelper.newShard("shardId-9", "shardId-5", null, range4, hashRange9));
+        shards.add(ShardObjectHelper.newShard("shardId-10", null, "shardId-5", range4, hashRange10));
+
+        return shards;
     }
 
 }

--- a/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShutdownTaskTest.java
+++ b/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShutdownTaskTest.java
@@ -111,7 +111,9 @@ public class ShutdownTaskTest {
         IKinesisProxy kinesisProxy = mock(IKinesisProxy.class);
         List<Shard> shards = constructShardListForGraphA();
         when(kinesisProxy.getShardList()).thenReturn(shards);
+        KinesisClientLibLeaseCoordinator leaseCoordinator = mock(KinesisClientLibLeaseCoordinator.class);
         ILeaseManager<KinesisClientLease> leaseManager = mock(KinesisClientLeaseManager.class);
+        when(leaseCoordinator.getLeaseManager()).thenReturn(leaseManager);
         boolean cleanupLeasesOfCompletedShards = false;
         boolean ignoreUnexpectedChildShards = false;
         ShutdownTask task = new ShutdownTask(defaultShardInfo,
@@ -122,7 +124,7 @@ public class ShutdownTaskTest {
                 INITIAL_POSITION_TRIM_HORIZON,
                 cleanupLeasesOfCompletedShards,
                 ignoreUnexpectedChildShards,
-                leaseManager,
+                leaseCoordinator,
                 TASK_BACKOFF_TIME_MILLIS,
                 getRecordsCache,
                 shardSyncer,
@@ -142,7 +144,9 @@ public class ShutdownTaskTest {
         List<Shard> shards = constructShardListForGraphA();
         IKinesisProxy kinesisProxy = mock(IKinesisProxy.class);
         when(kinesisProxy.getShardList()).thenReturn(shards);
+        KinesisClientLibLeaseCoordinator leaseCoordinator = mock(KinesisClientLibLeaseCoordinator.class);
         ILeaseManager<KinesisClientLease> leaseManager = mock(KinesisClientLeaseManager.class);
+        when(leaseCoordinator.getLeaseManager()).thenReturn(leaseManager);
         boolean cleanupLeasesOfCompletedShards = false;
         boolean ignoreUnexpectedChildShards = false;
 
@@ -155,7 +159,7 @@ public class ShutdownTaskTest {
                 INITIAL_POSITION_TRIM_HORIZON,
                 cleanupLeasesOfCompletedShards,
                 ignoreUnexpectedChildShards,
-                leaseManager,
+                leaseCoordinator,
                 TASK_BACKOFF_TIME_MILLIS,
                 getRecordsCache,
                 shardSyncer,
@@ -174,7 +178,9 @@ public class ShutdownTaskTest {
         List<Shard> shards = constructShardListForGraphA();
         IKinesisProxy kinesisProxy = mock(IKinesisProxy.class);
         when(kinesisProxy.getShardList()).thenReturn(shards);
+        KinesisClientLibLeaseCoordinator leaseCoordinator = mock(KinesisClientLibLeaseCoordinator.class);
         ILeaseManager<KinesisClientLease> leaseManager = mock(KinesisClientLeaseManager.class);
+        when(leaseCoordinator.getLeaseManager()).thenReturn(leaseManager);
         boolean cleanupLeasesOfCompletedShards = false;
         boolean ignoreUnexpectedChildShards = false;
 
@@ -187,7 +193,7 @@ public class ShutdownTaskTest {
                                              INITIAL_POSITION_TRIM_HORIZON,
                                              cleanupLeasesOfCompletedShards,
                                              ignoreUnexpectedChildShards,
-                                             leaseManager,
+                                             leaseCoordinator,
                                              TASK_BACKOFF_TIME_MILLIS,
                                              getRecordsCache,
                                              shardSyncer,
@@ -197,6 +203,7 @@ public class ShutdownTaskTest {
         verify(kinesisProxy, times(1)).getShardList();
         Assert.assertNull(result.getException());
         verify(getRecordsCache).shutdown();
+        verify(leaseCoordinator, never()).getAssignments();
     }
 
     @Test
@@ -210,11 +217,14 @@ public class ShutdownTaskTest {
         List<Shard> shards = constructShardListForGraphA();
         IKinesisProxy kinesisProxy = mock(IKinesisProxy.class);
         when(kinesisProxy.getShardList()).thenReturn(shards);
+        KinesisClientLibLeaseCoordinator leaseCoordinator = mock(KinesisClientLibLeaseCoordinator.class);
         ILeaseManager<KinesisClientLease> leaseManager = mock(KinesisClientLeaseManager.class);
+        when(leaseCoordinator.getLeaseManager()).thenReturn(leaseManager);
         boolean cleanupLeasesOfCompletedShards = false;
         boolean ignoreUnexpectedChildShards = false;
 
         when(shardSyncStrategy.onShardConsumerShutDown(shards)).thenReturn(new TaskResult(null));
+
         ShutdownTask task = new ShutdownTask(shardInfo,
                                              defaultRecordProcessor,
                                              checkpointer,
@@ -223,7 +233,7 @@ public class ShutdownTaskTest {
                                              INITIAL_POSITION_TRIM_HORIZON,
                                              cleanupLeasesOfCompletedShards,
                                              ignoreUnexpectedChildShards,
-                                             leaseManager,
+                                             leaseCoordinator,
                                              TASK_BACKOFF_TIME_MILLIS,
                                              getRecordsCache,
                                              shardSyncer,
@@ -233,6 +243,7 @@ public class ShutdownTaskTest {
         verify(kinesisProxy, times(1)).getShardList();
         Assert.assertNull(result.getException());
         verify(getRecordsCache).shutdown();
+        verify(leaseCoordinator).getAssignments();
     }
 
     @Test
@@ -242,7 +253,9 @@ public class ShutdownTaskTest {
         List<Shard> shards = constructShardListForGraphA();
         IKinesisProxy kinesisProxy = mock(IKinesisProxy.class);
         when(kinesisProxy.getShardList()).thenReturn(shards);
+        KinesisClientLibLeaseCoordinator leaseCoordinator = mock(KinesisClientLibLeaseCoordinator.class);
         ILeaseManager<KinesisClientLease> leaseManager = mock(KinesisClientLeaseManager.class);
+        when(leaseCoordinator.getLeaseManager()).thenReturn(leaseManager);
         boolean cleanupLeasesOfCompletedShards = false;
         boolean ignoreUnexpectedChildShards = false;
 
@@ -255,7 +268,7 @@ public class ShutdownTaskTest {
                                              INITIAL_POSITION_TRIM_HORIZON,
                                              cleanupLeasesOfCompletedShards,
                                              ignoreUnexpectedChildShards,
-                                             leaseManager,
+                                             leaseCoordinator,
                                              TASK_BACKOFF_TIME_MILLIS,
                                              getRecordsCache,
                                              shardSyncer,
@@ -265,6 +278,7 @@ public class ShutdownTaskTest {
         verify(kinesisProxy, never()).getShardList();
         Assert.assertNull(result.getException());
         verify(getRecordsCache).shutdown();
+        verify(leaseCoordinator, never()).getAssignments();
     }
 
     /**
@@ -272,7 +286,8 @@ public class ShutdownTaskTest {
      */
     @Test
     public final void testGetTaskType() {
-        ShutdownTask task = new ShutdownTask(null, null, null, null, null, null, false, false, null, 0, getRecordsCache, shardSyncer, shardSyncStrategy);
+        KinesisClientLibLeaseCoordinator leaseCoordinator = mock(KinesisClientLibLeaseCoordinator.class);
+        ShutdownTask task = new ShutdownTask(null, null, null, null, null, null, false, false, leaseCoordinator, 0, getRecordsCache, shardSyncer, shardSyncStrategy);
         Assert.assertEquals(TaskType.SHUTDOWN, task.getTaskType());
     }
 


### PR DESCRIPTION

*Description of changes:*
Change is made in ShutdownTask. When reaching a ShutdownTask with Terminate shutdown reason, do a re-validation about if the current shard reached shard_end. If it didn't reach the shard_end, force the current ShardConsumer to lose the lease and shutdown with Zombie state. This would enable other workers to pick up the lease for the unclosed shard.

*Test did for the changes*:
1. Unit tests covered ShardConsumer shutdown in three different scenarios: Lease lost, ShardEnd and incorrect ShardEnd.

2. Functional test done in real ShardEnd and incorrect ShardEnd scenarios.

3. Long running regression test is done with Split and Merge accounts. And also having the incorrect ShardEnd triggered randomly during the test to catch regressions.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
