### PR TITLE
Throttle error messages when Kinesis provisioned throughput exceeded

### DIFF
--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/lifecycle/ConsumerStates.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/lifecycle/ConsumerStates.java
@@ -258,14 +258,12 @@ class ConsumerStates {
 
         @Override
         public ConsumerTask createTask(ShardConsumerArgument argument, ShardConsumer consumer, ProcessRecordsInput input) {
-            ThrottlingReporter throttlingReporter = new ThrottlingReporter(5, argument.shardInfo().shardId());
             return new ProcessTask(argument.shardInfo(),
                     argument.shardRecordProcessor(),
                     argument.recordProcessorCheckpointer(),
                     argument.taskBackoffTimeMillis(),
                     argument.skipShardSyncAtWorkerInitializationIfLeasesExist(),
                     argument.shardDetector(),
-                    throttlingReporter,
                     input,
                     argument.shouldCallProcessRecordsEvenForEmptyRecordList(),
                     argument.idleTimeInMilliseconds(),

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/lifecycle/ProcessTask.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/lifecycle/ProcessTask.java
@@ -54,7 +54,6 @@ public class ProcessTask implements ConsumerTask {
     private final TaskType taskType = TaskType.PROCESS;
     private final long backoffTimeMillis;
     private final Shard shard;
-    private final ThrottlingReporter throttlingReporter;
     private final boolean shouldCallProcessRecordsEvenForEmptyRecordList;
     private final long idleTimeInMilliseconds;
     private final ProcessRecordsInput processRecordsInput;
@@ -67,7 +66,6 @@ public class ProcessTask implements ConsumerTask {
                        long backoffTimeMillis,
                        boolean skipShardSyncAtWorkerInitializationIfLeasesExist,
                        ShardDetector shardDetector,
-                       @NonNull ThrottlingReporter throttlingReporter,
                        ProcessRecordsInput processRecordsInput,
                        boolean shouldCallProcessRecordsEvenForEmptyRecordList,
                        long idleTimeInMilliseconds,
@@ -77,7 +75,6 @@ public class ProcessTask implements ConsumerTask {
         this.shardRecordProcessor = shardRecordProcessor;
         this.recordProcessorCheckpointer = recordProcessorCheckpointer;
         this.backoffTimeMillis = backoffTimeMillis;
-        this.throttlingReporter = throttlingReporter;
         this.processRecordsInput = processRecordsInput;
         this.shouldCallProcessRecordsEvenForEmptyRecordList = shouldCallProcessRecordsEvenForEmptyRecordList;
         this.idleTimeInMilliseconds = idleTimeInMilliseconds;
@@ -125,7 +122,6 @@ public class ProcessTask implements ConsumerTask {
                     return new TaskResult(null, true);
                 }
 
-                throttlingReporter.success();
                 List<KinesisClientRecord> records = deaggregateAnyKplRecords(processRecordsInput.records());
 
 

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/polling/SimpleRecordsFetcherFactory.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/polling/SimpleRecordsFetcherFactory.java
@@ -25,6 +25,7 @@ import software.amazon.kinesis.retrieval.DataFetchingStrategy;
 import software.amazon.kinesis.retrieval.GetRecordsRetrievalStrategy;
 import software.amazon.kinesis.retrieval.RecordsFetcherFactory;
 import software.amazon.kinesis.retrieval.RecordsPublisher;
+import software.amazon.kinesis.retrieval.ThrottlingReporter;
 
 @Slf4j
 @KinesisClientInternalApi
@@ -45,7 +46,8 @@ public class SimpleRecordsFetcherFactory implements RecordsFetcherFactory {
                         .newFixedThreadPool(1,
                                 new ThreadFactoryBuilder().setDaemon(true)
                                         .setNameFormat("prefetch-cache-" + shardId + "-%04d").build()),
-                idleMillisBetweenCalls, metricsFactory, "ProcessTask", shardId);
+                idleMillisBetweenCalls, metricsFactory, "ProcessTask", shardId,
+                new ThrottlingReporter(5, shardId));
 
     }
 

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/polling/SynchronousPrefetchingRetrievalFactory.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/polling/SynchronousPrefetchingRetrievalFactory.java
@@ -27,6 +27,7 @@ import software.amazon.kinesis.retrieval.GetRecordsRetrievalStrategy;
 import software.amazon.kinesis.retrieval.RecordsFetcherFactory;
 import software.amazon.kinesis.retrieval.RecordsPublisher;
 import software.amazon.kinesis.retrieval.RetrievalFactory;
+import software.amazon.kinesis.retrieval.ThrottlingReporter;
 
 /**
  *
@@ -78,6 +79,7 @@ public class SynchronousPrefetchingRetrievalFactory implements RetrievalFactory 
         return new PrefetchRecordsPublisher(recordsFetcherFactory.maxPendingProcessRecordsInput(),
                 recordsFetcherFactory.maxByteSize(), recordsFetcherFactory.maxRecordsCount(), maxRecords,
                 createGetRecordsRetrievalStrategy(shardInfo, metricsFactory), executorService, idleMillisBetweenCalls,
-                metricsFactory, "Prefetching", shardInfo.shardId());
+                metricsFactory, "Prefetching", shardInfo.shardId(),
+                new ThrottlingReporter(5, shardInfo.shardId()));
     }
 }

--- a/amazon-kinesis-client/src/test/java/software/amazon/kinesis/lifecycle/ProcessTaskTest.java
+++ b/amazon-kinesis-client/src/test/java/software/amazon/kinesis/lifecycle/ProcessTaskTest.java
@@ -99,8 +99,6 @@ public class ProcessTaskTest {
     private ShardRecordProcessor shardRecordProcessor;
     @Mock
     private ShardRecordProcessorCheckpointer checkpointer;
-    @Mock
-    private ThrottlingReporter throttlingReporter;
 
     private ProcessTask processTask;
 
@@ -120,8 +118,8 @@ public class ProcessTaskTest {
     private ProcessTask makeProcessTask(ProcessRecordsInput processRecordsInput, AggregatorUtil aggregatorUtil,
             boolean skipShardSync) {
         return new ProcessTask(shardInfo, shardRecordProcessor, checkpointer, taskBackoffTimeMillis,
-                skipShardSync, shardDetector, throttlingReporter,
-                processRecordsInput, shouldCallProcessRecordsEvenForEmptyRecordList, IDLE_TIME_IN_MILLISECONDS,
+                skipShardSync, shardDetector, processRecordsInput,
+                shouldCallProcessRecordsEvenForEmptyRecordList, IDLE_TIME_IN_MILLISECONDS,
                 aggregatorUtil, new NullMetricsFactory());
     }
 
@@ -498,8 +496,6 @@ public class ProcessTaskTest {
         when(checkpointer.lastCheckpointValue()).thenReturn(lastCheckpointValue);
         when(checkpointer.largestPermittedCheckpointValue()).thenReturn(largestPermittedCheckpointValue);
         processTask.call();
-        verify(throttlingReporter).success();
-        verify(throttlingReporter, never()).throttled();
         ArgumentCaptor<ProcessRecordsInput> recordsCaptor = ArgumentCaptor.forClass(ProcessRecordsInput.class);
         verify(shardRecordProcessor).processRecords(recordsCaptor.capture());
 

--- a/amazon-kinesis-client/src/test/java/software/amazon/kinesis/retrieval/polling/PrefetchRecordsPublisherIntegrationTest.java
+++ b/amazon-kinesis-client/src/test/java/software/amazon/kinesis/retrieval/polling/PrefetchRecordsPublisherIntegrationTest.java
@@ -63,6 +63,7 @@ import software.amazon.kinesis.metrics.NullMetricsFactory;
 import software.amazon.kinesis.retrieval.DataFetcherResult;
 import software.amazon.kinesis.retrieval.GetRecordsRetrievalStrategy;
 import software.amazon.kinesis.retrieval.RecordsRetrieved;
+import software.amazon.kinesis.retrieval.ThrottlingReporter;
 import software.amazon.kinesis.retrieval.kpl.ExtendedSequenceNumber;
 
 /**
@@ -115,7 +116,8 @@ public class PrefetchRecordsPublisherIntegrationTest {
                 IDLE_MILLIS_BETWEEN_CALLS,
                 new NullMetricsFactory(),
                 operation,
-                "test-shard");
+                "test-shard",
+                new ThrottlingReporter(5, "test-shard"));
     }
 
     @Test
@@ -168,7 +170,8 @@ public class PrefetchRecordsPublisherIntegrationTest {
                 IDLE_MILLIS_BETWEEN_CALLS,
                 new NullMetricsFactory(),
                 operation,
-                "test-shard-2");
+                "test-shard-2",
+                new ThrottlingReporter(5, "test-shard-2"));
 
         getRecordsCache.start(extendedSequenceNumber, initialPosition);
         sleep(IDLE_MILLIS_BETWEEN_CALLS);


### PR DESCRIPTION
*Issue #, if available:* https://github.com/awslabs/amazon-kinesis-client/issues/539

*Description of changes:*

The PR adds special logging for `ProvisionedThroughputExceededException` cases in `PrefetchRecordsPublisher` instead of using a default SdkException error message with stacktrace.
This way the behaviour will be the same as in latest versions of 1.X
I reused the existing `ThrottlingReporter` class for this purpose. 
As a related cleanup `ThrottlingReporter` was removed from `ProcessTask` as not really used

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
