### PR TITLE
MPHEE: first pass at adding logging for applications

### DIFF
--- a/amazon-kinesis-client-multilang/src/main/java/software/amazon/kinesis/multilang/MultiLangProtocol.java
+++ b/amazon-kinesis-client-multilang/src/main/java/software/amazon/kinesis/multilang/MultiLangProtocol.java
@@ -27,14 +27,7 @@ import software.amazon.kinesis.lifecycle.events.LeaseLostInput;
 import software.amazon.kinesis.lifecycle.events.ProcessRecordsInput;
 import software.amazon.kinesis.lifecycle.events.ShardEndedInput;
 import software.amazon.kinesis.multilang.config.MultiLangDaemonConfiguration;
-import software.amazon.kinesis.multilang.messages.CheckpointMessage;
-import software.amazon.kinesis.multilang.messages.InitializeMessage;
-import software.amazon.kinesis.multilang.messages.LeaseLostMessage;
-import software.amazon.kinesis.multilang.messages.Message;
-import software.amazon.kinesis.multilang.messages.ProcessRecordsMessage;
-import software.amazon.kinesis.multilang.messages.ShardEndedMessage;
-import software.amazon.kinesis.multilang.messages.ShutdownRequestedMessage;
-import software.amazon.kinesis.multilang.messages.StatusMessage;
+import software.amazon.kinesis.multilang.messages.*;
 import software.amazon.kinesis.processor.RecordProcessorCheckpointer;
 
 /**
@@ -193,6 +186,10 @@ class MultiLangProtocol {
             if (checkpointFailed.orElse(false)) {
                 return false;
             }
+
+            Optional<Boolean> messageLogged = message.filter(m -> m instanceof LogMessage)
+                    .map(m -> (LogMessage) m)
+                    .map(m -> m.getLogger().apply(m.getMessage()));
 
             statusMessage = message.filter(m -> m instanceof StatusMessage).map(m -> (StatusMessage) m );
         }

--- a/amazon-kinesis-client-multilang/src/main/java/software/amazon/kinesis/multilang/messages/LogMessage.java
+++ b/amazon-kinesis-client-multilang/src/main/java/software/amazon/kinesis/multilang/messages/LogMessage.java
@@ -1,0 +1,62 @@
+package software.amazon.kinesis.multilang.messages;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.function.Function;
+
+@Getter
+@Setter
+@Slf4j
+public class LogMessage extends Message {
+    /**
+     * The name used for the action field in {@link Message}.
+     */
+    public static final String ACTION = "log";
+
+    /**
+     * The shard id that this processor is getting initialized for.
+     */
+    private String message;
+    private String logLevel = "info";
+
+
+    public LogMessage() {
+        this.message = "initialized";
+    }
+
+    /**
+     * Default constructor.
+     */
+    public LogMessage(String message) {
+        this.message = message;
+        log.info("Client logging: " + this.message);
+    }
+
+    public Function<String, Boolean> getLogger() {
+        switch (logLevel) {
+            case "debug": {
+                return (m) -> {
+                    log.debug(m);
+                    return true;
+                };
+            }
+            case "warn":
+                return (m) -> {
+                    log.warn(m);
+                    return true;
+                };
+            case "error":
+                return (m) -> {
+                    log.error(m);
+                    return true;
+                };
+            default:
+                return (m) -> {
+                    log.info(m);
+                    return true;
+                };
+        }
+    }
+}

--- a/amazon-kinesis-client-multilang/src/main/java/software/amazon/kinesis/multilang/messages/Message.java
+++ b/amazon-kinesis-client-multilang/src/main/java/software/amazon/kinesis/multilang/messages/Message.java
@@ -32,6 +32,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
         @Type(value = ShutdownRequestedMessage.class, name = ShutdownRequestedMessage.ACTION),
         @Type(value = LeaseLostMessage.class, name = LeaseLostMessage.ACTION),
         @Type(value = ShardEndedMessage.class, name = ShardEndedMessage.ACTION),
+        @Type(value = LogMessage.class, name = LogMessage.ACTION),
 })
 public abstract class Message {
 


### PR DESCRIPTION
[MultiLang Daemon StdLogger call](https://github.com/awslabs/amazon-kinesis-client/issues/60)

Adding the ability for the clients to send logging messages through the normal stdout by having the KCL process new LogMessages

WIP right now


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

```
2022-06-17 13:31:49,176 [ShardRecordProcessor-0001] INFO  s.a.k.multilang.messages.LogMessage [NONE] - Processing record with key AN_ID_OF_A_POLICY 
2022-06-17 13:31:49,176 [multi-lang-daemon-0003] INFO  s.a.kinesis.multilang.LineReaderTask [NONE] - Starting: Reading next message from STDIN for shardId-000000000000 
2022-06-17 13:31:49,177 [ShardRecordProcessor-0001] ERROR s.a.k.multilang.messages.LogMessage [NONE] - Processing record with key AN_ID_OF_A_POLICY 
```

Python side maybe?
```
class KclLogger:
    class LogLevel(Enum):
        INFO = "info"
        DEBUG = "debug"
        ERROR = "error"
        WARN = "warn"

    def debug(self, message: str):
        self._write_action(self.LogLevel.DEBUG.value, message)

    def info(self, message: str):
        self._write_action(self.LogLevel.INFO.value, message)

    def warn(self, message: str):
        self._write_action(self.LogLevel.WARN.value, message)

    def error(self, message: str):
        self._write_action(self.LogLevel.ERROR.value, message)

    @staticmethod
    def _write_action(log_level: LogLevel, message: str):
        kclprocess.io_handler.write_action(KclLogger._create_message(log_level, message))

    @staticmethod
    def _create_message(log_level: LogLevel, message: str):
        return {
            "action": "log",
            "logLevel": log_level,
            "message": message
        }
```