### PR TITLE
Convert startGracefulShutdown() to a CompletableFuture

### DIFF
--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/coordinator/GracefulShutdownCoordinator.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/coordinator/GracefulShutdownCoordinator.java
@@ -15,7 +15,6 @@
 package software.amazon.kinesis.coordinator;
 
 import java.util.concurrent.*;
-import java.util.function.Supplier;
 
 import lombok.extern.slf4j.Slf4j;
 

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/coordinator/Scheduler.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/coordinator/Scheduler.java
@@ -31,15 +31,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.Callable;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
-import java.util.concurrent.ThreadLocalRandom;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.*;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -187,7 +179,7 @@ public class Scheduler implements Runnable {
     /**
      * Used to ensure that only one requestedShutdown is in progress at a time.
      */
-    private Future<Boolean> gracefulShutdownFuture;
+    private CompletableFuture<Boolean> gracefulShutdownFuture;
     @VisibleForTesting
     protected boolean gracefuleShutdownStarted = false;
 
@@ -716,7 +708,7 @@ public class Scheduler implements Runnable {
      *         completed successfully. A false value indicates that a non-exception case caused the shutdown process to
      *         terminate early.
      */
-    public Future<Boolean> startGracefulShutdown() {
+    public CompletableFuture<Boolean> startGracefulShutdown() {
         synchronized (this) {
             if (gracefulShutdownFuture == null) {
                 gracefulShutdownFuture = gracefulShutdownCoordinator


### PR DESCRIPTION
*Description of changes:*

We have a need to use the startGracefulShutdown() method. We noticed that this uses a standard Future rather than a CompletableFuture. As we use this in a Scala code base, we would like to be able to properly convert this call into a Scala future via [the Scala Future Converters](https://github.com/scala/scala-java8-compat/blob/main/src/main/scala/scala/compat/java8/FutureConverters.scala#L88). That is only possible with a CompletableFuture.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
