### PR TITLE
Fix `logOnErrorReadTimeoutWarning` formatting

### DIFF
--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/lifecycle/ShardConsumerSubscriber.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/lifecycle/ShardConsumerSubscriber.java
@@ -199,11 +199,11 @@ class ShardConsumerSubscriber implements Subscriber<RecordsRetrieved> {
     }
 
     protected void logOnErrorReadTimeoutWarning(Throwable t) {
-        log.warn("{}: onError().  Cancelling subscription, and marking self as failed. KCL will"
-                + " recreate the subscription as neccessary to continue processing. If you "
+        log.warn("{}: onError().  Cancelling subscription, and marking self as failed. KCL will "
+                + "recreate the subscription as necessary to continue processing. If you "
                 + "are seeing this warning frequently consider increasing the SDK timeouts "
-                + "by providing an OverrideConfiguration to the kinesis client. Alternatively you"
-                + "can configure LifecycleConfig.readTimeoutsToIgnoreBeforeWarning to suppress"
+                + "by providing an OverrideConfiguration to the kinesis client. Alternatively you "
+                + "can configure LifecycleConfig.readTimeoutsToIgnoreBeforeWarning to suppress "
                 + "intermittent ReadTimeout warnings. Last successful request details -- {}",
                 shardInfoId, recordsPublisher.getLastSuccessfulRequestDetails(), t);
     }


### PR DESCRIPTION
The formatting of the `logOnErrorReadTimeoutWarning` was inconsistent in where it had spaces and where it didn't. This caused words to be smashed together in the log message.

Example output:
```
onError().  Cancelling subscription, and marking self as failed. KCL will recreate the subscription as neccessary to continue processing. If you are seeing this warning frequently consider increasing the SDK timeouts by providing an OverrideConfiguration to the kinesis client. Alternatively youcan configure LifecycleConfig.readTimeoutsToIgnoreBeforeWarning to suppressintermittent ReadTimeout warnings. Last successful request details -- request id - UNKNOWN, timestamp - 2021-12-14T17:41:00.169Z
```
specifically note the `youcan` and `suppressintermittent`.

This change corrects the formatting of this log output to not include these smashed together words.

It also corrects a type in the word `necessary` (was `neccessary`).

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
