### PR TITLE
Allow InitialPositionInStreamExtended to be specified in properties file

### DIFF
--- a/amazon-kinesis-client-multilang/src/main/java/software/amazon/kinesis/multilang/config/MultiLangDaemonConfiguration.java
+++ b/amazon-kinesis-client-multilang/src/main/java/software/amazon/kinesis/multilang/config/MultiLangDaemonConfiguration.java
@@ -19,6 +19,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.net.URI;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -27,6 +28,7 @@ import java.util.UUID;
 import java.util.function.Function;
 
 import org.apache.commons.beanutils.BeanUtilsBean;
+import org.apache.commons.beanutils.ConvertUtils;
 import org.apache.commons.beanutils.ConvertUtilsBean;
 import org.apache.commons.beanutils.Converter;
 import org.apache.commons.beanutils.converters.ArrayConverter;
@@ -196,6 +198,14 @@ public class MultiLangDaemonConfiguration {
     public MultiLangDaemonConfiguration(BeanUtilsBean utilsBean, ConvertUtilsBean convertUtilsBean) {
         this.utilsBean = utilsBean;
         this.convertUtilsBean = convertUtilsBean;
+
+        convertUtilsBean.register(new Converter() {
+            @Override
+            public <T> T convert(Class<T> type, Object value) {
+                Date date = new Date(Long.parseLong(value.toString()) * 1000L);
+                return type.cast(InitialPositionInStreamExtended.newInitialPositionAtTimestamp(date));
+            }
+        }, InitialPositionInStreamExtended.class);
 
         convertUtilsBean.register(new Converter() {
             @Override

--- a/amazon-kinesis-client-multilang/src/test/java/software/amazon/kinesis/multilang/config/KinesisClientLibConfiguratorTest.java
+++ b/amazon-kinesis-client-multilang/src/test/java/software/amazon/kinesis/multilang/config/KinesisClientLibConfiguratorTest.java
@@ -27,6 +27,7 @@ import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.net.URI;
 import java.util.Arrays;
+import java.util.Date;
 import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
@@ -91,6 +92,16 @@ public class KinesisClientLibConfiguratorTest {
         assertEquals(config.getWorkerIdentifier(), "123");
         assertEquals(config.getFailoverTimeMillis(), 100);
         assertEquals(config.getShardSyncIntervalMillis(), 500);
+    }
+
+    @Test
+    public void testWithInitialPositionInStreamExtended() {
+        MultiLangDaemonConfiguration config = getConfiguration(StringUtils.join(new String[] { "applicationName = app",
+                "streamName = 123", "AWSCredentialsProvider = " + credentialName1 + ", " + credentialName2,
+                "initialPositionInStreamExtended = 1617406032" }, '\n'));
+
+        assertEquals(config.getInitialPositionInStreamExtended().getTimestamp(), new Date(1617406032000L));
+        assertEquals(config.getInitialPositionInStream(), InitialPositionInStream.AT_TIMESTAMP);
     }
 
     @Test


### PR DESCRIPTION
*Issue #, if available: https://github.com/awslabs/amazon-kinesis-client/issues/803

*Description of changes: This change allows a user of the multilang daemon to specify an initial timestamp in which the daemon will process records. E.g. if a user specifies `initialPositionInStreamExtended = 1617305352` in the properties file AND the stream does not currently have checkpoints present, the stream will start processing at `Thursday, April 1, 2021 7:29:12 PM GMT`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
