### PR TITLE
Fix for #475

### DIFF
--- a/amazon-kinesis-client-multilang/src/main/java/software/amazon/kinesis/multilang/config/MultiLangDaemonConfiguration.java
+++ b/amazon-kinesis-client-multilang/src/main/java/software/amazon/kinesis/multilang/config/MultiLangDaemonConfiguration.java
@@ -130,6 +130,8 @@ public class MultiLangDaemonConfiguration {
     private ShardPrioritization shardPrioritization;
     @ConfigurationSettable(configurationClass = CoordinatorConfig.class)
     private boolean skipShardSyncAtWorkerInitializationIfLeasesExist;
+    @ConfigurationSettable(configurationClass = CoordinatorConfig.class)
+    private long schedulerInitializationBackoffTimeMillis;
 
     @ConfigurationSettable(configurationClass = LifecycleConfig.class)
     private long taskBackoffTimeMillis;

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/coordinator/CoordinatorConfig.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/coordinator/CoordinatorConfig.java
@@ -90,4 +90,11 @@ public class CoordinatorConfig {
 
     private CoordinatorFactory coordinatorFactory = new SchedulerCoordinatorFactory();
 
+    /**
+     * Interval in milliseconds between retrying the scheduler initialization.
+     *
+     * <p>Default value: 1000L</p>
+     */
+    private long schedulerInitializationBackoffTimeMillis = 1000L;
+
 }


### PR DESCRIPTION
*Issue #, if available:*

#475 

*Description of changes:*

- Add a new configuration, `schedulerInitializationRetryIntervalMillis`, which is used in place of `parentShardPollIntervalMillis` when retrying failures during initialization. The default for this is 1 second.
- Updated the Scheduler initialization so that the sleep only occurs when initialization has not completed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
