### PR TITLE
Adding rid to SubscribeToShard response for debugging.

### DIFF
--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/common/RequestDetails.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/common/RequestDetails.java
@@ -29,26 +29,26 @@ public class RequestDetails {
     }
 
     /**
-     * Gets last successful response's request id.
+     * Gets last successful request's request id.
      *
-     * @return requestId associated with last succesful response.
+     * @return requestId associated with last successful request.
      */
-    public String getLastSuccessfulResponseRequestId() {
+    public String getRequestId() {
         return requestId.orElse(NONE);
     }
 
     /**
-     * Gets last successful response's timestamp.
+     * Gets last successful request's timestamp.
      *
-     * @return timestamp associated with last successful response.
+     * @return timestamp associated with last successful request.
      */
-    public String getLastSuccessfulResponseTimestamp() {
+    public String getTimestamp() {
         return timestamp.orElse(NONE);
     }
 
     @Override
     public String toString() {
-        return String.format("request id - %s, timestamp - %s", getLastSuccessfulResponseRequestId(), getLastSuccessfulResponseTimestamp());
+        return String.format("request id - %s, timestamp - %s", getRequestId(), getTimestamp());
     }
 
 }

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/common/RequestDetails.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/common/RequestDetails.java
@@ -1,14 +1,10 @@
 package software.amazon.kinesis.common;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 import lombok.experimental.Accessors;
 
 import java.util.Optional;
 
 @Accessors(fluent=true)
-@Getter
 public class RequestDetails {
 
     /**
@@ -20,12 +16,13 @@ public class RequestDetails {
     private final Optional<String> timestamp;
 
     public RequestDetails() {
-        this(Optional.empty(), Optional.empty());
+        this.requestId = Optional.empty();
+        this.timestamp = Optional.empty();
     }
 
-    public RequestDetails(Optional<String> requestId, Optional<String> timestamp) {
-        this.requestId = requestId;
-        this.timestamp = timestamp;
+    public RequestDetails(String requestId, String timestamp) {
+        this.requestId = Optional.of(requestId);
+        this.timestamp = Optional.of(timestamp);
     }
 
     /**

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/common/RequestDetails.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/common/RequestDetails.java
@@ -1,0 +1,17 @@
+package software.amazon.kinesis.common;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.experimental.Accessors;
+import software.amazon.awssdk.services.kinesis.model.KinesisResponseMetadata;
+
+import java.time.Instant;
+import java.util.Optional;
+
+@Accessors(fluent = true)
+@Getter
+@AllArgsConstructor
+public class RequestDetails {
+    private final String requestId;
+    private final String timestamp;
+}

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/common/RequestDetails.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/common/RequestDetails.java
@@ -2,12 +2,54 @@ package software.amazon.kinesis.common;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.experimental.Accessors;
 
-@Accessors(fluent = true)
+import java.util.Optional;
+
+@Accessors(fluent=true)
 @Getter
-@AllArgsConstructor
 public class RequestDetails {
-    private final String requestId;
-    private final String timestamp;
+
+    /**
+     * Placeholder for logging when no successful request has been made.
+     */
+    private static final String NONE = "NONE";
+
+    private final Optional<String> requestId;
+    private final Optional<String> timestamp;
+
+    public RequestDetails() {
+        this(Optional.empty(), Optional.empty());
+    }
+
+    public RequestDetails(Optional<String> requestId, Optional<String> timestamp) {
+        this.requestId = requestId;
+        this.timestamp = timestamp;
+    }
+
+    /**
+     * Gets last successful response's request id.
+     *
+     * @return requestId associated with last succesful response.
+     */
+    public String getLastSuccessfulResponseRequestId() {
+        return requestId.orElse(NONE);
+    }
+
+    /**
+     * Gets last successful response's timestamp.
+     *
+     * @return timestamp associated with last successful response.
+     */
+    public String getLastSuccessfulResponseTimestamp() {
+        return timestamp.orElse(NONE);
+    }
+
+    @Override
+    public String toString() {
+        return String.format("request id - %s, timestamp - %s", getLastSuccessfulResponseRequestId(), getLastSuccessfulResponseTimestamp());
+    }
+
 }
+

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/common/RequestDetails.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/common/RequestDetails.java
@@ -3,10 +3,6 @@ package software.amazon.kinesis.common;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.experimental.Accessors;
-import software.amazon.awssdk.services.kinesis.model.KinesisResponseMetadata;
-
-import java.time.Instant;
-import java.util.Optional;
 
 @Accessors(fluent = true)
 @Getter

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/lifecycle/ShardConsumerSubscriber.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/lifecycle/ShardConsumerSubscriber.java
@@ -129,8 +129,8 @@ class ShardConsumerSubscriber implements Subscriber<RecordsRetrieved> {
                 Duration timeSinceLastResponse = Duration.between(lastRequestTime, now);
                 if (timeSinceLastResponse.toMillis() > maxTimeBetweenRequests) {
                     log.error(
-                            "{}: Last request was dispatched at {}, but no response as of {} ({}).  Cancelling subscription, and restarting. Last successful response details: {}",
-                            shardConsumer.shardInfo().shardId(), lastRequestTime, now, timeSinceLastResponse, recordsPublisher.getLastSuccessfulResponseDetails());
+                            "{}: Last request was dispatched at {}, but no response as of {} ({}).  Cancelling subscription, and restarting. Last successful request details -- {}",
+                            shardConsumer.shardInfo().shardId(), lastRequestTime, now, timeSinceLastResponse, recordsPublisher.getLastSuccessfulRequestDetails());
                     cancel();
 
                     // Start the subscription again which will update the lastRequestTime as well.

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/lifecycle/ShardConsumerSubscriber.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/lifecycle/ShardConsumerSubscriber.java
@@ -130,7 +130,7 @@ class ShardConsumerSubscriber implements Subscriber<RecordsRetrieved> {
                 if (timeSinceLastResponse.toMillis() > maxTimeBetweenRequests) {
                     log.error(
                             "{}: Last request was dispatched at {}, but no response as of {} ({}).  Cancelling subscription, and restarting.",
-                            shardConsumer.shardInfo().shardId(), lastRequestTime, now, timeSinceLastResponse);
+                            shardConsumer.shardInfo().shardId(), lastRequestTime, now, timeSinceLastResponse, recordsPublisher.getLastRequestId());
                     cancel();
 
                     // Start the subscription again which will update the lastRequestTime as well.

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/lifecycle/ShardConsumerSubscriber.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/lifecycle/ShardConsumerSubscriber.java
@@ -129,8 +129,8 @@ class ShardConsumerSubscriber implements Subscriber<RecordsRetrieved> {
                 Duration timeSinceLastResponse = Duration.between(lastRequestTime, now);
                 if (timeSinceLastResponse.toMillis() > maxTimeBetweenRequests) {
                     log.error(
-                            "{}: Last request was dispatched at {}, but no response as of {} ({}).  Cancelling subscription, and restarting.",
-                            shardConsumer.shardInfo().shardId(), lastRequestTime, now, timeSinceLastResponse, recordsPublisher.getLastRequestId());
+                            "{}: Last request was dispatched at {}, but no response as of {} ({}).  Cancelling subscription, and restarting. Last successful response: RequestId - {}, Timestamp - {}",
+                            shardConsumer.shardInfo().shardId(), lastRequestTime, now, timeSinceLastResponse, recordsPublisher.getLastSuccessfulResponseRequestId(), recordsPublisher.getLastSuccessfulResponseTimestamp());
                     cancel();
 
                     // Start the subscription again which will update the lastRequestTime as well.

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/lifecycle/ShardConsumerSubscriber.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/lifecycle/ShardConsumerSubscriber.java
@@ -129,8 +129,8 @@ class ShardConsumerSubscriber implements Subscriber<RecordsRetrieved> {
                 Duration timeSinceLastResponse = Duration.between(lastRequestTime, now);
                 if (timeSinceLastResponse.toMillis() > maxTimeBetweenRequests) {
                     log.error(
-                            "{}: Last request was dispatched at {}, but no response as of {} ({}).  Cancelling subscription, and restarting. Last successful response: RequestId - {}, Timestamp - {}",
-                            shardConsumer.shardInfo().shardId(), lastRequestTime, now, timeSinceLastResponse, recordsPublisher.getLastSuccessfulResponseRequestId(), recordsPublisher.getLastSuccessfulResponseTimestamp());
+                            "{}: Last request was dispatched at {}, but no response as of {} ({}).  Cancelling subscription, and restarting. Last successful response details: {}",
+                            shardConsumer.shardInfo().shardId(), lastRequestTime, now, timeSinceLastResponse, recordsPublisher.getLastSuccessfulResponseDetails());
                     cancel();
 
                     // Start the subscription again which will update the lastRequestTime as well.

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/RecordsPublisher.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/RecordsPublisher.java
@@ -54,11 +54,11 @@ public interface RecordsPublisher extends Publisher<RecordsRetrieved> {
     void shutdown();
 
     /**
-     * Gets last successful response details.
+     * Gets last successful request details.
      *
-     * @return details associated with last successful response.
+     * @return details associated with last successful request.
      */
-    RequestDetails getLastSuccessfulResponseDetails();
+    RequestDetails getLastSuccessfulRequestDetails();
 
     /**
      * Notify the publisher on receipt of a data event.

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/RecordsPublisher.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/RecordsPublisher.java
@@ -15,49 +15,74 @@
 
 package software.amazon.kinesis.retrieval;
 
-import lombok.Getter;
-import lombok.Setter;
 import org.reactivestreams.Publisher;
 
 import software.amazon.kinesis.common.InitialPositionInStreamExtended;
+import software.amazon.kinesis.common.RequestDetails;
 import software.amazon.kinesis.retrieval.kpl.ExtendedSequenceNumber;
+
+import java.util.Optional;
 
 /**
  * Provides a record publisher that will retrieve records from Kinesis for processing
  */
-public abstract class RecordsPublisher implements Publisher<RecordsRetrieved> {
+public interface RecordsPublisher extends Publisher<RecordsRetrieved> {
 
-    @Getter @Setter
-    private String lastRequestId;
+    /**
+     * Placeholder for logging when no successful request has been made.
+     */
+    String NONE = "NONE";
 
     /**
      * Initializes the publisher with where to start processing. If there is a stored sequence number the publisher will
      * begin from that sequence number, otherwise it will use the initial position.
-     * 
+     *
      * @param extendedSequenceNumber
      *            the sequence number to start processing from
      * @param initialPositionInStreamExtended
      *            if there is no sequence number the initial position to use
      */
-    public abstract void start(ExtendedSequenceNumber extendedSequenceNumber, InitialPositionInStreamExtended initialPositionInStreamExtended);
+    void start(ExtendedSequenceNumber extendedSequenceNumber, InitialPositionInStreamExtended initialPositionInStreamExtended);
 
     /**
      * Restart from the last accepted and processed
      * @param recordsRetrieved the processRecordsInput to restart from
      */
-    public abstract void restartFrom(RecordsRetrieved recordsRetrieved);
-    
+    void restartFrom(RecordsRetrieved recordsRetrieved);
+
 
     /**
      * Shutdowns the publisher. Once this method returns the publisher should no longer provide any records.
      */
-    public abstract void shutdown();
+    void shutdown();
+
+    /**
+     * Gets last successful response details.
+     *
+     * @return details associated with last successful response.
+     */
+    Optional<RequestDetails> getLastSuccessfulResponseDetails();
+
+    /**
+     * Gets last successful response's request id.
+     *
+     * @return requestId associated with last succesful response.
+     */
+    String getLastSuccessfulResponseRequestId();
+
+    /**
+     * Gets last successful response's timestamp.
+     *
+     * @return timestamp associated with last successful response.
+     */
+    String getLastSuccessfulResponseTimestamp();
 
     /**
      * Notify the publisher on receipt of a data event.
+     *
      * @param ack acknowledgement received from the subscriber.
      */
-    public void notify(RecordsDeliveryAck ack) {
+    default void notify(RecordsDeliveryAck ack) {
         throw new UnsupportedOperationException("RecordsPublisher does not support acknowledgement from Subscriber");
     }
 }

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/RecordsPublisher.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/RecordsPublisher.java
@@ -28,10 +28,7 @@ import java.util.Optional;
  */
 public interface RecordsPublisher extends Publisher<RecordsRetrieved> {
 
-    /**
-     * Placeholder for logging when no successful request has been made.
-     */
-    String NONE = "NONE";
+
 
     /**
      * Initializes the publisher with where to start processing. If there is a stored sequence number the publisher will
@@ -61,25 +58,7 @@ public interface RecordsPublisher extends Publisher<RecordsRetrieved> {
      *
      * @return details associated with last successful response.
      */
-    Optional<RequestDetails> getLastSuccessfulResponseDetails();
-
-    /**
-     * Gets last successful response's request id.
-     *
-     * @return requestId associated with last succesful response.
-     */
-    default String getLastSuccessfulResponseRequestId() {
-        return getLastSuccessfulResponseDetails().map(RequestDetails::requestId).orElse(NONE);
-    }
-
-    /**
-     * Gets last successful response's timestamp.
-     *
-     * @return timestamp associated with last successful response.
-     */
-    default String getLastSuccessfulResponseTimestamp() {
-        return getLastSuccessfulResponseDetails().map(RequestDetails::timestamp).orElse(NONE);
-    }
+    RequestDetails getLastSuccessfulResponseDetails();
 
     /**
      * Notify the publisher on receipt of a data event.

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/RecordsPublisher.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/RecordsPublisher.java
@@ -15,6 +15,8 @@
 
 package software.amazon.kinesis.retrieval;
 
+import lombok.Getter;
+import lombok.Setter;
 import org.reactivestreams.Publisher;
 
 import software.amazon.kinesis.common.InitialPositionInStreamExtended;
@@ -23,7 +25,11 @@ import software.amazon.kinesis.retrieval.kpl.ExtendedSequenceNumber;
 /**
  * Provides a record publisher that will retrieve records from Kinesis for processing
  */
-public interface RecordsPublisher extends Publisher<RecordsRetrieved> {
+public abstract class RecordsPublisher implements Publisher<RecordsRetrieved> {
+
+    @Getter @Setter
+    private String lastRequestId;
+
     /**
      * Initializes the publisher with where to start processing. If there is a stored sequence number the publisher will
      * begin from that sequence number, otherwise it will use the initial position.
@@ -33,25 +39,25 @@ public interface RecordsPublisher extends Publisher<RecordsRetrieved> {
      * @param initialPositionInStreamExtended
      *            if there is no sequence number the initial position to use
      */
-    void start(ExtendedSequenceNumber extendedSequenceNumber, InitialPositionInStreamExtended initialPositionInStreamExtended);
+    public abstract void start(ExtendedSequenceNumber extendedSequenceNumber, InitialPositionInStreamExtended initialPositionInStreamExtended);
 
     /**
      * Restart from the last accepted and processed
      * @param recordsRetrieved the processRecordsInput to restart from
      */
-    void restartFrom(RecordsRetrieved recordsRetrieved);
+    public abstract void restartFrom(RecordsRetrieved recordsRetrieved);
     
 
     /**
      * Shutdowns the publisher. Once this method returns the publisher should no longer provide any records.
      */
-    void shutdown();
+    public abstract void shutdown();
 
     /**
      * Notify the publisher on receipt of a data event.
      * @param ack acknowledgement received from the subscriber.
      */
-    default void notify(RecordsDeliveryAck ack) {
+    public void notify(RecordsDeliveryAck ack) {
         throw new UnsupportedOperationException("RecordsPublisher does not support acknowledgement from Subscriber");
     }
 }

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/RecordsPublisher.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/RecordsPublisher.java
@@ -68,14 +68,18 @@ public interface RecordsPublisher extends Publisher<RecordsRetrieved> {
      *
      * @return requestId associated with last succesful response.
      */
-    String getLastSuccessfulResponseRequestId();
+    default String getLastSuccessfulResponseRequestId() {
+        return getLastSuccessfulResponseDetails().map(RequestDetails::requestId).orElse(NONE);
+    }
 
     /**
      * Gets last successful response's timestamp.
      *
      * @return timestamp associated with last successful response.
      */
-    String getLastSuccessfulResponseTimestamp();
+    default String getLastSuccessfulResponseTimestamp() {
+        return getLastSuccessfulResponseDetails().map(RequestDetails::timestamp).orElse(NONE);
+    }
 
     /**
      * Notify the publisher on receipt of a data event.

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/fanout/FanOutRecordsPublisher.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/fanout/FanOutRecordsPublisher.java
@@ -718,8 +718,8 @@ public class FanOutRecordsPublisher implements RecordsPublisher {
 
         @Override
         public void responseReceived(SubscribeToShardResponse response) {
-            log.debug("{}: [SubscriptionLifetime]: (RecordFlow#responseReceived) @ {} id: {} -- Response received",
-                    parent.shardId, connectionStartedAt, subscribeToShardId);
+            log.debug("{}: [SubscriptionLifetime]: (RecordFlow#responseReceived) @ {} id: {} -- Response received. rid: {}, erid: {}, sdkfields: {}",
+                    parent.shardId, connectionStartedAt, subscribeToShardId, response.responseMetadata().requestId(), response.responseMetadata().extendedRequestId(), response.sdkFields());
         }
 
         @Override

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/fanout/FanOutRecordsPublisher.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/fanout/FanOutRecordsPublisher.java
@@ -156,16 +156,6 @@ public class FanOutRecordsPublisher implements RecordsPublisher {
         lastSuccessfulRequestDetails = Optional.of(requestDetails);
     }
 
-    @Override
-    public String getLastSuccessfulResponseRequestId() {
-        return getLastSuccessfulResponseDetails().map(RequestDetails::requestId).orElse(NONE);
-    }
-
-    @Override
-    public String getLastSuccessfulResponseTimestamp() {
-        return getLastSuccessfulResponseDetails().map(RequestDetails::timestamp).orElse(NONE);
-    }
-
     // This method is not thread-safe. You need to acquire a lock in the caller in order to execute this.
     @VisibleForTesting
     RecordFlow evictAckedEventAndScheduleNextEvent(RecordsDeliveryAck recordsDeliveryAck) {

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/fanout/FanOutRecordsPublisher.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/fanout/FanOutRecordsPublisher.java
@@ -320,7 +320,7 @@ public class FanOutRecordsPublisher implements RecordsPublisher {
                 if (flow != null) {
                     String logMessage = String.format(
                             "%s: [SubscriptionLifetime] - (FanOutRecordsPublisher#errorOccurred) @ %s id: %s -- %s." +
-                                    " Last successful request details -- {}",
+                                    " Last successful request details -- %s",
                             shardId, flow.connectionStartedAt, flow.subscribeToShardId, category.throwableTypeString, lastSuccessfulRequestDetails);
                     switch (category.throwableType) {
                     case READ_TIMEOUT:
@@ -735,7 +735,7 @@ public class FanOutRecordsPublisher implements RecordsPublisher {
 
         @Override
         public void responseReceived(SubscribeToShardResponse response) {
-            log.debug("{}: [SubscriptionLifetime]: (RecordFlow#responseReceived) @ {} id: {} -- Response received. RequestId - {}",
+            log.debug("{}: [SubscriptionLifetime]: (RecordFlow#responseReceived) @ {} id: {} -- Response received. Request id - {}",
                     parent.shardId, connectionStartedAt, subscribeToShardId, response.responseMetadata().requestId());
 
             final RequestDetails requestDetails = new RequestDetails(response.responseMetadata().requestId(), connectionStartedAt.toString());

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/fanout/FanOutRecordsPublisher.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/fanout/FanOutRecordsPublisher.java
@@ -698,7 +698,6 @@ public class FanOutRecordsPublisher implements RecordsPublisher {
         private boolean isDisposed = false;
         private boolean isErrorDispatched = false;
         private boolean isCancelled = false;
-        private RequestDetails recordFlowLastSuccessfuRequestDetails;
 
         @Override
         public void onEventStream(SdkPublisher<SubscribeToShardEventStream> publisher) {
@@ -736,11 +735,11 @@ public class FanOutRecordsPublisher implements RecordsPublisher {
 
         @Override
         public void responseReceived(SubscribeToShardResponse response) {
-            log.debug("{}: [SubscriptionLifetime]: (RecordFlow#responseReceived) @ {} id: {} -- Response received. RequestId - {} -- Last successful request details -- {} ",
-                    parent.shardId, connectionStartedAt, subscribeToShardId, response.responseMetadata().requestId(), parent.lastSuccessfulRequestDetails);
+            log.debug("{}: [SubscriptionLifetime]: (RecordFlow#responseReceived) @ {} id: {} -- Response received. RequestId - {}",
+                    parent.shardId, connectionStartedAt, subscribeToShardId, response.responseMetadata().requestId());
 
-            recordFlowLastSuccessfuRequestDetails = new RequestDetails(Optional.of(response.responseMetadata().requestId()), Optional.of(connectionStartedAt.toString()));
-            parent.setLastSuccessfulRequestDetails(this.recordFlowLastSuccessfuRequestDetails);
+            final RequestDetails requestDetails = new RequestDetails(response.responseMetadata().requestId(), connectionStartedAt.toString());
+            parent.setLastSuccessfulRequestDetails(requestDetails);
         }
 
         @Override

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/fanout/FanOutRecordsPublisher.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/fanout/FanOutRecordsPublisher.java
@@ -345,8 +345,7 @@ public class FanOutRecordsPublisher implements RecordsPublisher {
                 try {
                     handleFlowError(propagationThrowable, triggeringFlow);
                 } catch (Throwable innerThrowable) {
-                    log.warn("{}: Exception while calling subscriber.onError. Last successful request:" +
-                            "Last successful request details -- {}", shardId, innerThrowable, lastSuccessfulRequestDetails);
+                    log.warn("{}: Exception while calling subscriber.onError. Last successful request details -- {}", shardId, lastSuccessfulRequestDetails, innerThrowable);
                 }
                 subscriber = null;
                 flow = null;
@@ -805,7 +804,7 @@ public class FanOutRecordsPublisher implements RecordsPublisher {
                 log.warn(
                         "{}: Unable to enqueue the {} shutdown event due to capacity restrictions in delivery queue with remaining capacity {}. Ignoring. Last successful request details -- {}",
                         parent.shardId, subscriptionShutdownEvent.getEventIdentifier(), parent.recordsDeliveryQueue.remainingCapacity(),
-                        subscriptionShutdownEvent.getShutdownEventThrowableOptional(), parent.lastSuccessfulRequestDetails);
+                        parent.lastSuccessfulRequestDetails, subscriptionShutdownEvent.getShutdownEventThrowableOptional());
             }
         }
 

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/polling/BlockingRecordsPublisher.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/polling/BlockingRecordsPublisher.java
@@ -16,6 +16,7 @@
 package software.amazon.kinesis.retrieval.polling;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import org.reactivestreams.Subscriber;
@@ -23,6 +24,7 @@ import software.amazon.kinesis.annotations.KinesisClientInternalApi;
 import software.amazon.kinesis.common.InitialPositionInStreamExtended;
 
 import software.amazon.awssdk.services.kinesis.model.GetRecordsResponse;
+import software.amazon.kinesis.common.RequestDetails;
 import software.amazon.kinesis.lifecycle.events.ProcessRecordsInput;
 import software.amazon.kinesis.retrieval.GetRecordsRetrievalStrategy;
 import software.amazon.kinesis.retrieval.KinesisClientRecord;
@@ -35,7 +37,7 @@ import software.amazon.kinesis.retrieval.kpl.ExtendedSequenceNumber;
  * GetRecordsRetrievalStrategy class.
  */
 @KinesisClientInternalApi
-public class BlockingRecordsPublisher extends RecordsPublisher {
+public class BlockingRecordsPublisher implements RecordsPublisher {
     private final int maxRecordsPerCall;
     private final GetRecordsRetrievalStrategy getRecordsRetrievalStrategy;
 
@@ -68,6 +70,21 @@ public class BlockingRecordsPublisher extends RecordsPublisher {
     @Override
     public void shutdown() {
         getRecordsRetrievalStrategy.shutdown();
+    }
+
+    @Override
+    public Optional<RequestDetails> getLastSuccessfulResponseDetails() {
+        return Optional.empty();
+    }
+
+    @Override
+    public String getLastSuccessfulResponseRequestId() {
+        return NONE;
+    }
+
+    @Override
+    public String getLastSuccessfulResponseTimestamp() {
+        return NONE;
     }
 
     @Override

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/polling/BlockingRecordsPublisher.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/polling/BlockingRecordsPublisher.java
@@ -78,16 +78,6 @@ public class BlockingRecordsPublisher implements RecordsPublisher {
     }
 
     @Override
-    public String getLastSuccessfulResponseRequestId() {
-        return NONE;
-    }
-
-    @Override
-    public String getLastSuccessfulResponseTimestamp() {
-        return NONE;
-    }
-
-    @Override
     public void subscribe(Subscriber<? super RecordsRetrieved> s) {
         subscriber = s;
     }

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/polling/BlockingRecordsPublisher.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/polling/BlockingRecordsPublisher.java
@@ -42,7 +42,7 @@ public class BlockingRecordsPublisher implements RecordsPublisher {
     private final GetRecordsRetrievalStrategy getRecordsRetrievalStrategy;
 
     private Subscriber<? super RecordsRetrieved> subscriber;
-    private final RequestDetails lastSuccessfulResponseDetails = new RequestDetails();
+    private final RequestDetails lastSuccessfulRequestDetails = new RequestDetails();
 
     public BlockingRecordsPublisher(final int maxRecordsPerCall,
                                     final GetRecordsRetrievalStrategy getRecordsRetrievalStrategy) {
@@ -74,8 +74,8 @@ public class BlockingRecordsPublisher implements RecordsPublisher {
     }
 
     @Override
-    public RequestDetails getLastSuccessfulResponseDetails() {
-        return lastSuccessfulResponseDetails;
+    public RequestDetails getLastSuccessfulRequestDetails() {
+        return lastSuccessfulRequestDetails;
     }
 
     @Override

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/polling/BlockingRecordsPublisher.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/polling/BlockingRecordsPublisher.java
@@ -35,7 +35,7 @@ import software.amazon.kinesis.retrieval.kpl.ExtendedSequenceNumber;
  * GetRecordsRetrievalStrategy class.
  */
 @KinesisClientInternalApi
-public class BlockingRecordsPublisher implements RecordsPublisher {
+public class BlockingRecordsPublisher extends RecordsPublisher {
     private final int maxRecordsPerCall;
     private final GetRecordsRetrievalStrategy getRecordsRetrievalStrategy;
 

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/polling/BlockingRecordsPublisher.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/polling/BlockingRecordsPublisher.java
@@ -42,6 +42,7 @@ public class BlockingRecordsPublisher implements RecordsPublisher {
     private final GetRecordsRetrievalStrategy getRecordsRetrievalStrategy;
 
     private Subscriber<? super RecordsRetrieved> subscriber;
+    private final RequestDetails lastSuccessfulResponseDetails = new RequestDetails();
 
     public BlockingRecordsPublisher(final int maxRecordsPerCall,
                                     final GetRecordsRetrievalStrategy getRecordsRetrievalStrategy) {
@@ -73,8 +74,8 @@ public class BlockingRecordsPublisher implements RecordsPublisher {
     }
 
     @Override
-    public Optional<RequestDetails> getLastSuccessfulResponseDetails() {
-        return Optional.empty();
+    public RequestDetails getLastSuccessfulResponseDetails() {
+        return lastSuccessfulResponseDetails;
     }
 
     @Override

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/polling/PrefetchRecordsPublisher.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/polling/PrefetchRecordsPublisher.java
@@ -18,7 +18,6 @@ package software.amazon.kinesis.retrieval.polling;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.LinkedBlockingQueue;

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/polling/PrefetchRecordsPublisher.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/polling/PrefetchRecordsPublisher.java
@@ -264,7 +264,7 @@ public class PrefetchRecordsPublisher implements RecordsPublisher {
     }
 
     @Override
-    public RequestDetails getLastSuccessfulResponseDetails() {
+    public RequestDetails getLastSuccessfulRequestDetails() {
         return lastSuccessfulRequestDetails;
     }
 

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/polling/PrefetchRecordsPublisher.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/polling/PrefetchRecordsPublisher.java
@@ -100,6 +100,7 @@ public class PrefetchRecordsPublisher implements RecordsPublisher {
     private boolean wasReset = false;
 
     private Instant lastEventDeliveryTime = Instant.EPOCH;
+    private final RequestDetails lastSuccessfulRequestDetails = new RequestDetails();
 
     @Data
     @Accessors(fluent = true)
@@ -263,8 +264,8 @@ public class PrefetchRecordsPublisher implements RecordsPublisher {
     }
 
     @Override
-    public Optional<RequestDetails> getLastSuccessfulResponseDetails() {
-        return Optional.empty();
+    public RequestDetails getLastSuccessfulResponseDetails() {
+        return lastSuccessfulRequestDetails;
     }
 
     @Override

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/polling/PrefetchRecordsPublisher.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/polling/PrefetchRecordsPublisher.java
@@ -268,16 +268,6 @@ public class PrefetchRecordsPublisher implements RecordsPublisher {
     }
 
     @Override
-    public String getLastSuccessfulResponseRequestId() {
-        return NONE;
-    }
-
-    @Override
-    public String getLastSuccessfulResponseTimestamp() {
-        return NONE;
-    }
-
-    @Override
     public void restartFrom(RecordsRetrieved recordsRetrieved) {
         if (!(recordsRetrieved instanceof PrefetchRecordsRetrieved)) {
             throw new IllegalArgumentException(

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/polling/PrefetchRecordsPublisher.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/polling/PrefetchRecordsPublisher.java
@@ -18,6 +18,7 @@ package software.amazon.kinesis.retrieval.polling;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -46,6 +47,7 @@ import software.amazon.awssdk.services.kinesis.model.ExpiredIteratorException;
 import software.amazon.awssdk.services.kinesis.model.GetRecordsResponse;
 import software.amazon.kinesis.annotations.KinesisClientInternalApi;
 import software.amazon.kinesis.common.InitialPositionInStreamExtended;
+import software.amazon.kinesis.common.RequestDetails;
 import software.amazon.kinesis.lifecycle.events.ProcessRecordsInput;
 import software.amazon.kinesis.metrics.MetricsFactory;
 import software.amazon.kinesis.metrics.MetricsLevel;
@@ -76,7 +78,7 @@ import static software.amazon.kinesis.common.DiagnosticUtils.takeDelayedDelivery
  */
 @Slf4j
 @KinesisClientInternalApi
-public class PrefetchRecordsPublisher extends RecordsPublisher {
+public class PrefetchRecordsPublisher implements RecordsPublisher {
     private static final String EXPIRED_ITERATOR_METRIC = "ExpiredIterator";
     private int maxPendingProcessRecordsInput;
     private int maxByteSize;
@@ -258,6 +260,21 @@ public class PrefetchRecordsPublisher extends RecordsPublisher {
         defaultGetRecordsCacheDaemon.isShutdown = true;
         executorService.shutdownNow();
         started = false;
+    }
+
+    @Override
+    public Optional<RequestDetails> getLastSuccessfulResponseDetails() {
+        return Optional.empty();
+    }
+
+    @Override
+    public String getLastSuccessfulResponseRequestId() {
+        return NONE;
+    }
+
+    @Override
+    public String getLastSuccessfulResponseTimestamp() {
+        return NONE;
     }
 
     @Override

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/polling/PrefetchRecordsPublisher.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/polling/PrefetchRecordsPublisher.java
@@ -76,7 +76,7 @@ import static software.amazon.kinesis.common.DiagnosticUtils.takeDelayedDelivery
  */
 @Slf4j
 @KinesisClientInternalApi
-public class PrefetchRecordsPublisher implements RecordsPublisher {
+public class PrefetchRecordsPublisher extends RecordsPublisher {
     private static final String EXPIRED_ITERATOR_METRIC = "ExpiredIterator";
     private int maxPendingProcessRecordsInput;
     private int maxByteSize;

--- a/amazon-kinesis-client/src/test/java/software/amazon/kinesis/lifecycle/ShardConsumerSubscriberTest.java
+++ b/amazon-kinesis-client/src/test/java/software/amazon/kinesis/lifecycle/ShardConsumerSubscriberTest.java
@@ -35,6 +35,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -61,6 +62,7 @@ import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import software.amazon.kinesis.common.InitialPositionInStreamExtended;
+import software.amazon.kinesis.common.RequestDetails;
 import software.amazon.kinesis.leases.ShardInfo;
 import software.amazon.kinesis.lifecycle.events.ProcessRecordsInput;
 import software.amazon.kinesis.retrieval.KinesisClientRecord;
@@ -490,7 +492,7 @@ public class ShardConsumerSubscriberTest {
         }
     }
 
-    private class TestPublisher extends RecordsPublisher {
+    private class TestPublisher implements RecordsPublisher {
 
         private final LinkedList<ResponseItem> responses = new LinkedList<>();
         protected volatile long requested = 0;
@@ -554,6 +556,21 @@ public class ShardConsumerSubscriberTest {
         @Override
         public void shutdown() {
 
+        }
+
+        @Override
+        public Optional<RequestDetails> getLastSuccessfulResponseDetails() {
+            return Optional.empty();
+        }
+
+        @Override
+        public String getLastSuccessfulResponseRequestId() {
+            return NONE;
+        }
+
+        @Override
+        public String getLastSuccessfulResponseTimestamp() {
+            return NONE;
         }
 
         @Override

--- a/amazon-kinesis-client/src/test/java/software/amazon/kinesis/lifecycle/ShardConsumerSubscriberTest.java
+++ b/amazon-kinesis-client/src/test/java/software/amazon/kinesis/lifecycle/ShardConsumerSubscriberTest.java
@@ -564,16 +564,6 @@ public class ShardConsumerSubscriberTest {
         }
 
         @Override
-        public String getLastSuccessfulResponseRequestId() {
-            return NONE;
-        }
-
-        @Override
-        public String getLastSuccessfulResponseTimestamp() {
-            return NONE;
-        }
-
-        @Override
         public void subscribe(Subscriber<? super RecordsRetrieved> s) {
             subscriber = s;
             s.onSubscribe(new Subscription() {

--- a/amazon-kinesis-client/src/test/java/software/amazon/kinesis/lifecycle/ShardConsumerSubscriberTest.java
+++ b/amazon-kinesis-client/src/test/java/software/amazon/kinesis/lifecycle/ShardConsumerSubscriberTest.java
@@ -490,7 +490,7 @@ public class ShardConsumerSubscriberTest {
         }
     }
 
-    private class TestPublisher implements RecordsPublisher {
+    private class TestPublisher extends RecordsPublisher {
 
         private final LinkedList<ResponseItem> responses = new LinkedList<>();
         protected volatile long requested = 0;

--- a/amazon-kinesis-client/src/test/java/software/amazon/kinesis/lifecycle/ShardConsumerSubscriberTest.java
+++ b/amazon-kinesis-client/src/test/java/software/amazon/kinesis/lifecycle/ShardConsumerSubscriberTest.java
@@ -561,7 +561,7 @@ public class ShardConsumerSubscriberTest {
         }
 
         @Override
-        public RequestDetails getLastSuccessfulResponseDetails() {
+        public RequestDetails getLastSuccessfulRequestDetails() {
             return lastSuccessfulRequestDetails;
         }
 

--- a/amazon-kinesis-client/src/test/java/software/amazon/kinesis/lifecycle/ShardConsumerSubscriberTest.java
+++ b/amazon-kinesis-client/src/test/java/software/amazon/kinesis/lifecycle/ShardConsumerSubscriberTest.java
@@ -79,6 +79,8 @@ public class ShardConsumerSubscriberTest {
 
     private static final String TERMINAL_MARKER = "Terminal";
 
+    private final RequestDetails lastSuccessfulRequestDetails = new RequestDetails();
+
     @Mock
     private ShardConsumer shardConsumer;
     @Mock
@@ -559,8 +561,8 @@ public class ShardConsumerSubscriberTest {
         }
 
         @Override
-        public Optional<RequestDetails> getLastSuccessfulResponseDetails() {
-            return Optional.empty();
+        public RequestDetails getLastSuccessfulResponseDetails() {
+            return lastSuccessfulRequestDetails;
         }
 
         @Override

--- a/amazon-kinesis-client/src/test/java/software/amazon/kinesis/lifecycle/ShardConsumerTest.java
+++ b/amazon-kinesis-client/src/test/java/software/amazon/kinesis/lifecycle/ShardConsumerTest.java
@@ -216,16 +216,6 @@ public class ShardConsumerTest {
         }
 
         @Override
-        public String getLastSuccessfulResponseRequestId() {
-            return NONE;
-        }
-
-        @Override
-        public String getLastSuccessfulResponseTimestamp() {
-            return NONE;
-        }
-
-        @Override
         public void subscribe(Subscriber<? super RecordsRetrieved> s) {
             subscriber = s;
             subscriber.onSubscribe(subscription);

--- a/amazon-kinesis-client/src/test/java/software/amazon/kinesis/lifecycle/ShardConsumerTest.java
+++ b/amazon-kinesis-client/src/test/java/software/amazon/kinesis/lifecycle/ShardConsumerTest.java
@@ -70,6 +70,7 @@ import com.google.common.util.concurrent.ThreadFactoryBuilder;
 
 import lombok.extern.slf4j.Slf4j;
 import software.amazon.kinesis.common.InitialPositionInStreamExtended;
+import software.amazon.kinesis.common.RequestDetails;
 import software.amazon.kinesis.leases.ShardInfo;
 import software.amazon.kinesis.lifecycle.events.ProcessRecordsInput;
 import software.amazon.kinesis.lifecycle.events.TaskExecutionListenerInput;
@@ -168,7 +169,7 @@ public class ShardConsumerTest {
         assertThat(remainder.isEmpty(), equalTo(true));
     }
 
-    private class TestPublisher extends RecordsPublisher {
+    private class TestPublisher implements RecordsPublisher {
 
         final CyclicBarrier barrier = new CyclicBarrier(2);
         final CyclicBarrier requestBarrier = new CyclicBarrier(2);
@@ -207,6 +208,21 @@ public class ShardConsumerTest {
         @Override
         public void shutdown() {
 
+        }
+
+        @Override
+        public Optional<RequestDetails> getLastSuccessfulResponseDetails() {
+            return Optional.empty();
+        }
+
+        @Override
+        public String getLastSuccessfulResponseRequestId() {
+            return NONE;
+        }
+
+        @Override
+        public String getLastSuccessfulResponseTimestamp() {
+            return NONE;
         }
 
         @Override

--- a/amazon-kinesis-client/src/test/java/software/amazon/kinesis/lifecycle/ShardConsumerTest.java
+++ b/amazon-kinesis-client/src/test/java/software/amazon/kinesis/lifecycle/ShardConsumerTest.java
@@ -168,7 +168,7 @@ public class ShardConsumerTest {
         assertThat(remainder.isEmpty(), equalTo(true));
     }
 
-    private class TestPublisher implements RecordsPublisher {
+    private class TestPublisher extends RecordsPublisher {
 
         final CyclicBarrier barrier = new CyclicBarrier(2);
         final CyclicBarrier requestBarrier = new CyclicBarrier(2);

--- a/amazon-kinesis-client/src/test/java/software/amazon/kinesis/lifecycle/ShardConsumerTest.java
+++ b/amazon-kinesis-client/src/test/java/software/amazon/kinesis/lifecycle/ShardConsumerTest.java
@@ -89,6 +89,7 @@ public class ShardConsumerTest {
 
     private final String shardId = "shardId-0-0";
     private final String concurrencyToken = "TestToken";
+    private final RequestDetails lastSuccessfulRequestDetails = new RequestDetails();
     private ShardInfo shardInfo;
     private TaskExecutionListenerInput initialTaskInput;
     private TaskExecutionListenerInput processTaskInput;
@@ -211,8 +212,8 @@ public class ShardConsumerTest {
         }
 
         @Override
-        public Optional<RequestDetails> getLastSuccessfulResponseDetails() {
-            return Optional.empty();
+        public RequestDetails getLastSuccessfulResponseDetails() {
+            return lastSuccessfulRequestDetails;
         }
 
         @Override

--- a/amazon-kinesis-client/src/test/java/software/amazon/kinesis/lifecycle/ShardConsumerTest.java
+++ b/amazon-kinesis-client/src/test/java/software/amazon/kinesis/lifecycle/ShardConsumerTest.java
@@ -212,7 +212,7 @@ public class ShardConsumerTest {
         }
 
         @Override
-        public RequestDetails getLastSuccessfulResponseDetails() {
+        public RequestDetails getLastSuccessfulRequestDetails() {
             return lastSuccessfulRequestDetails;
         }
 

--- a/amazon-kinesis-client/src/test/java/software/amazon/kinesis/retrieval/polling/PrefetchRecordsPublisherTest.java
+++ b/amazon-kinesis-client/src/test/java/software/amazon/kinesis/retrieval/polling/PrefetchRecordsPublisherTest.java
@@ -54,7 +54,6 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
-import com.google.common.annotations.VisibleForTesting;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.After;
 import org.junit.Before;
@@ -76,6 +75,7 @@ import software.amazon.awssdk.services.kinesis.model.ExpiredIteratorException;
 import software.amazon.awssdk.services.kinesis.model.GetRecordsResponse;
 import software.amazon.awssdk.services.kinesis.model.Record;
 import software.amazon.kinesis.common.InitialPositionInStreamExtended;
+import software.amazon.kinesis.common.RequestDetails;
 import software.amazon.kinesis.lifecycle.ShardConsumerNotifyingSubscriber;
 import software.amazon.kinesis.lifecycle.events.ProcessRecordsInput;
 import software.amazon.kinesis.metrics.NullMetricsFactory;
@@ -115,6 +115,7 @@ public class PrefetchRecordsPublisherTest {
     private String operation = "ProcessTask";
     private GetRecordsResponse getRecordsResponse;
     private Record record;
+    private RequestDetails requestDetails;
 
     @Before
     public void setup() {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Adding Request ID logging to aid in SubscribeToShard debugging.

Testing:
```
2020-02-14 12:15:07,732 [KinesisTester-0000] ERROR s.a.k.l.ShardConsumerSubscriber [NONE] - shardId-000000000006: Last request was dispatched at 2020-02-14T20:14:07.616Z, but no response as of 2020-02-14T20:15:07.732Z (PT1M0.116S).  Cancelling subscription, and restarting. Last successful request details: request id - d052b922-6a8a-a098-8693-b8bc4f4decec, timestamp - 2020-02-14T20:13:18.537Z 
```
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
