### PR TITLE
Move throwable exception handling up a level to prevent daemon thread death

### DIFF
--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/polling/PrefetchRecordsPublisher.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/polling/PrefetchRecordsPublisher.java
@@ -414,11 +414,14 @@ public class PrefetchRecordsPublisher implements RecordsPublisher {
                     makeRetrievalAttempt();
                 } catch(PositionResetException pre) {
                     log.debug("{} : Position was reset while attempting to add item to queue.", streamAndShardId);
+                } catch (Throwable e) {
+                    log.error("{} :  Unexpected exception was thrown. This could probably be an issue or a bug." +
+                            " Please search for the exception/error online to check what is going on. If the " +
+                            "issue persists or is a recurring problem, feel free to open an issue on, " +
+                            "https://github.com/awslabs/amazon-kinesis-client.", streamAndShardId, e);
                 } finally {
                     resetLock.readLock().unlock();
                 }
-
-
             }
             callShutdownOnStrategy();
         }
@@ -469,11 +472,6 @@ public class PrefetchRecordsPublisher implements RecordsPublisher {
                     log.error("{} :  Exception thrown while fetching records from Kinesis", streamAndShardId, e);
                 } catch (SdkException e) {
                     log.error("{} :  Exception thrown while fetching records from Kinesis", streamAndShardId, e);
-                } catch (Throwable e) {
-                    log.error("{} :  Unexpected exception was thrown. This could probably be an issue or a bug." +
-                            " Please search for the exception/error online to check what is going on. If the " +
-                            "issue persists or is a recurring problem, feel free to open an issue on, " +
-                            "https://github.com/awslabs/amazon-kinesis-client.", streamAndShardId, e);
                 } finally {
                     MetricsUtil.endScope(scope);
                 }


### PR DESCRIPTION
### Issue

Going into the `ExpiredShardIterator` code block under `makeRetrievalAttempt`  exposes a restartIterator call that doesn't have proper exception handling. If restartIterator throws an exception, the daemon thread for GetRecords dies and no progress is ever made afterwards until the application restarts.

### Description of changes
Moves throwable exception handling up a layer to prevent daemon thread death

-------------
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
