### PR TITLE
Added metric to record when a lease cannot be taken due to a Conditio…

### DIFF
--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/leases/dynamodb/DynamoDBLeaseTaker.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/leases/dynamodb/DynamoDBLeaseTaker.java
@@ -236,6 +236,7 @@ public class DynamoDBLeaseTaker implements LeaseTaker {
             }
 
             scope.addData("TakenLeases", takenLeases.size(), StandardUnit.COUNT, MetricsLevel.SUMMARY);
+            scope.addData("UntakenLeases", untakenLeaseKeys.size(), StandardUnit.COUNT, MetricsLevel.SUMMARY);
         } finally {
             MetricsUtil.endScope(scope);
         }


### PR DESCRIPTION
…nalCheckFailedException

*Issue #, if available:*
No existing issue number. This is to match internal code. Customers have the ability to get the number of taken leases and the ability to get the number of untaken leases by taking the total number of leases minus the number of taken leases. To improve customer experience, we can emit the untaken value that we calculate to make it much easier to find when there are conditional ddb checks that fail on leases. 

*Description of changes:*
This change allows users to emit metrics for leases that are not taken due to conditional check exceptions. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
