### PR TITLE
Also consider TableStatus.UPDATING status

### DIFF
--- a/src/main/java/com/amazonaws/services/kinesis/leases/impl/LeaseManager.java
+++ b/src/main/java/com/amazonaws/services/kinesis/leases/impl/LeaseManager.java
@@ -162,7 +162,8 @@ public class LeaseManager<T extends Lease> implements ILeaseManager<T> {
      */
     @Override
     public boolean leaseTableExists() throws DependencyException {
-        return TableStatus.ACTIVE == tableStatus();
+        TableStatus tableStatus = tableStatus();
+        return TableStatus.ACTIVE == tableStatus || TableStatus.UPDATING == tableStatus;
     }
 
     private TableStatus tableStatus() throws DependencyException {

--- a/src/test/java/com/amazonaws/services/kinesis/leases/impl/LeaseManagerIntegrationTest.java
+++ b/src/test/java/com/amazonaws/services/kinesis/leases/impl/LeaseManagerIntegrationTest.java
@@ -265,6 +265,29 @@ public class LeaseManagerIntegrationTest extends LeaseIntegrationTest {
     }
 
     @Test
+    public void testWaitUntilLeaseTableExistsUpdatingStatus() throws LeasingException {
+        AmazonDynamoDBClient ddbMock = Mockito.mock(ddbClient.getClass());
+        DescribeTableResult result = Mockito.mock(DescribeTableResult.class);
+        TableDescription description = Mockito.mock(TableDescription.class);
+        Mockito.when(description.getTableStatus()).thenReturn(TableStatus.UPDATING.name());
+        Mockito.when(result.getTable()).thenReturn(description);
+        Mockito.when(ddbMock.describeTable(Mockito.any(DescribeTableRequest.class))).thenReturn(result);
+        KinesisClientLeaseManager manager = new KinesisClientLeaseManager("existing_table", ddbMock, true,
+                KinesisClientLibConfiguration.DEFAULT_DDB_BILLING_MODE) {
+
+            @Override
+            long sleep(long timeToSleepMillis) {
+                Assert.fail("Should not sleep");
+                return 0L;
+            }
+
+        };
+
+
+        Assert.assertTrue(manager.waitUntilLeaseTableExists(1, 1));
+    }
+
+    @Test
     public void testWaitUntilLeaseTableExistsPayPerRequest() throws LeasingException {
         AmazonDynamoDBClient ddbMock = Mockito.mock(ddbClient.getClass());
         DescribeTableResult result = Mockito.mock(DescribeTableResult.class);


### PR DESCRIPTION
*Description of changes:*
Based on: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/WorkingWithTables.Basics.html#WorkingWithTables.Basics.UpdateTable

```
When you issue an UpdateTable request, the status of the table changes from AVAILABLE to UPDATING. The table remains fully available for use while it is UPDATING. When this process is completed, the table status changes from UPDATING to AVAILABLE.
```

If we are updating a table's IOPS or billing mode, the UPDATING status can remain few minutes to one hour. This prevents KCL thread from starting. However based on DDB documentation, it is still functioning during UPDATING process, so KCL thread should be able to continue in this situation.

`mvn clean install -DskipITs` passed.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
