### PR TITLE
#328 Add support to pass worker process loop exceptions back to the c…

### DIFF
--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/WorkerProcessLoopExceptionListener.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/WorkerProcessLoopExceptionListener.java
@@ -1,0 +1,15 @@
+package com.amazonaws.services.kinesis.clientlibrary.lib.worker;
+
+/**
+ * A listener for when the worker processing loop encounters an unexpected exception
+ * so the client caller can inspect the error that occurred and take action.
+ */
+public interface WorkerProcessLoopExceptionListener {
+
+    /**
+     * Listeners implement this method and can read the exception to take the appropriate action.
+     *
+     * @param e the exception that occurred
+     */
+    void exceptionOccured(Exception e);
+}


### PR DESCRIPTION
Add support to pass worker process loop exceptions back to the client to enable error handling if required.

*Issue #328*

*Description of changes: To enable the exception caught and ignored in the worker process loop to be sent back to the caller in event the calling code wishes to handle it, for example deal with Java OutOfMemory exceptions.*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
