### PR TITLE
Adding DDB BillingMode Support

### DIFF
--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/KinesisClientLibConfiguration.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/KinesisClientLibConfiguration.java
@@ -361,6 +361,7 @@ public class KinesisClientLibConfiguration {
      *        {@link RecordProcessorCheckpointer#checkpoint(String)}
      * @param regionName The region name for the service
      * @param shutdownGraceMillis The number of milliseconds before graceful shutdown terminates forcefully
+     * @param billingMode The DDB Billing mode to set for lease table creation.
      */
     // CHECKSTYLE:IGNORE HiddenFieldCheck FOR NEXT 26 LINES
     // CHECKSTYLE:IGNORE ParameterNumber FOR NEXT 26 LINES
@@ -431,6 +432,7 @@ public class KinesisClientLibConfiguration {
      *        with a call to Amazon Kinesis before checkpointing for calls to
      *        {@link RecordProcessorCheckpointer#checkpoint(String)}
      * @param regionName The region name for the service
+     * @param billingMode The DDB Billing mode to set for lease table creation.
      */
     // CHECKSTYLE:IGNORE HiddenFieldCheck FOR NEXT 26 LINES
     // CHECKSTYLE:IGNORE ParameterNumber FOR NEXT 26 LINES
@@ -507,7 +509,7 @@ public class KinesisClientLibConfiguration {
         this.shardSyncStrategyType = DEFAULT_SHARD_SYNC_STRATEGY_TYPE;
         this.shardPrioritization = DEFAULT_SHARD_PRIORITIZATION;
         this.recordsFetcherFactory = new SimpleRecordsFetcherFactory();
-        this.billingMode=billingMode;
+        this.billingMode = billingMode;
     }
 
     /**
@@ -1162,6 +1164,11 @@ public class KinesisClientLibConfiguration {
         return this;
     }
 
+    /**
+     * The DDB Billing mode to set for lease table creation.
+     * @param billingMode - Either PAY_PER_REQUEST, or PROVISIONED; Defaults to PROVISIONED
+     * @return
+     */
     public KinesisClientLibConfiguration withBillingMode(BillingMode billingMode){
         this.billingMode = billingMode == null ? DEFAULT_DDB_BILLING_MODE : billingMode;
         return this;

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/Worker.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/Worker.java
@@ -576,7 +576,7 @@ public class Worker implements Runnable {
     private static KinesisClientLibLeaseCoordinator getLeaseCoordinator(KinesisClientLibConfiguration config,
             AmazonDynamoDB dynamoDBClient, IMetricsFactory metricsFactory) {
         return new KinesisClientLibLeaseCoordinator(
-                new KinesisClientLeaseManager(config.getTableName(), dynamoDBClient), DEFAULT_LEASE_SELECTOR,
+                new KinesisClientLeaseManager(config.getTableName(), dynamoDBClient, config.getBillingMode()), DEFAULT_LEASE_SELECTOR,
                 config.getWorkerIdentifier(), config.getFailoverTimeMillis(), config.getEpsilonMillis(),
                 config.getMaxLeasesForWorker(), config.getMaxLeasesToStealAtOneTime(),
                 config.getMaxLeaseRenewalThreads(), metricsFactory);
@@ -1345,7 +1345,7 @@ public class Worker implements Runnable {
             }
 
             if (leaseManager == null) {
-                leaseManager = new KinesisClientLeaseManager(config.getTableName(), dynamoDBClient);
+                leaseManager = new KinesisClientLeaseManager(config.getTableName(), dynamoDBClient, config.getBillingMode());
             }
 
             if (shardPrioritization == null) {

--- a/src/main/java/com/amazonaws/services/kinesis/leases/impl/KinesisClientLeaseManager.java
+++ b/src/main/java/com/amazonaws/services/kinesis/leases/impl/KinesisClientLeaseManager.java
@@ -14,6 +14,7 @@
  */
 package com.amazonaws.services.kinesis.leases.impl;
 
+import com.amazonaws.services.dynamodbv2.model.BillingMode;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -38,8 +39,8 @@ public class KinesisClientLeaseManager extends LeaseManager<KinesisClientLease> 
      * @param table Leases table
      * @param dynamoDBClient DynamoDB client to use
      */
-    public KinesisClientLeaseManager(String table, AmazonDynamoDB dynamoDBClient) {
-        this(table, dynamoDBClient, false);
+    public KinesisClientLeaseManager(String table, AmazonDynamoDB dynamoDBClient, BillingMode billingMode) {
+        this(table, dynamoDBClient, false, billingMode);
     }
 
     /**
@@ -50,8 +51,8 @@ public class KinesisClientLeaseManager extends LeaseManager<KinesisClientLease> 
      * @param dynamoDBClient DynamoDB client to use
      * @param consistentReads true if we want consistent reads for testing purposes.
      */
-    public KinesisClientLeaseManager(String table, AmazonDynamoDB dynamoDBClient, boolean consistentReads) {
-        super(table, dynamoDBClient, new KinesisClientLeaseSerializer(), consistentReads);
+    public KinesisClientLeaseManager(String table, AmazonDynamoDB dynamoDBClient, boolean consistentReads, BillingMode billingMode) {
+        super(table, dynamoDBClient, new KinesisClientLeaseSerializer(), consistentReads, billingMode);
     }
 
     /**

--- a/src/main/java/com/amazonaws/services/kinesis/leases/impl/LeaseManager.java
+++ b/src/main/java/com/amazonaws/services/kinesis/leases/impl/LeaseManager.java
@@ -70,6 +70,7 @@ public class LeaseManager<T extends Lease> implements ILeaseManager<T> {
      * @param table leases table
      * @param dynamoDBClient DynamoDB client to use
      * @param serializer LeaseSerializer to use to convert to/from DynamoDB objects.
+     * @param billingMode The DDB Billing mode to set for lease table creation.
      */
     public LeaseManager(String table, AmazonDynamoDB dynamoDBClient, ILeaseSerializer<T> serializer, BillingMode billingMode) {
         this(table, dynamoDBClient, serializer, false, billingMode);
@@ -85,6 +86,7 @@ public class LeaseManager<T extends Lease> implements ILeaseManager<T> {
      * @param dynamoDBClient DynamoDB client to use
      * @param serializer lease serializer to use
      * @param consistentReads true if we want consistent reads for testing purposes.
+     * @param billingMode The DDB Billing mode to set for lease table creation.
      */
     public LeaseManager(String table, AmazonDynamoDB dynamoDBClient, ILeaseSerializer<T> serializer, boolean consistentReads, BillingMode billingMode) {
         verifyNotNull(table, "Table name cannot be null");

--- a/src/main/java/com/amazonaws/services/kinesis/leases/impl/LeaseManager.java
+++ b/src/main/java/com/amazonaws/services/kinesis/leases/impl/LeaseManager.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
+import com.amazonaws.services.dynamodbv2.model.BillingMode;
 import com.amazonaws.services.kinesis.leases.util.DynamoUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -61,16 +62,17 @@ public class LeaseManager<T extends Lease> implements ILeaseManager<T> {
     protected AmazonDynamoDB dynamoDBClient;
     protected ILeaseSerializer<T> serializer;
     protected boolean consistentReads;
+    private BillingMode billingMode;
 
     /**
      * Constructor.
-     * 
+     *
      * @param table leases table
      * @param dynamoDBClient DynamoDB client to use
      * @param serializer LeaseSerializer to use to convert to/from DynamoDB objects.
      */
-    public LeaseManager(String table, AmazonDynamoDB dynamoDBClient, ILeaseSerializer<T> serializer) {
-        this(table, dynamoDBClient, serializer, false);
+    public LeaseManager(String table, AmazonDynamoDB dynamoDBClient, ILeaseSerializer<T> serializer, BillingMode billingMode) {
+        this(table, dynamoDBClient, serializer, false, billingMode);
     }
 
     /**
@@ -78,13 +80,13 @@ public class LeaseManager<T extends Lease> implements ILeaseManager<T> {
      * - our code is meant to be resilient to inconsistent reads. Using consistent reads during testing speeds up
      * execution of simple tests (you don't have to wait out the consistency window). Test cases that want to experience
      * eventual consistency should not set consistentReads=true.
-     * 
+     *
      * @param table leases table
      * @param dynamoDBClient DynamoDB client to use
      * @param serializer lease serializer to use
      * @param consistentReads true if we want consistent reads for testing purposes.
      */
-    public LeaseManager(String table, AmazonDynamoDB dynamoDBClient, ILeaseSerializer<T> serializer, boolean consistentReads) {
+    public LeaseManager(String table, AmazonDynamoDB dynamoDBClient, ILeaseSerializer<T> serializer, boolean consistentReads, BillingMode billingMode) {
         verifyNotNull(table, "Table name cannot be null");
         verifyNotNull(dynamoDBClient, "dynamoDBClient cannot be null");
         verifyNotNull(serializer, "ILeaseSerializer cannot be null");
@@ -93,6 +95,7 @@ public class LeaseManager<T extends Lease> implements ILeaseManager<T> {
         this.dynamoDBClient = dynamoDBClient;
         this.consistentReads = consistentReads;
         this.serializer = serializer;
+        this.billingMode=billingMode;
     }
 
     /**
@@ -118,11 +121,13 @@ public class LeaseManager<T extends Lease> implements ILeaseManager<T> {
         request.setTableName(table);
         request.setKeySchema(serializer.getKeySchema());
         request.setAttributeDefinitions(serializer.getAttributeDefinitions());
-
-        ProvisionedThroughput throughput = new ProvisionedThroughput();
-        throughput.setReadCapacityUnits(readCapacity);
-        throughput.setWriteCapacityUnits(writeCapacity);
-        request.setProvisionedThroughput(throughput);
+        request.setBillingMode(billingMode.name());
+        if(BillingMode.PROVISIONED.equals(billingMode)){
+            ProvisionedThroughput throughput = new ProvisionedThroughput();
+            throughput.setReadCapacityUnits(readCapacity);
+            throughput.setWriteCapacityUnits(writeCapacity);
+            request.setProvisionedThroughput(throughput);
+        }
 
         try {
             dynamoDBClient.createTable(request);

--- a/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/KinesisClientLibConfigurationTest.java
+++ b/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/KinesisClientLibConfigurationTest.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.fail;
 
 import java.util.Date;
 
+import com.amazonaws.services.dynamodbv2.model.BillingMode;
 import org.junit.Test;
 import org.mockito.Mockito;
 
@@ -86,7 +87,7 @@ public class KinesisClientLibConfigurationTest {
                         TEST_VALUE_INT,
                         skipCheckpointValidationValue,
                         null,
-                        TEST_VALUE_LONG);
+                        TEST_VALUE_LONG, BillingMode.PROVISIONED);
     }
 
     @Test
@@ -126,7 +127,7 @@ public class KinesisClientLibConfigurationTest {
                                 TEST_VALUE_INT,
                                 skipCheckpointValidationValue,
                                 null,
-                                longValues[6]);
+                                longValues[6], BillingMode.PROVISIONED);
             } catch (IllegalArgumentException e) {
                 System.out.println(e.getMessage());
             }
@@ -161,7 +162,7 @@ public class KinesisClientLibConfigurationTest {
                                 intValues[1],
                                 skipCheckpointValidationValue,
                                 null,
-                                TEST_VALUE_LONG);
+                                TEST_VALUE_LONG, BillingMode.PAY_PER_REQUEST);
             } catch (IllegalArgumentException e) {
                 System.out.println(e.getMessage());
             }

--- a/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/KinesisClientLibLeaseCoordinatorIntegrationTest.java
+++ b/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/KinesisClientLibLeaseCoordinatorIntegrationTest.java
@@ -61,7 +61,8 @@ public class KinesisClientLibLeaseCoordinatorIntegrationTest {
         if (leaseManager == null) {
             AmazonDynamoDBClient ddb = new AmazonDynamoDBClient(new DefaultAWSCredentialsProviderChain());
             leaseManager =
-                    new KinesisClientLeaseManager(TABLE_NAME, ddb, useConsistentReads);
+                    new KinesisClientLeaseManager(TABLE_NAME, ddb, useConsistentReads,
+                            KinesisClientLibConfiguration.DEFAULT_DDB_BILLING_MODE);
         }
         leaseManager.createLeaseTableIfNotExists(10L, 10L);
         leaseManager.deleteAll();

--- a/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardSyncerTest.java
+++ b/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardSyncerTest.java
@@ -70,7 +70,7 @@ public class ShardSyncerTest {
             InitialPositionInStreamExtended.newInitialPositionAtTimestamp(new Date(1000L));
     private final boolean cleanupLeasesOfCompletedShards = true;
     AmazonDynamoDB ddbClient = DynamoDBEmbedded.create().amazonDynamoDB();
-    LeaseManager<KinesisClientLease> leaseManager = new KinesisClientLeaseManager("tempTestTable", ddbClient);
+    LeaseManager<KinesisClientLease> leaseManager = new KinesisClientLeaseManager("tempTestTable", ddbClient, KinesisClientLibConfiguration.DEFAULT_DDB_BILLING_MODE);
     private static final int EXPONENT = 128;
     protected static final KinesisLeaseCleanupValidator leaseCleanupValidator = new KinesisLeaseCleanupValidator();
     private static final KinesisShardSyncer shardSyncer = new KinesisShardSyncer(leaseCleanupValidator);

--- a/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/WorkerTest.java
+++ b/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/WorkerTest.java
@@ -2133,7 +2133,8 @@ public class WorkerTest {
         final long idleTimeInMilliseconds = 2L;
 
         AmazonDynamoDB ddbClient = DynamoDBEmbedded.create().amazonDynamoDB();
-        LeaseManager<KinesisClientLease> leaseManager = new KinesisClientLeaseManager("foo", ddbClient);
+        LeaseManager<KinesisClientLease> leaseManager = new KinesisClientLeaseManager("foo", ddbClient,
+                KinesisClientLibConfiguration.DEFAULT_DDB_BILLING_MODE);
         leaseManager.createLeaseTableIfNotExists(1L, 1L);
         for (KinesisClientLease initialLease : initialLeases) {
             leaseManager.createLeaseIfNotExists(initialLease);

--- a/src/test/java/com/amazonaws/services/kinesis/leases/impl/LeaseCoordinatorExerciser.java
+++ b/src/test/java/com/amazonaws/services/kinesis/leases/impl/LeaseCoordinatorExerciser.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import javax.swing.*;
 
 import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
+import com.amazonaws.services.kinesis.clientlibrary.lib.worker.KinesisClientLibConfiguration;
 import com.amazonaws.services.kinesis.leases.interfaces.LeaseSelector;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -59,7 +60,8 @@ public class LeaseCoordinatorExerciser {
                 new DefaultAWSCredentialsProviderChain();
         AmazonDynamoDBClient ddb = new AmazonDynamoDBClient(creds);
 
-        ILeaseManager<KinesisClientLease> leaseManager = new KinesisClientLeaseManager("nagl_ShardProgress", ddb);
+        ILeaseManager<KinesisClientLease> leaseManager = new KinesisClientLeaseManager("nagl_ShardProgress", ddb,
+                KinesisClientLibConfiguration.DEFAULT_DDB_BILLING_MODE);
 
         if (leaseManager.createLeaseTableIfNotExists(10L, 50L)) {
             LOG.info("Waiting for newly created lease table");

--- a/src/test/java/com/amazonaws/services/kinesis/leases/impl/LeaseIntegrationTest.java
+++ b/src/test/java/com/amazonaws/services/kinesis/leases/impl/LeaseIntegrationTest.java
@@ -16,6 +16,7 @@ package com.amazonaws.services.kinesis.leases.impl;
 
 import java.util.logging.Logger;
 
+import com.amazonaws.services.kinesis.clientlibrary.lib.worker.KinesisClientLibConfiguration;
 import com.amazonaws.services.kinesis.leases.exceptions.LeasingException;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -46,7 +47,8 @@ public class LeaseIntegrationTest {
             if (leaseManager == null) {
                 // Do some static setup once per class.
 
-                leaseManager = new KinesisClientLeaseManager("nagl_ShardProgress", ddbClient, true);
+                leaseManager = new KinesisClientLeaseManager("nagl_ShardProgress", ddbClient, true,
+                        KinesisClientLibConfiguration.DEFAULT_DDB_BILLING_MODE);
 
                 MetricsHelper.startScope(new NullMetricsFactory());
             }

--- a/src/test/java/com/amazonaws/services/kinesis/leases/impl/LeaseManagerIntegrationTest.java
+++ b/src/test/java/com/amazonaws/services/kinesis/leases/impl/LeaseManagerIntegrationTest.java
@@ -18,6 +18,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import com.amazonaws.services.kinesis.clientlibrary.lib.worker.KinesisClientLibConfiguration;
 import junit.framework.Assert;
 
 import org.junit.Test;
@@ -233,7 +234,24 @@ public class LeaseManagerIntegrationTest extends LeaseIntegrationTest {
 
     @Test
     public void testWaitUntilLeaseTableExists() throws LeasingException {
-        KinesisClientLeaseManager manager = new KinesisClientLeaseManager("nagl_ShardProgress", ddbClient, true) {
+        KinesisClientLeaseManager manager = new KinesisClientLeaseManager("nagl_ShardProgress", ddbClient, true,
+                KinesisClientLibConfiguration.DEFAULT_DDB_BILLING_MODE) {
+
+            @Override
+            long sleep(long timeToSleepMillis) {
+                Assert.fail("Should not sleep");
+                return 0L;
+            }
+
+        };
+
+        Assert.assertTrue(manager.waitUntilLeaseTableExists(1, 1));
+    }
+
+    @Test
+    public void testWaitUntilLeaseTableExistsPayPerRequest() throws LeasingException {
+        KinesisClientLeaseManager manager = new KinesisClientLeaseManager("nagl_ShardProgress_PayPerRequest", ddbClient, true,
+                KinesisClientLibConfiguration.DEFAULT_DDB_BILLING_MODE) {
 
             @Override
             long sleep(long timeToSleepMillis) {
@@ -252,7 +270,8 @@ public class LeaseManagerIntegrationTest extends LeaseIntegrationTest {
          * Just using AtomicInteger for the indirection it provides.
          */
         final AtomicInteger sleepCounter = new AtomicInteger(0);
-        KinesisClientLeaseManager manager = new KinesisClientLeaseManager("nonexistentTable", ddbClient, true) {
+        KinesisClientLeaseManager manager = new KinesisClientLeaseManager("nonexistentTable", ddbClient, true,
+                KinesisClientLibConfiguration.DEFAULT_DDB_BILLING_MODE) {
 
             @Override
             long sleep(long timeToSleepMillis) {

--- a/src/test/java/com/amazonaws/services/kinesis/leases/impl/LeaseManagerIntegrationTest.java
+++ b/src/test/java/com/amazonaws/services/kinesis/leases/impl/LeaseManagerIntegrationTest.java
@@ -18,6 +18,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import com.amazonaws.services.dynamodbv2.model.BillingMode;
 import com.amazonaws.services.kinesis.clientlibrary.lib.worker.KinesisClientLibConfiguration;
 import junit.framework.Assert;
 
@@ -251,7 +252,7 @@ public class LeaseManagerIntegrationTest extends LeaseIntegrationTest {
     @Test
     public void testWaitUntilLeaseTableExistsPayPerRequest() throws LeasingException {
         KinesisClientLeaseManager manager = new KinesisClientLeaseManager("nagl_ShardProgress_PayPerRequest", ddbClient, true,
-                KinesisClientLibConfiguration.DEFAULT_DDB_BILLING_MODE) {
+                BillingMode.PAY_PER_REQUEST) {
 
             @Override
             long sleep(long timeToSleepMillis) {


### PR DESCRIPTION
*Description of changes:*
Adding BillingMode Support to KCL 1.x. This enables the customer to specify if they want provisioned capacity for DDB, or pay per request.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
