### PR TITLE
Update the Worker shutdown logic to make sure that the nager also terminates all the threads that it has started

### DIFF
--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/Worker.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/Worker.java
@@ -1045,6 +1045,10 @@ public class Worker implements Runnable {
         // Lost leases will force Worker to begin shutdown process for all shard consumers in
         // Worker.run().
         leaseCoordinator.stop();
+
+        // Stop the leash cleanup manager
+        leaseCleanupManager.shutdown();
+
         // Stop the periodicShardSyncManager for the worker
         if (shardSyncStrategy != null) {
             shardSyncStrategy.onWorkerShutDown();

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/Worker.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/Worker.java
@@ -1046,7 +1046,7 @@ public class Worker implements Runnable {
         // Worker.run().
         leaseCoordinator.stop();
 
-        // Stop the leash cleanup manager
+        // Stop the lease cleanup manager
         leaseCleanupManager.shutdown();
 
         // Stop the periodicShardSyncManager for the worker

--- a/src/main/java/com/amazonaws/services/kinesis/leases/impl/LeaseCleanupManager.java
+++ b/src/main/java/com/amazonaws/services/kinesis/leases/impl/LeaseCleanupManager.java
@@ -122,7 +122,7 @@ public class LeaseCleanupManager {
     }
 
     /**
-     * Starts the lease cleanup thread, which is scheduled periodically as specified by
+     * Stops the lease cleanup thread, which is scheduled periodically as specified by
      * {@link LeaseCleanupManager#leaseCleanupIntervalMillis}
      */
     public void shutdown() {

--- a/src/main/java/com/amazonaws/services/kinesis/leases/impl/LeaseCleanupManager.java
+++ b/src/main/java/com/amazonaws/services/kinesis/leases/impl/LeaseCleanupManager.java
@@ -122,6 +122,23 @@ public class LeaseCleanupManager {
     }
 
     /**
+     * Starts the lease cleanup thread, which is scheduled periodically as specified by
+     * {@link LeaseCleanupManager#leaseCleanupIntervalMillis}
+     */
+    public void shutdown() {
+        if (isRunning) {
+            LOG.info("Stopping the lease cleanup thread.");
+            completedLeaseStopwatch.stop();
+            garbageLeaseStopwatch.stop();
+            deletionThreadPool.shutdown();
+
+            isRunning = false;
+        } else {
+            LOG.info("Lease cleanup thread already stopped.");
+        }
+    }
+
+    /**
      * Enqueues a lease for deletion without check for duplicate entry. Use {@link #isEnqueuedForDeletion}
      * for checking the duplicate entries.
      * @param leasePendingDeletion

--- a/src/test/java/com/amazonaws/services/kinesis/leases/impl/LeaseCleanupManagerTest.java
+++ b/src/test/java/com/amazonaws/services/kinesis/leases/impl/LeaseCleanupManagerTest.java
@@ -94,6 +94,18 @@ public class LeaseCleanupManagerTest {
     }
 
     /**
+     * Tests subsequent calls to shutdown {@link LeaseCleanupManager}.
+     */
+    @Test
+    public final void testSubsequentShutdowns() {
+        leaseCleanupManager.start();
+        Assert.assertTrue(leaseCleanupManager.isRunning());
+        leaseCleanupManager.shutdown();
+        Assert.assertFalse(leaseCleanupManager.isRunning());
+        leaseCleanupManager.shutdown();
+    }
+
+    /**
      * Tests that when both child shard leases are present, we are able to delete the parent shard for the completed
      * shard case.
      */


### PR DESCRIPTION
*Issue #:* [#796](https://github.com/awslabs/amazon-kinesis-client/issues/796)

*Description of changes:* Fix to cleanup the threads started by the LeaseCleanupManager when the Worker triggers a shutdown. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
