### PR TITLE
Ensure IntegrationTests follow pattern of "*IntegrationTest.java" fil…

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,10 @@ Please open an issue if you have any questions.
 
 ## Building from Source
 
-After you've downloaded the code from GitHub, you can build it using Maven. To disable GPG signing in the build, use this command: `mvn clean install -Dgpg.skip=true`
+After you've downloaded the code from GitHub, you can build it using Maven. To disable GPG signing in the build, use
+ this command: `mvn clean install -Dgpg.skip=true`. Note: This command runs Integration tests, which in turn creates AWS
+  resources (which requires manual cleanup). Integration tests require valid AWS credentials need to be discovered at
+   runtime. To skip running integration tests, add ` -DskipITs` option to the build command.  
 
 ## Integration with the Kinesis Producer Library
 For producer-side developers using the **[Kinesis Producer Library (KPL)][kinesis-guide-kpl]**, the KCL integrates without additional effort. When the KCL retrieves an aggregated Amazon Kinesis record consisting of multiple KPL user records, it will automatically invoke the KPL to extract the individual user records before returning them to the user.

--- a/amazon-kinesis-client/src/test/java/software/amazon/kinesis/leases/dynamodb/DynamoDBLeaseRenewerBillingModePayPerRequestIntegrationTest.java
+++ b/amazon-kinesis-client/src/test/java/software/amazon/kinesis/leases/dynamodb/DynamoDBLeaseRenewerBillingModePayPerRequestIntegrationTest.java
@@ -35,7 +35,7 @@ import static org.hamcrest.CoreMatchers.nullValue;
 import static org.junit.Assert.assertThat;
 
 @RunWith(MockitoJUnitRunner.class)
-public class DynamoDBLeaseRenewerIntegrationBillingModePayPerRequestTest extends
+public class DynamoDBLeaseRenewerBillingModePayPerRequestIntegrationTest extends
         LeaseIntegrationBillingModePayPerRequestTest {
     private final String TEST_METRIC = "TestOperation";
 


### PR DESCRIPTION
…e name pattern to skip running it with -DSkipITs mvn option.

*Issue #, if available:*

*Description of changes:*
Integration tests are run for the command in the README file. Update README to add an option to skip integration tests for incremental testing.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
