### PR TITLE
Fixing bug where ShardFilter parameter for ListShards was being passe…

### DIFF
--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/proxies/KinesisProxy.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/proxies/KinesisProxy.java
@@ -315,13 +315,12 @@ public class KinesisProxy implements IKinesisProxyExtended {
         request.setRequestCredentials(credentialsProvider.getCredentials());
         if (StringUtils.isEmpty(nextToken)) {
             request.setStreamName(streamName);
+            request.setShardFilter(shardFilter);
         } else {
             request.setNextToken(nextToken);
         }
 
-        if (shardFilter != null) {
-            request.setShardFilter(shardFilter);
-        }
+        LOG.info("Listing shards with list shards request " + request);
 
         ListShardsResult result = null;
         LimitExceededException lastException = null;


### PR DESCRIPTION
…d in for paginated calls.

*Issue #, if available:*

*Description of changes:*

Fixing a bug where `ShardFilter` is incorrectly passed - since ListShards only requires parameters when not specifying a `nextToken` for paginated calls. 

Testing: Verified paginated calls worked + logging.

```
2021-02-23 08:06:08,856 [KinesisTester-0000] INFO  c.a.s.k.c.proxies.KinesisProxy [NONE] - Listing shards with list shards request {StreamName: paginated-stream,MaxResults: 1,ShardFilter: {Type: AT_LATEST,}} 
2021-02-23 08:06:15,146 [KinesisTester-0000] INFO  c.a.s.k.c.proxies.KinesisProxy [NONE] - Listing shards with list shards request {NextToken: AAAAAAAAAAEOvjHlCPvOeJUiphSoP8zimqd4h59yNzPeBrpZTDLTPWQ8kqnkag4WEBIJIfKWWaln2vEk2lq52+sk+rLpe+G1twyv8p9+A8N14dpxkZyATzL1qbMd7BLOUzWy4b3bw6D4M+NjIlwGp1LnbU5c/WqQo2wNbGIvaIMVABdJaYRTvKELa6oE0EqCVSFyafQLQF4luau2QqiGpKYckLf9SeN1ySUbylkik7XyP2eB7FXof3W2tNyZIYHmpu7Lw6GWFrY=,MaxResults: 1,} 
2021-02-23 08:06:16,536 [KinesisTester-0000] INFO  c.a.s.k.c.proxies.KinesisProxy [NONE] - Listing shards with list shards request {NextToken: AAAAAAAAAAFk8tYIWwWWYZPb69LSfrb+SNXUjCmrUwODqPq0hFQs168iKAjoihaW4TFdTM7ktqNpOhJ71HSBvHDsQvnBea9PxPuhRA6VCU/BrKS4sWxd8jW+DlB6kqzCia7VcSu6Fm7cUFupBXVVAQC6uibtlpFjd0y2SihBrFt0dotlZEsSjHeIzu/YEr0aszYvYpbGJ72BLTll+wlfmcwmdh04uEyu7xpPtyWNSncCJNtfoZp+m+bVvbZH/15Yn8MZ3MATGMw=,MaxResults: 1,} 
2021-02-23 08:06:17,485 [KinesisTester-0000] INFO  c.a.s.k.c.proxies.KinesisProxy [NONE] - Listing shards with list shards request {NextToken: AAAAAAAAAAEVmPV6yICWgTXFfp4HPqyUyWrkV81rzOp9FjiEKwYetICfy4U0QQwKO5F2DVgCREtPVD6sWvaeU7pHUpMx9o1GxIrZGCfrtgEpak1V0QX/63LQYobYjcA9c9TXXX/qB+KFZSa/SqHmGvkxflEMpHPzA4Qp8IYKLyEYtYD+NGChQgkpYf1/Q1relH5gg05R9g0vXUf1sEgwMqasu0tqglJ5m29qQlS2aGIctbrCvD8EEz54ZcYIcyj6yB6r4EgT+AI=,MaxResults: 1,} 
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
