### PR TITLE
Add acquiredLock flag to prevent unlocking when no lock is held

### DIFF
--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/coordinator/Scheduler.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/coordinator/Scheduler.java
@@ -40,6 +40,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -279,7 +280,8 @@ public class Scheduler implements Runnable {
                     .createWorkerStateChangeListener();
         }
         this.leaderDecider = new DeterministicShuffleShardSyncLeaderDecider(leaseRefresher,
-                Executors.newSingleThreadScheduledExecutor(), PERIODIC_SHARD_SYNC_MAX_WORKERS_DEFAULT);
+                Executors.newSingleThreadScheduledExecutor(),
+                PERIODIC_SHARD_SYNC_MAX_WORKERS_DEFAULT);
         this.failoverTimeMillis = this.leaseManagementConfig.failoverTimeMillis();
         this.taskBackoffTimeMillis = this.lifecycleConfig.taskBackoffTimeMillis();
 //        this.retryGetRecordsInSeconds = this.retrievalConfig.retryGetRecordsInSeconds();


### PR DESCRIPTION
### Description of changes
* On exceptions prior to locking, the electLeaders will jump to the finally code block and *block* indefinitely
* This change adds an acquiredLock flag to ensure we only unlock in the finally code block if the lock was acquired.

### Testing

```java
public class Foo {

    public static void main(String[] args) throws IOException {
        final ScheduledExecutorService scheduledExecutorService = Executors.newSingleThreadScheduledExecutor();
        final Runner runner = new Runner();
        scheduledExecutorService.scheduleAtFixedRate(runner, 10L,10 ,TimeUnit.MILLISECONDS);
        System.out.println("Done");
    }

    static class Runner implements Runnable {

        ReadWriteLock readWriteLock = new ReentrantReadWriteLock();
        @Override
        public void run() {
            System.out.println("Running");
            try {
                throw new TimeoutException("timeout");
            } catch (Throwable e) {
                e.printStackTrace();
            } finally {
                System.out.println("Forever blocking");
                readWriteLock.readLock().unlock();
                System.out.println("Did I get here?");
            }
        }
    }
}
```


**Output**:

```java
Done
Running
Forever blocking
java.util.concurrent.TimeoutException: timeout
    at Foo$Runner.run(Foo.java:26)
    at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
    at java.util.concurrent.FutureTask.runAndReset(FutureTask.java:308)
    at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$301(ScheduledThreadPoolExecutor.java:180)
    at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:294)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
    at java.lang.Thread.run(Thread.java:748)
```


This shows that trying to unlock a *lock* that isn't *locked* will block indefinitely; one could say we're in a *deadlock* sort of situation here


### Other stuff
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
