### PR TITLE
Update log4j to 2.17.0 and couple of other dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,0 @@
-version: 2
-updates:
-- package-ecosystem: "maven"
-  directory: "/"
-  schedule: 
-    interval: "daily"
-

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+- package-ecosystem: "maven"
+  directory: "/"
+  schedule: 
+    interval: "daily"
+

--- a/pom.xml
+++ b/pom.xml
@@ -268,7 +268,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
-        <version>3.0.1</version>
+        <version>3.2.1</version>
         <executions>
           <execution>
             <id>attach-sources</id>

--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
     <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
-      <version>1.16.10</version>
+      <version>1.18.22</version>
       <scope>provided</scope>
     </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>DynamoDBLocal</artifactId>
-      <version>1.11.86</version>
+      <version>1.17.2</version>
       <scope>test</scope>
     </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -166,7 +166,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
-        <version>2.19.1</version>
+        <version>2.22.2</version>
         <configuration>
           <includes>
             <include>**/*IntegrationTest.java</include>

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>26.0-jre</version>
+      <version>31.0.1-jre</version>
     </dependency>
     <dependency>
       <groupId>com.google.protobuf</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.11</version>
+      <version>4.13.2</version>
       <scope>test</scope>
     </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
-      <version>3.7</version>
+      <version>3.12.0</version>
     </dependency>
     <dependency>
       <groupId>commons-logging</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -311,7 +311,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>
-            <version>1.6</version>
+            <version>3.0.1</version>
             <executions>
               <execution>
                 <id>sign-artifacts</id>

--- a/pom.xml
+++ b/pom.xml
@@ -252,7 +252,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.10.3</version>
+        <version>3.3.1</version>
         <configuration>
           <excludePackageNames>com.amazonaws.services.kinesis.producer.protobuf</excludePackageNames>
         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
   </licenses>
 
   <properties>
-    <aws-java-sdk.version>1.12.128</aws-java-sdk.version>
+    <aws-java-sdk.version>1.12.130</aws-java-sdk.version>
     <sqlite4java.version>1.0.392</sqlite4java.version>
     <sqlite4java.native>libsqlite4java</sqlite4java.native>
     <sqlite4java.libpath>${project.build.directory}/test-lib</sqlite4java.libpath>

--- a/pom.xml
+++ b/pom.xml
@@ -150,7 +150,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.19.1</version>
+        <version>2.22.2</version>
         <configuration>
           <excludes>
             <exclude>**/*IntegrationTest.java</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
-      <version>3.11.4</version>
+      <version>3.19.1</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
     <dependency>
       <groupId>commons-logging</groupId>
       <artifactId>commons-logging</artifactId>
-      <version>1.1.3</version>
+      <version>1.2</version>
     </dependency>
     <dependency>
       <groupId>org.projectlombok</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,7 @@
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core</artifactId>
-      <version>2.16.0</version>
+      <version>2.17.0</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -136,7 +136,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.2</version>
+          <version>3.8.1</version>
           <configuration>
             <source>1.8</source>
             <target>1.8</target>

--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,11 @@
   <dependencies>
     <dependency>
       <groupId>com.amazonaws</groupId>
+      <artifactId>aws-java-sdk-core</artifactId>
+      <version>${aws-java-sdk.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk-dynamodb</artifactId>
       <version>${aws-java-sdk.version}</version>
     </dependency>
@@ -108,6 +113,12 @@
       <artifactId>log4j-core</artifactId>
       <version>2.17.0</version>
       <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+      <version>2.13.0</version>
     </dependency>
   </dependencies>
 
@@ -300,7 +311,7 @@
         <jdk>[1.8,)</jdk>
       </activation>
       <properties>
-        <additionalparam>-Xdoclint:none</additionalparam>
+        <doclint>none</doclint>
       </properties>
     </profile>
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Update dependencies:
    - Bump commons-logging from 1.1.3 to 1.2
    - Bump maven-source-plugin from 3.0.1 to 3.2.1
    - Bump DynamoDBLocal from 1.11.86 to 1.17.2
    - Bump commons-lang3 from 3.7 to 3.12.0
    - **Bump log4j-core from 2.16.0 to 2.17.0**
    - Bump maven-surefire-plugin from 2.19.1 to 2.22.2
    - Bump maven-javadoc-plugin from 2.10.3 to 3.3.1
    - Bump lombok from 1.16.10 to 1.18.22
    - Bump maven-compiler-plugin from 3.2 to 3.8.1
    - Bump maven-gpg-plugin from 1.6 to 3.0.1
    - Bump maven-failsafe-plugin from 2.19.1 to 2.22.2
    - Bump protobuf-java from 3.11.4 to 3.19.1
    - Bump aws-java-sdk.version from 1.12.128 to 1.12.130
    - Bump junit from 4.11 to 4.13.2
    - Bump guava from 26.0-jre to 31.0.1-jre


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
