### PR TITLE
Fix null pointer exception that happens in shutdown before lease have got

### DIFF
--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/coordinator/Scheduler.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/coordinator/Scheduler.java
@@ -763,9 +763,12 @@ public class Scheduler implements Runnable {
             // Stop accepting new leases. Once we do this we can be sure that
             // no more leases will be acquired.
             //
-            leaseCoordinator.stopLeaseTaker();
+            Collection<Lease> leases = Collections.emptyList();
+            if (leaseCoordinator != null) {
+                leaseCoordinator.stopLeaseTaker();
+                leases = leaseCoordinator.getAssignments();
+            }
 
-            Collection<Lease> leases = leaseCoordinator.getAssignments();
             if (leases == null || leases.isEmpty()) {
                 //
                 // If there are no leases notification is already completed, but we still need to shutdown the worker.


### PR DESCRIPTION

*Issue #, if available:*
https://github.com/awslabs/amazon-kinesis-client/issues/900
https://github.com/awslabs/amazon-kinesis-client/issues/745

*Description of changes:*
This change adds a null check to avoid exceptions, in conditions when the worker didn't get the lease. 
Without this change, the shutdown process interrupts and workers are continuing to operate.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
