### PR TITLE
Fixing log message spacing

### DIFF
--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/fanout/FanOutRecordsPublisher.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/fanout/FanOutRecordsPublisher.java
@@ -381,7 +381,7 @@ public class FanOutRecordsPublisher implements RecordsPublisher {
     private void resetRecordsDeliveryStateOnSubscriptionOnInit() {
         // Clear any lingering records in the queue.
         if (!recordsDeliveryQueue.isEmpty()) {
-            log.warn("{}: Found non-empty queue while starting subscription. This indicates unsuccessful clean up of"
+            log.warn("{}: Found non-empty queue while starting subscription. This indicates unsuccessful clean up of "
                     + "previous subscription - {}. Last successful request details -- {}", streamAndShardId, subscribeToShardId, lastSuccessfulRequestDetails);
             recordsDeliveryQueue.clear();
         }


### PR DESCRIPTION
*Issue #, if available:*
log message shows:
```
[WARN]shardId-000000002201: Found non-empty queue while starting subscription. This indicates unsuccessful clean up ofprevious subscription - 22. Last successful request details -- request id - c2163ff9-a7c6-eacb-9ad8-3cfd4a1ff280, timestamp - 2021-03-19T01:39:16.478Z
```

missing space between words 'of' and 'previous'

*Description of changes:*
Add space between words 'of' and 'previous'.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
