### PR TITLE
DDB is considered healthy in UPDATING status

### DIFF
--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/leases/dynamodb/DynamoDBLeaseRefresher.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/leases/dynamodb/DynamoDBLeaseRefresher.java
@@ -190,7 +190,8 @@ public class DynamoDBLeaseRefresher implements LeaseRefresher {
      */
     @Override
     public boolean leaseTableExists() throws DependencyException {
-        return TableStatus.ACTIVE == tableStatus();
+        TableStatus tableStatus = tableStatus();
+        return TableStatus.ACTIVE == tableStatus || TableStatus.UPDATING == tableStatus;
     }
 
     private TableStatus tableStatus() throws DependencyException {


### PR DESCRIPTION

*Description of changes:*
Based on: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/WorkingWithTables.Basics.html#WorkingWithTables.Basics.UpdateTable

```
When you issue an UpdateTable request, the status of the table changes from AVAILABLE to UPDATING. The table remains fully available for use while it is UPDATING. When this process is completed, the table status changes from UPDATING to AVAILABLE.
```

If we are updating a table's IOPS or billing mode, the UPDATING status can remain few minutes to one hour. This prevents KCL thread from starting. However based on DDB documentation, it is still functioning during UPDATING process, so KCL thread should be able to continue in this situation.

`mvn clean install -DskipITs` passed.

**Note** : This change is the same as the pull request in `v1.x` branch: https://github.com/awslabs/amazon-kinesis-client/pull/712

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.





By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
