### PR TITLE
Silence warning when there are no stale streams to delete

### DIFF
--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/coordinator/Scheduler.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/coordinator/Scheduler.java
@@ -562,10 +562,12 @@ public class Scheduler implements Runnable {
                 final Set<StreamIdentifier> staleStreamIdsToBeRevived = staleStreamIdDeletionDecisionMap.get(true);
                 removeStreamsFromStaleStreamsList(staleStreamIdsToBeRevived);
 
-                log.warn(
-                        "Streams enqueued for deletion for lease table cleanup along with their scheduled time for deletion: {} ",
-                        staleStreamDeletionMap.entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey,
-                                entry -> entry.getValue().plus(waitPeriodToDeleteOldStreams))));
+                if (!staleStreamDeletionMap.isEmpty()) {
+                    log.warn(
+                            "Streams enqueued for deletion for lease table cleanup along with their scheduled time for deletion: {} ",
+                            staleStreamDeletionMap.entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey,
+                                    entry -> entry.getValue().plus(waitPeriodToDeleteOldStreams))));
+                }
 
                 streamSyncWatch.reset().start();
 


### PR DESCRIPTION
A warning is logged when stale steams are to be deleted, but the log is still emitted even if the map of streams to delete is empty.  This just silences the warning as it is emitted at least a few times per minute.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.