### PR TITLE
Ensure the new test task is scheduled beyond millisecond delay to avo…

### DIFF
--- a/amazon-kinesis-client/src/test/java/software/amazon/kinesis/lifecycle/ShardConsumerTest.java
+++ b/amazon-kinesis-client/src/test/java/software/amazon/kinesis/lifecycle/ShardConsumerTest.java
@@ -816,6 +816,10 @@ public class ShardConsumerTest {
         assertThat(consumer.taskRunningTime(), nullValue());
         cache.requestBarrier.reset();
 
+        // Sleep for 10 millis before processing next task. If we don't; then the following
+        // assertion on time fails. This happens if cache.publish() is executed in the
+        // same millisecond as that of previousTaskStartTime, resulting in the unit test failure.
+        Thread.sleep(10);
         cache.publish();
 
         awaitAndResetBarrier(taskArriveBarrier);


### PR DESCRIPTION
…id incorrect test failure.

*Issue #, if available:*

*Description of changes:*
Fix ShardConsumerTest unit test failures by adding sleep time as a short term workaround.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
