### PR TITLE
Ensure IntegrationTests follow pattern of "*IntegrationTest.java" fil…

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,9 @@ Please open an issue if you have any questions.
 
 ## Building from Source
 
-After you've downloaded the code from GitHub, you can build it using Maven. To disable GPG signing in the build, use this command: `mvn clean install -Dgpg.skip=true`
+After you've downloaded the code from GitHub, you can build it using Maven. To disable GPG signing in the build, use
+ this command: `mvn clean install -Dgpg.skip=true -DskipITs`. To run integration tests, remove the `-DskipITs` option
+  from the command. Note: Integration tests create AWS resources and require valid AWS credentials to be discovered at runtime.
 
 ## Integration with the Kinesis Producer Library
 For producer-side developers using the **[Kinesis Producer Library (KPL)][kinesis-guide-kpl]**, the KCL integrates without additional effort. When the KCL retrieves an aggregated Amazon Kinesis record consisting of multiple KPL user records, it will automatically invoke the KPL to extract the individual user records before returning them to the user.

--- a/amazon-kinesis-client/src/test/java/software/amazon/kinesis/leases/dynamodb/DynamoDBLeaseRenewerBillingModePayPerRequestIntegrationTest.java
+++ b/amazon-kinesis-client/src/test/java/software/amazon/kinesis/leases/dynamodb/DynamoDBLeaseRenewerBillingModePayPerRequestIntegrationTest.java
@@ -35,7 +35,7 @@ import static org.hamcrest.CoreMatchers.nullValue;
 import static org.junit.Assert.assertThat;
 
 @RunWith(MockitoJUnitRunner.class)
-public class DynamoDBLeaseRenewerIntegrationBillingModePayPerRequestTest extends
+public class DynamoDBLeaseRenewerBillingModePayPerRequestIntegrationTest extends
         LeaseIntegrationBillingModePayPerRequestTest {
     private final String TEST_METRIC = "TestOperation";
 


### PR DESCRIPTION
…e name pattern to skip running it with -DSkipITs mvn option.

*Issue #, if available:*

*Description of changes:*

Before this change, integration tests were run by default which failed if the valid AWS credentials are not available. By using `DskipITs`, integ tests could be skipped, however that requires all the integ tests to follow "*IntegrationTest.java" naming pattern. Updated the class name  DynamoDBLeaseRenewerIntegrationBillingModePayPerRequestTest to DynamoDBLeaseRenewerBillingModePayPerRequestIntegrationTest . Updated read me to reflect the choice to skip the integ tests by default.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
