### PR TITLE
Upgrade SDK to version 2.10.25

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
   </scm>
 
   <properties>
-    <awssdk.version>2.10.0</awssdk.version>
+    <awssdk.version>2.10.25</awssdk.version>
   </properties>
 
   <licenses>


### PR DESCRIPTION
*Description of changes:*

Upgrade SDK version to 2.10.25.

This version of SDK introduced a PING frame to health check the H2 connection while receiving Read/Write timeout. If H2 connection is not able to ack the PING frame, the current H2 connection will be closed and new H2 connection will be established. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
