### PR TITLE
Updating MultiLangDaemonConfiguration

### DIFF
--- a/amazon-kinesis-client-multilang/src/main/java/software/amazon/kinesis/multilang/config/MultiLangDaemonConfiguration.java
+++ b/amazon-kinesis-client-multilang/src/main/java/software/amazon/kinesis/multilang/config/MultiLangDaemonConfiguration.java
@@ -269,10 +269,36 @@ public class MultiLangDaemonConfiguration {
         }
     }
 
+    private void setRegionForClient(String name, BuilderDynaBean client, Region region, boolean override) {
+        if(override) {
+            setRegionForClient(name, client, region);
+        } else {
+            String propertyValue;
+            try {
+                propertyValue = utilsBean.getProperty(client,"region");
+                //Check if property is already set. If not, set region for client
+                if(propertyValue == null || propertyValue.isEmpty()) {
+                    setRegionForClient(name, client, region);
+                }
+            } catch (IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
+                log.error("Failed to get region on {}", name, e);
+                throw new IllegalStateException(e);
+            }
+        }
+    }
+
     public void setRegionName(Region region) {
-        setRegionForClient("kinesisClient", kinesisClient, region);
-        setRegionForClient("dynamoDbClient", dynamoDbClient, region);
-        setRegionForClient("cloudWatchClient", cloudWatchClient, region);
+        setRegionForClient("kinesisClient", kinesisClient, region, false);
+        setRegionForClient("dynamoDbClient", dynamoDbClient, region, false);
+        setRegionForClient("cloudWatchClient", cloudWatchClient, region, false);
+    }
+
+    public void setDynamoDBRegionName(Region region) {
+        setRegionForClient("dynamoDbClient", dynamoDbClient, region, true);
+    }
+
+    public void setCloudWatchRegionName(Region region) {
+        setRegionForClient("cloudWatchClient", cloudWatchClient, region, true);
     }
 
     private void setEndpointForClient(String name, BuilderDynaBean client, String endpoint) {


### PR DESCRIPTION
*Issue #, if available:*
940

*Description of changes:*
Allowing the ability to set the region for kinesisClient, dynamoDbClient, cloudWatchClient separately and having regionName act as the default for all in the abscense of the new properties available.

Added a new private setRegionForClient method which takes a boolean argument of 'override'. This new method will set the property regardless if it's already set if override is true. If override is false, the method checks to see if the property has been set and only set the property if it's empty.

The reason for the new method is to allow for the properties to be loaded in any order during consumption of properties file without overriding any properties unexpectedly.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
