### PR TITLE
KCL 1.X - Guardrails to avoid checkpoint corruption during resharding

### DIFF
--- a/src/main/java/com/amazonaws/services/kinesis/leases/impl/KinesisClientLeaseSerializer.java
+++ b/src/main/java/com/amazonaws/services/kinesis/leases/impl/KinesisClientLeaseSerializer.java
@@ -22,6 +22,7 @@ import com.amazonaws.services.dynamodbv2.model.AttributeAction;
 import com.amazonaws.services.dynamodbv2.model.AttributeDefinition;
 import com.amazonaws.services.dynamodbv2.model.AttributeValue;
 import com.amazonaws.services.dynamodbv2.model.AttributeValueUpdate;
+import com.amazonaws.services.dynamodbv2.model.ComparisonOperator;
 import com.amazonaws.services.dynamodbv2.model.ExpectedAttributeValue;
 import com.amazonaws.services.dynamodbv2.model.KeySchemaElement;
 import com.amazonaws.services.kinesis.clientlibrary.types.ExtendedSequenceNumber;
@@ -124,6 +125,19 @@ public class KinesisClientLeaseSerializer implements ILeaseSerializer<KinesisCli
     @Override
     public Map<String, ExpectedAttributeValue> getDynamoLeaseOwnerExpectation(KinesisClientLease lease) {
         return baseSerializer.getDynamoLeaseOwnerExpectation(lease);
+    }
+
+    @Override
+    public Map<String, ExpectedAttributeValue> getDynamoLeaseCheckpointExpectation(KinesisClientLease lease) {
+        Map<String, ExpectedAttributeValue> result = baseSerializer.getDynamoLeaseCheckpointExpectation(lease);
+        ExpectedAttributeValue eav;
+
+        if (!lease.getCheckpoint().equals(ExtendedSequenceNumber.SHARD_END)) {
+            eav = new ExpectedAttributeValue(DynamoUtils.createAttributeValue(ExtendedSequenceNumber.SHARD_END.getSequenceNumber()));
+            eav.setComparisonOperator(ComparisonOperator.NE);
+            result.put(CHECKPOINT_SEQUENCE_NUMBER_KEY, eav);
+        }
+        return result;
     }
 
     @Override

--- a/src/main/java/com/amazonaws/services/kinesis/leases/impl/LeaseCleanupManager.java
+++ b/src/main/java/com/amazonaws/services/kinesis/leases/impl/LeaseCleanupManager.java
@@ -218,6 +218,8 @@ public class LeaseCleanupManager {
                     LOG.info("Lease not present in lease table while cleaning the shard " + shardInfo.getShardId());
                     cleanedUpCompletedLease = true;
                 }
+            } else {
+                cleanupFailureReason = "Configuration/Interval condition not satisfied to execute lease cleanup this cycle";
             }
             if (!cleanedUpCompletedLease && !alreadyCheckedForGarbageCollection && timeToCheckForGarbageShard) {
                 // throws ResourceNotFoundException

--- a/src/main/java/com/amazonaws/services/kinesis/leases/impl/LeaseManager.java
+++ b/src/main/java/com/amazonaws/services/kinesis/leases/impl/LeaseManager.java
@@ -20,6 +20,7 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import com.amazonaws.services.dynamodbv2.model.BillingMode;
+import com.amazonaws.services.dynamodbv2.model.ExpectedAttributeValue;
 import com.amazonaws.services.kinesis.clientlibrary.lib.worker.KinesisClientLibConfiguration;
 import com.amazonaws.services.kinesis.leases.util.DynamoUtils;
 import org.apache.commons.logging.Log;
@@ -582,7 +583,9 @@ public class LeaseManager<T extends Lease> implements ILeaseManager<T> {
         UpdateItemRequest request = new UpdateItemRequest();
         request.setTableName(table);
         request.setKey(serializer.getDynamoHashKey(lease));
-        request.setExpected(serializer.getDynamoLeaseCounterExpectation(lease));
+        Map<String, ExpectedAttributeValue> expectations = serializer.getDynamoLeaseCounterExpectation(lease);
+        expectations.putAll(serializer.getDynamoLeaseCheckpointExpectation(lease));
+        request.setExpected(expectations);
 
         Map<String, AttributeValueUpdate> updates = serializer.getDynamoLeaseCounterUpdate(lease);
         updates.putAll(serializer.getDynamoUpdateLeaseUpdate(lease));

--- a/src/main/java/com/amazonaws/services/kinesis/leases/impl/LeaseSerializer.java
+++ b/src/main/java/com/amazonaws/services/kinesis/leases/impl/LeaseSerializer.java
@@ -128,6 +128,11 @@ public class LeaseSerializer implements ILeaseSerializer<Lease> {
     }
 
     @Override
+    public Map<String, ExpectedAttributeValue> getDynamoLeaseCheckpointExpectation(final Lease lease) {
+        return new HashMap<>();
+    }
+
+    @Override
     public Map<String, ExpectedAttributeValue> getDynamoNonexistantExpectation() {
         Map<String, ExpectedAttributeValue> result = new HashMap<String, ExpectedAttributeValue>();
 

--- a/src/main/java/com/amazonaws/services/kinesis/leases/interfaces/ILeaseSerializer.java
+++ b/src/main/java/com/amazonaws/services/kinesis/leases/interfaces/ILeaseSerializer.java
@@ -75,6 +75,14 @@ public interface ILeaseSerializer<T extends Lease> {
     public Map<String, ExpectedAttributeValue> getDynamoLeaseOwnerExpectation(T lease);
 
     /**
+     * @param lease
+     * @return the attribute value map asserting that the checkpoint state is as expected.
+     */
+    default Map<String, ExpectedAttributeValue> getDynamoLeaseCheckpointExpectation(T lease) {
+        throw new UnsupportedOperationException("DynamoLeaseCheckpointExpectation is not implemented");
+    }
+
+    /**
      * @return the attribute value map asserting that a lease does not exist.
      */
     public Map<String, ExpectedAttributeValue> getDynamoNonexistantExpectation();

--- a/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardConsumerTest.java
+++ b/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardConsumerTest.java
@@ -587,7 +587,9 @@ public class ShardConsumerTest {
         parentShardIds.add("parentShardId");
         KinesisClientLease currentLease = createLease(streamShardId, "leaseOwner", parentShardIds);
         currentLease.setCheckpoint(new ExtendedSequenceNumber("testSequenceNumbeer"));
-        when(leaseManager.getLease(streamShardId)).thenReturn(currentLease);
+        KinesisClientLease currentLease1 = createLease(streamShardId, "leaseOwner", parentShardIds);
+        currentLease1.setCheckpoint(ExtendedSequenceNumber.SHARD_END);
+        when(leaseManager.getLease(streamShardId)).thenReturn(currentLease, currentLease, currentLease1);
         when(leaseCoordinator.getCurrentlyHeldLease(shardInfo.getShardId())).thenReturn(currentLease);
 
         RecordProcessorCheckpointer recordProcessorCheckpointer = new RecordProcessorCheckpointer(
@@ -714,7 +716,10 @@ public class ShardConsumerTest {
         parentShardIds.add("parentShardId");
         KinesisClientLease currentLease = createLease(streamShardId, "leaseOwner", parentShardIds);
         currentLease.setCheckpoint(new ExtendedSequenceNumber("testSequenceNumbeer"));
-        when(leaseManager.getLease(streamShardId)).thenReturn(currentLease);
+        KinesisClientLease currentLease1 = createLease(streamShardId, "leaseOwner", parentShardIds);
+        currentLease1.setCheckpoint(ExtendedSequenceNumber.SHARD_END);
+        when(leaseManager.getLease(streamShardId)).thenReturn(currentLease, currentLease, currentLease1);
+
         when(leaseCoordinator.getLeaseManager()).thenReturn(leaseManager);
 
         TransientShutdownErrorTestStreamlet processor = new TransientShutdownErrorTestStreamlet();


### PR DESCRIPTION
1. Update the checkpoint with non SHARD_END sequence number only if t…he DDB sequence number is not SHARD_END.
2. Verify the shard end checkpointing by directly looking up the ddb lease entry

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
