### PR TITLE
Bug fix for cleanupLease logic -- not check child shards when cleanup is disabled

### DIFF
--- a/src/main/java/com/amazonaws/services/kinesis/leases/impl/LeaseCleanupManager.java
+++ b/src/main/java/com/amazonaws/services/kinesis/leases/impl/LeaseCleanupManager.java
@@ -238,7 +238,7 @@ public class LeaseCleanupManager {
             } else {
                 cleanupFailureReason = "Configuration/Interval condition not satisfied to execute lease cleanup this cycle";
             }
-            if (!cleanedUpCompletedLease && !alreadyCheckedForGarbageCollection && timeToCheckForGarbageShard) {
+            if (cleanupLeasesUponShardCompletion && !cleanedUpCompletedLease && !alreadyCheckedForGarbageCollection && timeToCheckForGarbageShard) {
                 // throws ResourceNotFoundException
                 wereChildShardsPresent = !CollectionUtils
                             .isNullOrEmpty(getChildShardsFromService(shardInfo));


### PR DESCRIPTION
*Description of changes:*

## Issue
By Isuru: Lease cleanup for completed shards in the lease table is enabled by default. However, customers can disable it. When it's disabled, KCL LeaseManager periodically calls GetRecords on already consumed (Checkpointed with SHARD_END in lease table) shards to validate whether each shard exists. This leads to an increase in MillisBehindLatest on the service side. 

## Fix
Update the logic in cleanupLease that, if customer didn't enable lease cleanup, it should not look for child shards.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
