### PR TITLE
Emit Glue Schema Registry usage metrics

### DIFF
--- a/amazon-kinesis-client/pom.xml
+++ b/amazon-kinesis-client/pom.xml
@@ -77,12 +77,12 @@
     <dependency>
       <groupId>software.amazon.glue</groupId>
       <artifactId>schema-registry-serde</artifactId>
-      <version>1.1.1</version>
+      <version>1.1.3</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.glue</groupId>
       <artifactId>schema-registry-common</artifactId>
-      <version>1.1.1</version>
+      <version>1.1.3</version>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>

--- a/amazon-kinesis-client/pom.xml
+++ b/amazon-kinesis-client/pom.xml
@@ -77,12 +77,12 @@
     <dependency>
       <groupId>software.amazon.glue</groupId>
       <artifactId>schema-registry-serde</artifactId>
-      <version>1.1.3</version>
+      <version>1.1.4</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.glue</groupId>
       <artifactId>schema-registry-common</artifactId>
-      <version>1.1.3</version>
+      <version>1.1.4</version>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>
@@ -321,6 +321,45 @@
             <goals>
               <goal>jar</goal>
             </goals>
+          </execution>
+        </executions>
+      </plugin>
+
+      <!-- Required for generating maven version as a Java class for runtime access -->
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>templating-maven-plugin</artifactId>
+        <version>1.0.0</version>
+        <executions>
+          <execution>
+            <id>generate-version-class</id>
+            <goals>
+              <goal>filter-sources</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-resources-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>copy-dist</id>
+            <phase>prepare-package</phase>
+            <goals>
+              <goal>copy-resources</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${project.build.outputDirectory}</outputDirectory>
+              <resources>
+                <resource>
+                  <directory>${project.basedir}/target/generated-sources/java-templates/</directory>
+                  <filtering>false</filtering>
+                  <excludes>
+                  </excludes>
+                </resource>
+              </resources>
+            </configuration>
           </execution>
         </executions>
       </plugin>

--- a/amazon-kinesis-client/src/main/java-templates/KinesisClientLibraryPackage.java
+++ b/amazon-kinesis-client/src/main/java-templates/KinesisClientLibraryPackage.java
@@ -1,0 +1,5 @@
+package software.amazon.kinesis.common;
+
+public final class KinesisClientLibraryPackage {
+    public static final String VERSION = "${project.version}";
+}

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/schemaregistry/SchemaRegistryDecoder.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/schemaregistry/SchemaRegistryDecoder.java
@@ -14,11 +14,13 @@ import java.util.List;
  */
 @Slf4j
 public class SchemaRegistryDecoder {
+    private static final String USER_AGENT_APP_NAME = "kcl";
     private final GlueSchemaRegistryDeserializer glueSchemaRegistryDeserializer;
 
     public SchemaRegistryDecoder(
         GlueSchemaRegistryDeserializer glueSchemaRegistryDeserializer) {
         this.glueSchemaRegistryDeserializer = glueSchemaRegistryDeserializer;
+        this.glueSchemaRegistryDeserializer.overrideUserAgentApp(USER_AGENT_APP_NAME);
     }
 
     /**

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/schemaregistry/SchemaRegistryDecoder.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/schemaregistry/SchemaRegistryDecoder.java
@@ -3,6 +3,7 @@ package software.amazon.kinesis.schemaregistry;
 import com.amazonaws.services.schemaregistry.common.Schema;
 import com.amazonaws.services.schemaregistry.deserializers.GlueSchemaRegistryDeserializer;
 import lombok.extern.slf4j.Slf4j;
+import software.amazon.kinesis.common.KinesisClientLibraryPackage;
 import software.amazon.kinesis.retrieval.KinesisClientRecord;
 
 import java.nio.ByteBuffer;
@@ -14,7 +15,7 @@ import java.util.List;
  */
 @Slf4j
 public class SchemaRegistryDecoder {
-    private static final String USER_AGENT_APP_NAME = "kcl";
+    private static final String USER_AGENT_APP_NAME = "kcl" + "-" + KinesisClientLibraryPackage.VERSION;
     private final GlueSchemaRegistryDeserializer glueSchemaRegistryDeserializer;
 
     public SchemaRegistryDecoder(


### PR DESCRIPTION
*Description of changes:*

Sets the User Agent for the de-serializer to "kcl". This enables the underlying Glue Schema Registry library to emit UserAgent metrics.

*Testing*

Build successful.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
