### PR TITLE
Fixing bug where ShardFilter parameter for ListShards was being passe…

### DIFF
--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/leases/KinesisShardDetector.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/leases/KinesisShardDetector.java
@@ -192,9 +192,9 @@ public class KinesisShardDetector implements ShardDetector {
         exceptionManager.add(ResourceInUseException.class, t -> t);
         exceptionManager.add(KinesisException.class, t -> t);
 
-        ListShardsRequest.Builder request = KinesisRequestsBuilder.listShardsRequestBuilder().shardFilter(shardFilter);
+        ListShardsRequest.Builder request = KinesisRequestsBuilder.listShardsRequestBuilder();
         if (StringUtils.isEmpty(nextToken)) {
-            request = request.streamName(streamIdentifier.streamName());
+            request = request.streamName(streamIdentifier.streamName()).shardFilter(shardFilter);
         } else {
             request = request.nextToken(nextToken);
         }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This resulted in a bug where all calls for ListShards when initializing
the lease table would fail, since Kinesis only requires the NextToken
parameter when making paginated calls.

Testing:

Created a large stream which was enough to cause pagination; tried to initiate a shard sync with an empty lease table (breaks as expected):
```
software.amazon.awssdk.services.kinesis.model.InvalidArgumentException: NextToken and ShardFilter cannot be provided together. (Service: Kinesis, Status Code: 400, Request ID: d62dd0fc-5122-ac86-8e85-5f676ac531f5, Extended Request ID: rINtS4L3nKaKtVM5VL2QrXKNc8+QCXjz/xM/8tN/gq/PJU/w+TuRDb8PdqbdrSkeP/qBAVFWLFWQuuLfrXnA0ypsFmqMVgpa)
```

After the change, we see that the lease table is created as expected with all shards.

New logging:

```

2021-02-18 18:18:20,605 [ShardRecordProcessor-0090] INFO  s.a.k.leases.KinesisShardDetector [NONE] - Stream paginated-stream: listing shards with list shards request ListShardsRequest(StreamName=paginated-stream) 
...
2021-02-18 18:19:57,949 [KinesisTester-0000] INFO  s.a.k.leases.KinesisShardDetector [NONE] - Stream paginated-stream: listing shards with list shards request ListShardsRequest(StreamName=paginated-stream, ShardFilter=ShardFilter(Type=AT_LATEST)) 
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
