### PR TITLE
Removing cached shard progress, adding guardrails for duplicate shard responses.

### DIFF
--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/proxies/KinesisProxy.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/proxies/KinesisProxy.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.EnumSet;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -485,10 +486,11 @@ public class KinesisProxy implements IKinesisProxyExtended {
                 }
             } while (response.getStreamDescription().isHasMoreShards());
         }
-        this.cachedShardMap = shards.stream().collect(Collectors.toMap(Shard::getShardId, Function.identity()));
+        final List<Shard> dedupedShards = new ArrayList<>(new LinkedHashSet<>(shards));
+        this.cachedShardMap = dedupedShards.stream().collect(Collectors.toMap(Shard::getShardId, Function.identity()));
         this.lastCacheUpdateTime = Instant.now();
 
-        return shards;
+        return dedupedShards;
     }
 
     /**

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/proxies/KinesisProxy.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/proxies/KinesisProxy.java
@@ -490,7 +490,8 @@ public class KinesisProxy implements IKinesisProxyExtended {
         }
         final List<Shard> dedupedShards = new ArrayList<>(new LinkedHashSet<>(shards));
         if (dedupedShards.size() < shards.size()) {
-            LOG.warn("Found duplicate child shards in ListShards response. Request ids - " + requestIds);
+            LOG.warn("Found duplicate shards in response when sync'ing from Kinesis. " +
+                    "Request ids - " + requestIds + ". Response - " + shards);
         }
         this.cachedShardMap = dedupedShards.stream().collect(Collectors.toMap(Shard::getShardId, Function.identity()));
         this.lastCacheUpdateTime = Instant.now();

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/utils/RequestUtil.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/utils/RequestUtil.java
@@ -1,0 +1,24 @@
+package com.amazonaws.services.kinesis.clientlibrary.utils;
+
+import com.amazonaws.AmazonWebServiceResult;
+
+/**
+ * Helper class to parse metadata from AWS requests.
+ */
+public class RequestUtil {
+    private static final String DEFAULT_REQUEST_ID = "NONE";
+
+    /**
+     * Get the requestId associated with a request.
+     *
+     * @param result
+     * @return the requestId for a request, or "NONE" if one is not available.
+     */
+    public static String requestId(AmazonWebServiceResult result) {
+        if (result == null || result.getSdkResponseMetadata() == null || result.getSdkResponseMetadata().getRequestId() == null) {
+            return DEFAULT_REQUEST_ID;
+        }
+
+        return result.getSdkResponseMetadata().getRequestId();
+    }
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Removing cached shardmap that's used for shard syncs, as this can lead to unexpected behavior in partial failures. Also adding guardrails for duplicate shard responses.

Example logging:
```
2021-05-03 12:41:25,342 [main] WARN  com.amazonaws.services.kinesis.clientlibrary.proxies.KinesisProxy - Found duplicate shards in response when sync'ing from Kinesis. Request ids - [NONE]. Response - [{ShardId: shard-1,}, {ShardId: shard-2,}, {ShardId: shard-3,}, {ShardId: shard-4,}, {ShardId: shard-1,}, {ShardId: shard-2,}, {ShardId: shard-3,}, {ShardId: shard-4,}]
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
