### PR TITLE
Pass `isAtShardEnd` correctly to `processRecords` call

### DIFF
--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/lifecycle/ProcessTask.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/lifecycle/ProcessTask.java
@@ -215,7 +215,7 @@ public class ProcessTask implements ConsumerTask {
                 shardInfoId);
 
         final ProcessRecordsInput processRecordsInput = ProcessRecordsInput.builder().records(records).cacheExitTime(input.cacheExitTime()).cacheEntryTime(input.cacheEntryTime())
-                .checkpointer(recordProcessorCheckpointer).millisBehindLatest(input.millisBehindLatest()).build();
+                .isAtShardEnd(input.isAtShardEnd()).checkpointer(recordProcessorCheckpointer).millisBehindLatest(input.millisBehindLatest()).build();
 
         final MetricsScope scope = MetricsUtil.createMetricsWithOperation(metricsFactory, PROCESS_TASK_OPERATION);
         shardInfo.streamIdentifierSerOpt()


### PR DESCRIPTION
The processor's `processRecords` is always called with `isAtShardEnd=false`. The flag is not being set correctly.

*Issue #, if available:*
https://github.com/awslabs/amazon-kinesis-client/issues/934

The client never gets that it reached the end of shard. The information is only available via side channel lifecycle `TaskExecutionListener`, however the shard is immediately checkpointed (regardless the rest of the processing). If the code using KCL exists after this point, it may effectively lose the data between the previous checkpoint and the shard end.


*Description of changes:*
Propagate the `isAtShardEnd` from _source_`ProcessRecordsInput` to the newly built `ProcessRecordsInput` that is then passed to `processRecords`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
