### PR TITLE
Update logback dependency to 1.2.8

### DIFF
--- a/amazon-kinesis-client-multilang/pom.xml
+++ b/amazon-kinesis-client-multilang/pom.xml
@@ -78,7 +78,7 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>1.2.7</version>
+      <version>1.2.8</version>
     </dependency>
     <dependency>
       <groupId>com.beust</groupId>

--- a/amazon-kinesis-client/pom.xml
+++ b/amazon-kinesis-client/pom.xml
@@ -152,7 +152,7 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>1.2.7</version>
+      <version>1.2.8</version>
       <scope>test</scope>
     </dependency>
 


### PR DESCRIPTION
*Issue #, if available:* 
N/A - basically copied what was done in https://github.com/awslabs/amazon-kinesis-client/pull/866

*Description of changes:*
Following the guidance described in http://logback.qos.ch/news.html
> As an additional extra precaution, in addition to upgrading to logback version 1.2.8, we also recommend users to set their logback configuration files as read-only.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
