### PR TITLE
Adjusting H2 initial window size to 512 KB

### DIFF
--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/common/KinesisClientUtil.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/common/KinesisClientUtil.java
@@ -28,7 +28,7 @@ import java.time.Duration;
  */
 public class KinesisClientUtil {
 
-    private static int INITIAL_WINDOW_SIZE_BYTES = 10 * 1024 * 1024;
+    private static int INITIAL_WINDOW_SIZE_BYTES = 512 * 1024; // 512 KB
     private static long HEALTH_CHECK_PING_PERIOD_MILLIS = 60 * 1000;
 
     /**


### PR DESCRIPTION
Testing results: https://sim.amazon.com/issues/Streamy-3319

This should significantly reduce memory pressure on hosts running a high number of subscriptions without affecting throughput.
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
