### PR TITLE
Upgrade AWS SDK version to 2.17.52.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
   </scm>
 
   <properties>
-    <awssdk.version>2.16.98</awssdk.version>
+    <awssdk.version>2.17.52</awssdk.version>
   </properties>
 
   <licenses>


### PR DESCRIPTION
Upgrade AWS SDK version to upgrade vulnerable Netty versions.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
