### PR TITLE
Fixing typo is debug logs.

### DIFF
--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/leases/dynamodb/DynamoDBLeaseTaker.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/leases/dynamodb/DynamoDBLeaseTaker.java
@@ -503,7 +503,7 @@ public class DynamoDBLeaseTaker implements LeaseTaker {
         } else {
             if (log.isDebugEnabled()) {
                 log.debug("Worker {} will attempt to steal {} leases from most loaded worker {}. "
-                        + " He has {} leases, target is {}, I need {}, maxLeasesToSteatAtOneTime is {}.",
+                        + " He has {} leases, target is {}, I need {}, maxLeasesToStealAtOneTime is {}.",
                         workerIdentifier,
                         numLeasesToSteal,
                         mostLoadedWorker.getKey(),


### PR DESCRIPTION
maxLeasesToSteatAtOneTime -> maxLeasesToStealAtOneTime

*Description of changes:*
There is a typo in the debug logs. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
