### PR TITLE
Stop passing latest shards to the next ShardSyncTask in ShardSyncTask…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <artifactId>amazon-kinesis-client</artifactId>
   <packaging>jar</packaging>
   <name>Amazon Kinesis Client Library for Java</name>
-  <version>1.13.2</version>
+  <version>1.13.3-SNAPSHOT</version>
   <description>The Amazon Kinesis Client Library for Java enables Java developers to easily consume and process data
     from Amazon Kinesis.
   </description>
@@ -25,7 +25,7 @@
   </licenses>
 
   <properties>
-    <aws-java-sdk.version>1.11.655</aws-java-sdk.version>
+    <aws-java-sdk.version>1.11.728</aws-java-sdk.version>
     <sqlite4java.version>1.0.392</sqlite4java.version>
     <sqlite4java.native>libsqlite4java</sqlite4java.native>
     <sqlite4java.libpath>${project.build.directory}/test-lib</sqlite4java.libpath>

--- a/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardSyncTaskManagerTest.java
+++ b/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardSyncTaskManagerTest.java
@@ -23,6 +23,8 @@ import java.util.concurrent.Executors;
 
 import static org.mockito.AdditionalAnswers.delegatesTo;
 import static org.mockito.Matchers.anyBoolean;
+import static org.mockito.Matchers.matches;
+import static org.mockito.Matchers.notNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -91,10 +93,14 @@ public class ShardSyncTaskManagerTest {
         pausableNoOpShardSyncer.blockShardSyncLatch.countDown();
         // Wait for ShardSyncer to be initialized.
         pausableNoOpShardSyncer.waitForShardSyncerInitializationLatch.await();
-        // There should be 1 more shardSyncer invocation after the previous shardSync completes.
-        verify(mockShardSyncer, times(2))
+        // There should be totally 2 invocation of shardSyncer. The first one should be triggered with an empty list the latestShards.
+        // The second invocation should be the pending shard sync task, which should have null as the latestShards.
+        verify(mockShardSyncer, times(1))
                 .checkAndCreateLeasesForNewShards(Matchers.any(), Matchers.any(), Matchers.any(), anyBoolean(),
-                        anyBoolean(), Matchers.any());
+                        anyBoolean(), Matchers.eq(new ArrayList<>()));
+        verify(mockShardSyncer, times(1))
+                .checkAndCreateLeasesForNewShards(Matchers.any(), Matchers.any(), Matchers.any(), anyBoolean(),
+                        anyBoolean(), Matchers.eq(null));
     }
 
     private static class PausableNoOpShardSyncer implements ShardSyncer {


### PR DESCRIPTION

*Issue #, if available:*

*Description of changes:*

Currently KCL 1.x is having issue picking up new shards after resharding. This is due to a bug in ShardSyncTaskManager that we are passing the latestShards to the next pending ShardSyncTask. Fixing the issue by always passing null to the next ShardSyncTask.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
