### PR TITLE
Adding backward compatible constructors that use the default DDB Billing Mode

### DIFF
--- a/src/main/java/com/amazonaws/services/kinesis/leases/impl/KinesisClientLeaseManager.java
+++ b/src/main/java/com/amazonaws/services/kinesis/leases/impl/KinesisClientLeaseManager.java
@@ -15,6 +15,7 @@
 package com.amazonaws.services.kinesis.leases.impl;
 
 import com.amazonaws.services.dynamodbv2.model.BillingMode;
+import com.amazonaws.services.kinesis.clientlibrary.lib.worker.KinesisClientLibConfiguration;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -35,12 +36,36 @@ public class KinesisClientLeaseManager extends LeaseManager<KinesisClientLease> 
 
     /**
      * Constructor.
+     *
+     * @param table Leases table
+     * @param dynamoDBClient DynamoDB client to use
+     */
+    @Deprecated
+    public KinesisClientLeaseManager(String table, AmazonDynamoDB dynamoDBClient) {
+        this(table, dynamoDBClient, false, KinesisClientLibConfiguration.DEFAULT_DDB_BILLING_MODE);
+    }
+
+    /**
+     * Constructor.
      * 
      * @param table Leases table
      * @param dynamoDBClient DynamoDB client to use
      */
     public KinesisClientLeaseManager(String table, AmazonDynamoDB dynamoDBClient, BillingMode billingMode) {
         this(table, dynamoDBClient, false, billingMode);
+    }
+
+    /**
+     * Constructor for integration tests - see comment on superclass for documentation on setting the consistentReads
+     * flag.
+     *
+     * @param table leases table
+     * @param dynamoDBClient DynamoDB client to use
+     * @param consistentReads true if we want consistent reads for testing purposes.
+     */
+    @Deprecated
+    public KinesisClientLeaseManager(String table, AmazonDynamoDB dynamoDBClient, boolean consistentReads) {
+        super(table, dynamoDBClient, new KinesisClientLeaseSerializer(), consistentReads, KinesisClientLibConfiguration.DEFAULT_DDB_BILLING_MODE);
     }
 
     /**

--- a/src/main/java/com/amazonaws/services/kinesis/leases/impl/LeaseManager.java
+++ b/src/main/java/com/amazonaws/services/kinesis/leases/impl/LeaseManager.java
@@ -20,6 +20,7 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import com.amazonaws.services.dynamodbv2.model.BillingMode;
+import com.amazonaws.services.kinesis.clientlibrary.lib.worker.KinesisClientLibConfiguration;
 import com.amazonaws.services.kinesis.leases.util.DynamoUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -63,6 +64,18 @@ public class LeaseManager<T extends Lease> implements ILeaseManager<T> {
     protected ILeaseSerializer<T> serializer;
     protected boolean consistentReads;
     private BillingMode billingMode;
+
+    /**
+     * Constructor.
+     *
+     * @param table leases table
+     * @param dynamoDBClient DynamoDB client to use
+     * @param serializer LeaseSerializer to use to convert to/from DynamoDB objects.
+     */
+    @Deprecated
+    public LeaseManager(String table, AmazonDynamoDB dynamoDBClient, ILeaseSerializer<T> serializer) {
+        this(table, dynamoDBClient, serializer, false, KinesisClientLibConfiguration.DEFAULT_DDB_BILLING_MODE);
+    }
 
     /**
      * Constructor.


### PR DESCRIPTION
*Issue #, if available:*
awslabs/dynamodb-streams-kinesis-adapter#27

*Description of changes:*
Adding backward compatible constructors based on recent changes. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
