### PR TITLE
change logging level (#799)

### DIFF
--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/lifecycle/ProcessTask.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/lifecycle/ProcessTask.java
@@ -217,7 +217,7 @@ public class ProcessTask implements ConsumerTask {
         } catch (Exception e) {
             log.error("ShardId {}: Application processRecords() threw an exception when processing shard ",
                     shardInfoId, e);
-            log.error("ShardId {}: Skipping over the following data records: {}", shardInfoId, records);
+            log.debug("ShardId {}: Skipping over the following data records: {}", shardInfoId, records);
         } finally {
             MetricsUtil.addLatency(scope, RECORD_PROCESSOR_PROCESS_RECORDS_METRIC, startTime, MetricsLevel.SUMMARY);
             MetricsUtil.endScope(scope);


### PR DESCRIPTION
https://github.com/awslabs/amazon-kinesis-client/issues/799
Hi,

We recently have issue with checkpointing for few days and ProcessTasks was writing Record on each fail..
So it generate a lot of logs in cloudwatch.
We want to avoid this situation and not print record.

My proposition is to change ProcessTask.java#L220 to debug