### PR TITLE
adding support for web identity token in multilang

### DIFF
--- a/amazon-kinesis-client-multilang/pom.xml
+++ b/amazon-kinesis-client-multilang/pom.xml
@@ -28,7 +28,7 @@
   <artifactId>amazon-kinesis-client-multilang</artifactId>
 
   <properties>
-    <aws-java-sdk.version>1.11.477</aws-java-sdk.version>
+    <aws-java-sdk.version>1.11.908</aws-java-sdk.version>
   </properties>
 
   <dependencies>
@@ -61,6 +61,12 @@
           <artifactId>httpclient</artifactId>
         </exclusion>
       </exclusions>
+    </dependency>
+
+    <dependency>
+        <groupId>com.amazonaws</groupId>
+        <artifactId>aws-java-sdk-sts</artifactId>
+        <version>${aws-java-sdk.version}</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
*Issue #, if available:* #761 

*Description of changes:*
- Updates to latest AWS Java SDK for web identity token support (see [documentation](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts-minimum-sdk.html))
- Adds `aws-java-sdk-sts` as a dependency, needed by `WebIdentityTokenCredentialsProvider` to assume role and provide credentials (see [WebIdentityTokenCredentialsProvider](https://github.com/aws/aws-sdk-java/blob/master/aws-java-sdk-core/src/main/java/com/amazonaws/auth/WebIdentityTokenCredentialsProvider.java#L58) and [STSProfileCredentialsServiceProvider](https://github.com/aws/aws-sdk-java/blob/master/aws-java-sdk-core/src/main/java/com/amazonaws/auth/profile/internal/securitytoken/STSProfileCredentialsServiceProvider.java#L56-L58))

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
