### PR TITLE
Change hierarchicalShardSyncer getter to be public.

### DIFF
--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/leases/LeaseManagementConfig.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/leases/LeaseManagementConfig.java
@@ -306,7 +306,7 @@ public class LeaseManagementConfig {
 
     private LeaseManagementFactory leaseManagementFactory;
 
-    private HierarchicalShardSyncer hierarchicalShardSyncer() {
+    public HierarchicalShardSyncer hierarchicalShardSyncer() {
         if(hierarchicalShardSyncer == null) {
             hierarchicalShardSyncer = new HierarchicalShardSyncer();
         }


### PR DESCRIPTION
*Description of changes:*

This PR to make the `hierarchicalShardSyncer` getter in `LeaseManagementConfig.java` public again.

In v2.2.x the `hierarchicalShardSyncer` could be get and set via the lombok accessors. In v2.3.x a custom getter was introduced for accessing `hierarchicalShardSyncer`. The getter overwrote the lombok acessor, which is fine, but defined the access as `private`, preventing access to `hierarchicalShardSyncer` from outside the instance. I believe to be consistent we want the getter to be `public`, as are the getters of other variables.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
