### PR TITLE
Update for Compatibility with DynamoDBStreamsKinesisAdapter

### DIFF
--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/AsynchronousGetRecordsRetrievalStrategy.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/AsynchronousGetRecordsRetrievalStrategy.java
@@ -45,24 +45,24 @@ public class AsynchronousGetRecordsRetrievalStrategy implements GetRecordsRetrie
     private static final int TIME_TO_KEEP_ALIVE = 5;
     private static final int CORE_THREAD_POOL_COUNT = 1;
 
-    private final KinesisDataFetcher dataFetcher;
+    private final IDataFetcher dataFetcher;
     private final ExecutorService executorService;
     private final int retryGetRecordsInSeconds;
     private final String shardId;
     final Supplier<CompletionService<DataFetcherResult>> completionServiceSupplier;
 
-    public AsynchronousGetRecordsRetrievalStrategy(@NonNull final KinesisDataFetcher dataFetcher,
+    public AsynchronousGetRecordsRetrievalStrategy(@NonNull final IDataFetcher dataFetcher,
             final int retryGetRecordsInSeconds, final int maxGetRecordsThreadPool, String shardId) {
         this(dataFetcher, buildExector(maxGetRecordsThreadPool, shardId), retryGetRecordsInSeconds, shardId);
     }
 
-    public AsynchronousGetRecordsRetrievalStrategy(final KinesisDataFetcher dataFetcher,
+    public AsynchronousGetRecordsRetrievalStrategy(final IDataFetcher dataFetcher,
             final ExecutorService executorService, final int retryGetRecordsInSeconds, String shardId) {
         this(dataFetcher, executorService, retryGetRecordsInSeconds, () -> new ExecutorCompletionService<>(executorService),
                 shardId);
     }
 
-    AsynchronousGetRecordsRetrievalStrategy(KinesisDataFetcher dataFetcher, ExecutorService executorService,
+    AsynchronousGetRecordsRetrievalStrategy(IDataFetcher dataFetcher, ExecutorService executorService,
             int retryGetRecordsInSeconds, Supplier<CompletionService<DataFetcherResult>> completionServiceSupplier,
             String shardId) {
         this.dataFetcher = dataFetcher;
@@ -148,7 +148,7 @@ public class AsynchronousGetRecordsRetrievalStrategy implements GetRecordsRetrie
     }
 
     @Override
-    public KinesisDataFetcher getDataFetcher() {
+    public IDataFetcher getDataFetcher() {
         return dataFetcher;
     }
 }

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/BlockOnParentShardTask.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/BlockOnParentShardTask.java
@@ -30,7 +30,7 @@ import com.amazonaws.services.kinesis.leases.interfaces.ILeaseManager;
  * If we don't find a checkpoint for the parent shard(s), we assume they have been trimmed and directly
  * proceed with processing data from the shard.
  */
-class BlockOnParentShardTask implements ITask {
+public class BlockOnParentShardTask implements ITask {
 
     private static final Log LOG = LogFactory.getLog(BlockOnParentShardTask.class);
     private final ShardInfo shardInfo;
@@ -45,9 +45,9 @@ class BlockOnParentShardTask implements ITask {
      * @param leaseManager Used to fetch the lease and checkpoint info for parent shards
      * @param parentShardPollIntervalMillis Sleep time if the parent shard has not completed processing
      */
-    BlockOnParentShardTask(ShardInfo shardInfo,
-            ILeaseManager<KinesisClientLease> leaseManager,
-            long parentShardPollIntervalMillis) {
+    public BlockOnParentShardTask(ShardInfo shardInfo,
+                                  ILeaseManager<KinesisClientLease> leaseManager,
+                                  long parentShardPollIntervalMillis) {
         this.shardInfo = shardInfo;
         this.leaseManager = leaseManager;
         this.parentShardPollIntervalMillis = parentShardPollIntervalMillis;

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/GetRecordsRetrievalStrategy.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/GetRecordsRetrievalStrategy.java
@@ -46,9 +46,9 @@ public interface GetRecordsRetrievalStrategy {
     boolean isShutdown();
 
     /**
-     * Returns the KinesisDataFetcher used to getRecords from Kinesis.
+     * Returns the IDataFetcher used to getRecords
      * 
-     * @return KinesisDataFetcher
+     * @return IDataFetcher
      */
-    KinesisDataFetcher getDataFetcher();
+    IDataFetcher getDataFetcher();
 }

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/IDataFetcher.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/IDataFetcher.java
@@ -1,0 +1,23 @@
+package com.amazonaws.services.kinesis.clientlibrary.lib.worker;
+
+import com.amazonaws.services.kinesis.clientlibrary.types.ExtendedSequenceNumber;
+import com.amazonaws.services.kinesis.model.ChildShard;
+
+import java.util.List;
+
+public interface IDataFetcher {
+
+    DataFetcherResult getRecords(int maxRecords);
+
+    void initialize(String initialCheckpoint, InitialPositionInStreamExtended initialPositionInStream);
+
+    void initialize(ExtendedSequenceNumber initialCheckpoint, InitialPositionInStreamExtended initialPositionInStream);
+
+    void advanceIteratorTo(String sequenceNumber, InitialPositionInStreamExtended initialPositionInStream);
+
+    void restartIterator();
+
+    boolean isShardEndReached();
+
+    List<ChildShard> getChildShards();
+}

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/IPeriodicShardSyncManager.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/IPeriodicShardSyncManager.java
@@ -1,0 +1,28 @@
+package com.amazonaws.services.kinesis.clientlibrary.lib.worker;
+
+import com.google.common.annotations.VisibleForTesting;
+import lombok.Value;
+import lombok.experimental.Accessors;
+
+public interface IPeriodicShardSyncManager {
+
+    TaskResult start();
+
+    /**
+     * Runs ShardSync once, without scheduling further periodic ShardSyncs.
+     * @return TaskResult from shard sync
+     */
+    TaskResult syncShardsOnce();
+
+    void stop();
+
+    @Value
+    @Accessors(fluent = true)
+    @VisibleForTesting
+    class ShardSyncResponse {
+        private final boolean shouldDoShardSync;
+        private final boolean isHoleDetected;
+        private final String reasonForDecision;
+    }
+}
+

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/IShardConsumer.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/IShardConsumer.java
@@ -1,0 +1,24 @@
+package com.amazonaws.services.kinesis.clientlibrary.lib.worker;
+
+public interface IShardConsumer {
+
+    boolean isSkipShardSyncAtWorkerInitializationIfLeasesExist();
+
+    enum TaskOutcome {
+        SUCCESSFUL, END_OF_SHARD, NOT_COMPLETE, FAILURE, LEASE_NOT_FOUND
+    }
+
+    boolean consumeShard();
+
+    boolean isShutdown();
+
+    ShutdownReason getShutdownReason();
+
+    boolean beginShutdown();
+
+    void notifyShutdownRequested(ShutdownNotification shutdownNotification);
+
+    KinesisConsumerStates.ShardConsumerState getCurrentState();
+
+    boolean isShutdownRequested();
+}

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/IShardConsumerFactory.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/IShardConsumerFactory.java
@@ -1,0 +1,34 @@
+package com.amazonaws.services.kinesis.clientlibrary.lib.worker;
+
+import com.amazonaws.services.kinesis.clientlibrary.interfaces.ICheckpoint;
+import com.amazonaws.services.kinesis.clientlibrary.interfaces.v2.IRecordProcessor;
+import com.amazonaws.services.kinesis.leases.impl.LeaseCleanupManager;
+import com.amazonaws.services.kinesis.metrics.interfaces.IMetricsFactory;
+
+import java.util.Optional;
+import java.util.concurrent.ExecutorService;
+
+public interface IShardConsumerFactory {
+
+    /**
+     * Returns a shard consumer to be used for consuming a (assigned) shard.
+     *
+     * @return Returns a shard consumer object.
+     */
+    IShardConsumer createShardConsumer(ShardInfo shardInfo,
+                                       StreamConfig streamConfig,
+                                       ICheckpoint checkpointTracker,
+                                       IRecordProcessor recordProcessor,
+                                       RecordProcessorCheckpointer recordProcessorCheckpointer,
+                                       KinesisClientLibLeaseCoordinator leaseCoordinator,
+                                       long parentShardPollIntervalMillis,
+                                       boolean cleanupLeasesUponShardCompletion,
+                                       ExecutorService executorService,
+                                       IMetricsFactory metricsFactory,
+                                       long taskBackoffTimeMillis,
+                                       boolean skipShardSyncAtWorkerInitializationIfLeasesExist,
+                                       Optional<Integer> retryGetRecordsInSeconds,
+                                       Optional<Integer> maxGetRecordsThreadPool,
+                                       KinesisClientLibConfiguration config, ShardSyncer shardSyncer, ShardSyncStrategy shardSyncStrategy,
+                                       LeaseCleanupManager leaseCleanupManager);
+}

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ITask.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ITask.java
@@ -20,7 +20,7 @@ import java.util.concurrent.Callable;
  * Interface for shard processing tasks.
  * A task may execute an application callback (e.g. initialize, process, shutdown).
  */
-interface ITask extends Callable<TaskResult> {
+public interface ITask extends Callable<TaskResult> {
 
     /**
      * Perform task logic.

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/InitializeTask.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/InitializeTask.java
@@ -29,7 +29,7 @@ import com.amazonaws.services.kinesis.metrics.interfaces.MetricsLevel;
 /**
  * Task for initializing shard position and invoking the RecordProcessor initialize() API.
  */
-class InitializeTask implements ITask {
+public class InitializeTask implements ITask {
 
     private static final Log LOG = LogFactory.getLog(InitializeTask.class);
 
@@ -37,7 +37,7 @@ class InitializeTask implements ITask {
 
     private final ShardInfo shardInfo;
     private final IRecordProcessor recordProcessor;
-    private final KinesisDataFetcher dataFetcher;
+    private final IDataFetcher dataFetcher;
     private final TaskType taskType = TaskType.INITIALIZE;
     private final ICheckpoint checkpoint;
     private final RecordProcessorCheckpointer recordProcessorCheckpointer;
@@ -49,14 +49,14 @@ class InitializeTask implements ITask {
     /**
      * Constructor.
      */
-    InitializeTask(ShardInfo shardInfo,
-                   IRecordProcessor recordProcessor,
-                   ICheckpoint checkpoint,
-                   RecordProcessorCheckpointer recordProcessorCheckpointer,
-                   KinesisDataFetcher dataFetcher,
-                   long backoffTimeMillis,
-                   StreamConfig streamConfig,
-                   GetRecordsCache getRecordsCache) {
+    public InitializeTask(ShardInfo shardInfo,
+                          IRecordProcessor recordProcessor,
+                          ICheckpoint checkpoint,
+                          RecordProcessorCheckpointer recordProcessorCheckpointer,
+                          IDataFetcher dataFetcher,
+                          long backoffTimeMillis,
+                          StreamConfig streamConfig,
+                          GetRecordsCache getRecordsCache) {
         this.shardInfo = shardInfo;
         this.recordProcessor = recordProcessor;
         this.checkpoint = checkpoint;

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/KinesisClientLibConfiguration.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/KinesisClientLibConfiguration.java
@@ -20,6 +20,7 @@ import java.util.Optional;
 import java.util.Set;
 
 import com.amazonaws.services.dynamodbv2.model.BillingMode;
+import com.amazonaws.services.kinesis.leases.impl.LeaseCleanupManager;
 import org.apache.commons.lang3.Validate;
 
 import com.amazonaws.ClientConfiguration;
@@ -61,7 +62,7 @@ public class KinesisClientLibConfiguration {
     public static final int DEFAULT_MAX_RECORDS = 10000;
 
     /**
-     * The default value for how long the {@link ShardConsumer} should sleep if no records are returned from the call to
+     * The default value for how long the {@link KinesisShardConsumer} should sleep if no records are returned from the call to
      * {@link com.amazonaws.services.kinesis.AmazonKinesis#getRecords(com.amazonaws.services.kinesis.model.GetRecordsRequest)}.
      */
     public static final long DEFAULT_IDLETIME_BETWEEN_READS_MILLIS = 1000L;
@@ -627,7 +628,7 @@ public class KinesisClientLibConfiguration {
      * @param billingMode The DDB Billing mode to set for lease table creation.
      * @param recordsFetcherFactory Factory to create the records fetcher to retrieve data from Kinesis for a given shard.
      * @param leaseCleanupIntervalMillis Rate at which to run lease cleanup thread in
-     *        {@link com.amazonaws.services.kinesis.leases.impl.LeaseCleanupManager}
+     *        {@link LeaseCleanupManager}
      * @param completedLeaseCleanupThresholdMillis Threshold in millis at which to check if there are any completed leases
      *        (leases for shards which have been closed as a result of a resharding operation) that need to be cleaned up.
      * @param garbageLeaseCleanupThresholdMillis Threshold in millis at which to check if there are any garbage leases
@@ -926,7 +927,7 @@ public class KinesisClientLibConfiguration {
     }
 
     /**
-     * @return Interval in millis at which to run lease cleanup thread in {@link com.amazonaws.services.kinesis.leases.impl.LeaseCleanupManager}
+     * @return Interval in millis at which to run lease cleanup thread in {@link LeaseCleanupManager}
      */
     public long leaseCleanupIntervalMillis() {
         return leaseCleanupIntervalMillis;
@@ -1030,7 +1031,7 @@ public class KinesisClientLibConfiguration {
      * Keeping it protected to forbid outside callers from depending on this internal object.
      * @return The initialPositionInStreamExtended object.
      */
-    protected InitialPositionInStreamExtended getInitialPositionInStreamExtended() {
+    public InitialPositionInStreamExtended getInitialPositionInStreamExtended() {
         return initialPositionInStreamExtended;
     }
 
@@ -1623,7 +1624,7 @@ public class KinesisClientLibConfiguration {
 
     /**
      * @param leaseCleanupIntervalMillis Rate at which to run lease cleanup thread in
-     * {@link com.amazonaws.services.kinesis.leases.impl.LeaseCleanupManager}
+     * {@link LeaseCleanupManager}
      * @return
      */
     public KinesisClientLibConfiguration withLeaseCleanupIntervalMillis(long leaseCleanupIntervalMillis) {

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/KinesisClientLibLeaseCoordinator.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/KinesisClientLibLeaseCoordinator.java
@@ -51,7 +51,7 @@ import com.amazonaws.services.kinesis.metrics.interfaces.IMetricsFactory;
 /**
  * This class is used to coordinate/manage leases owned by this worker process and to get/set checkpoints.
  */
-class KinesisClientLibLeaseCoordinator extends LeaseCoordinator<KinesisClientLease> implements ICheckpoint {
+public class KinesisClientLibLeaseCoordinator extends LeaseCoordinator<KinesisClientLease> implements ICheckpoint {
 
     private static final Log LOG = LogFactory.getLog(KinesisClientLibLeaseCoordinator.class);
 
@@ -368,7 +368,7 @@ class KinesisClientLibLeaseCoordinator extends LeaseCoordinator<KinesisClientLea
      *
      * @return LeaseManager
      */
-    ILeaseManager<KinesisClientLease> getLeaseManager() {
+    public ILeaseManager<KinesisClientLease> getLeaseManager() {
         return leaseManager;
     }
 

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/KinesisDataFetcher.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/KinesisDataFetcher.java
@@ -39,7 +39,7 @@ import lombok.Data;
 /**
  * Used to get data from Amazon Kinesis. Tracks iterator state internally.
  */
-class KinesisDataFetcher {
+public class KinesisDataFetcher implements IDataFetcher{
 
     private static final Log LOG = LogFactory.getLog(KinesisDataFetcher.class);
 
@@ -185,7 +185,7 @@ class KinesisDataFetcher {
      * @param sequenceNumber advance the iterator to the record at this sequence number.
      * @param initialPositionInStream The initialPositionInStream.
      */
-    void advanceIteratorTo(String sequenceNumber, InitialPositionInStreamExtended initialPositionInStream) {
+    public void advanceIteratorTo(String sequenceNumber, InitialPositionInStreamExtended initialPositionInStream) {
         if (sequenceNumber == null) {
             throw new IllegalArgumentException("SequenceNumber should not be null: shardId " + shardId);
         } else if (sequenceNumber.equals(SentinelCheckpoint.LATEST.toString())) {
@@ -276,11 +276,11 @@ class KinesisDataFetcher {
     /**
      * @return the shardEndReached
      */
-    protected boolean isShardEndReached() {
+    public boolean isShardEndReached() {
         return isShardEndReached;
     }
 
-    protected List<ChildShard> getChildShards() {
+    public List<ChildShard> getChildShards() {
         return childShards;
     }
 
@@ -290,5 +290,4 @@ class KinesisDataFetcher {
     String getNextIterator() {
         return nextIterator;
     }
-
 }

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/KinesisShardConsumerFactory.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/KinesisShardConsumerFactory.java
@@ -1,0 +1,48 @@
+package com.amazonaws.services.kinesis.clientlibrary.lib.worker;
+
+import com.amazonaws.services.kinesis.clientlibrary.interfaces.ICheckpoint;
+import com.amazonaws.services.kinesis.clientlibrary.interfaces.v2.IRecordProcessor;
+import com.amazonaws.services.kinesis.leases.impl.LeaseCleanupManager;
+import com.amazonaws.services.kinesis.metrics.interfaces.IMetricsFactory;
+
+import java.util.Optional;
+import java.util.concurrent.ExecutorService;
+
+public class KinesisShardConsumerFactory implements IShardConsumerFactory{
+
+    @Override
+    public IShardConsumer createShardConsumer(ShardInfo shardInfo,
+                                              StreamConfig streamConfig,
+                                              ICheckpoint checkpointTracker,
+                                              IRecordProcessor recordProcessor,
+                                              RecordProcessorCheckpointer recordProcessorCheckpointer,
+                                              KinesisClientLibLeaseCoordinator leaseCoordinator,
+                                              long parentShardPollIntervalMillis,
+                                              boolean cleanupLeasesUponShardCompletion,
+                                              ExecutorService executorService,
+                                              IMetricsFactory metricsFactory,
+                                              long taskBackoffTimeMillis,
+                                              boolean skipShardSyncAtWorkerInitializationIfLeasesExist,
+                                              Optional<Integer> retryGetRecordsInSeconds,
+                                              Optional<Integer> maxGetRecordsThreadPool,
+                                              KinesisClientLibConfiguration config, ShardSyncer shardSyncer, ShardSyncStrategy shardSyncStrategy,
+                                              LeaseCleanupManager leaseCleanupManager) {
+        return new KinesisShardConsumer(shardInfo,
+                streamConfig,
+                checkpointTracker,
+                recordProcessor,
+                recordProcessorCheckpointer,
+                leaseCoordinator,
+                parentShardPollIntervalMillis,
+                cleanupLeasesUponShardCompletion,
+                executorService,
+                metricsFactory,
+                taskBackoffTimeMillis,
+                skipShardSyncAtWorkerInitializationIfLeasesExist,
+                new KinesisDataFetcher(streamConfig.getStreamProxy(), shardInfo),
+                retryGetRecordsInSeconds,
+                maxGetRecordsThreadPool,
+                config, shardSyncer, shardSyncStrategy,
+                leaseCleanupManager);
+    }
+}

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/KinesisShutdownTask.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/KinesisShutdownTask.java
@@ -44,9 +44,9 @@ import java.util.stream.Collectors;
 /**
  * Task for invoking the RecordProcessor shutdown() callback.
  */
-class ShutdownTask implements ITask {
+public class KinesisShutdownTask implements ITask {
 
-    private static final Log LOG = LogFactory.getLog(ShutdownTask.class);
+    private static final Log LOG = LogFactory.getLog(KinesisShutdownTask.class);
 
     @VisibleForTesting
     static final int RETRY_RANDOM_MAX_RANGE = 50;
@@ -72,19 +72,19 @@ class ShutdownTask implements ITask {
      * Constructor.
      */
     // CHECKSTYLE:IGNORE ParameterNumber FOR NEXT 10 LINES
-    ShutdownTask(ShardInfo shardInfo,
-            IRecordProcessor recordProcessor,
-            RecordProcessorCheckpointer recordProcessorCheckpointer,
-            ShutdownReason reason,
-            IKinesisProxy kinesisProxy,
-            InitialPositionInStreamExtended initialPositionInStream,
-            boolean cleanupLeasesOfCompletedShards,
-            boolean ignoreUnexpectedChildShards,
-            KinesisClientLibLeaseCoordinator leaseCoordinator,
-            long backoffTimeMillis,
-            GetRecordsCache getRecordsCache, ShardSyncer shardSyncer,
-            ShardSyncStrategy shardSyncStrategy, List<ChildShard> childShards,
-            LeaseCleanupManager leaseCleanupManager) {
+    KinesisShutdownTask(ShardInfo shardInfo,
+                        IRecordProcessor recordProcessor,
+                        RecordProcessorCheckpointer recordProcessorCheckpointer,
+                        ShutdownReason reason,
+                        IKinesisProxy kinesisProxy,
+                        InitialPositionInStreamExtended initialPositionInStream,
+                        boolean cleanupLeasesOfCompletedShards,
+                        boolean ignoreUnexpectedChildShards,
+                        KinesisClientLibLeaseCoordinator leaseCoordinator,
+                        long backoffTimeMillis,
+                        GetRecordsCache getRecordsCache, ShardSyncer shardSyncer,
+                        ShardSyncStrategy shardSyncStrategy, List<ChildShard> childShards,
+                        LeaseCleanupManager leaseCleanupManager) {
         this.shardInfo = shardInfo;
         this.recordProcessor = recordProcessor;
         this.recordProcessorCheckpointer = recordProcessorCheckpointer;

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/MetricsCollectingTaskDecorator.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/MetricsCollectingTaskDecorator.java
@@ -21,7 +21,7 @@ import com.amazonaws.services.kinesis.metrics.interfaces.MetricsLevel;
 /**
  * Decorates an ITask and reports metrics about its timing and success/failure.
  */
-class MetricsCollectingTaskDecorator implements ITask {
+public class MetricsCollectingTaskDecorator implements ITask {
 
     private final ITask other;
     private final IMetricsFactory factory;

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/PeriodicShardSyncStrategy.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/PeriodicShardSyncStrategy.java
@@ -6,9 +6,9 @@ package com.amazonaws.services.kinesis.clientlibrary.lib.worker;
  */
 class PeriodicShardSyncStrategy implements ShardSyncStrategy {
 
-    private PeriodicShardSyncManager periodicShardSyncManager;
+    private IPeriodicShardSyncManager periodicShardSyncManager;
 
-    PeriodicShardSyncStrategy(PeriodicShardSyncManager periodicShardSyncManager) {
+    PeriodicShardSyncStrategy(IPeriodicShardSyncManager periodicShardSyncManager) {
         this.periodicShardSyncManager = periodicShardSyncManager;
     }
 

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/PrefetchGetRecordsCache.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/PrefetchGetRecordsCache.java
@@ -60,7 +60,7 @@ public class PrefetchGetRecordsCache implements GetRecordsCache {
     private PrefetchCounters prefetchCounters;
     private boolean started = false;
     private final String operation;
-    private final KinesisDataFetcher dataFetcher;
+    private final IDataFetcher dataFetcher;
     private final String shardId;
 
     /**

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ProcessTask.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ProcessTask.java
@@ -41,7 +41,7 @@ import com.amazonaws.services.kinesis.model.Shard;
 /**
  * Task for fetching data records and invoking processRecords() on the record processor instance.
  */
-class ProcessTask implements ITask {
+public class ProcessTask implements ITask {
 
     private static final Log LOG = LogFactory.getLog(ProcessTask.class);
 
@@ -55,7 +55,7 @@ class ProcessTask implements ITask {
     private final ShardInfo shardInfo;
     private final IRecordProcessor recordProcessor;
     private final RecordProcessorCheckpointer recordProcessorCheckpointer;
-    private final KinesisDataFetcher dataFetcher;
+    private final IDataFetcher dataFetcher;
     private final TaskType taskType = TaskType.PROCESS;
     private final StreamConfig streamConfig;
     private final long backoffTimeMillis;
@@ -81,7 +81,7 @@ class ProcessTask implements ITask {
      *            The retrieval strategy for fetching records from kinesis
      */
     public ProcessTask(ShardInfo shardInfo, StreamConfig streamConfig, IRecordProcessor recordProcessor,
-                       RecordProcessorCheckpointer recordProcessorCheckpointer, KinesisDataFetcher dataFetcher,
+                       RecordProcessorCheckpointer recordProcessorCheckpointer, IDataFetcher dataFetcher,
                        long backoffTimeMillis, boolean skipShardSyncAtWorkerInitializationIfLeasesExist,
                        GetRecordsCache getRecordsCache) {
         this(shardInfo, streamConfig, recordProcessor, recordProcessorCheckpointer, dataFetcher, backoffTimeMillis,
@@ -107,7 +107,7 @@ class ProcessTask implements ITask {
      *            determines how throttling events should be reported in the log.
      */
     public ProcessTask(ShardInfo shardInfo, StreamConfig streamConfig, IRecordProcessor recordProcessor,
-                       RecordProcessorCheckpointer recordProcessorCheckpointer, KinesisDataFetcher dataFetcher,
+                       RecordProcessorCheckpointer recordProcessorCheckpointer, IDataFetcher dataFetcher,
                        long backoffTimeMillis, boolean skipShardSyncAtWorkerInitializationIfLeasesExist,
                        ThrottlingReporter throttlingReporter, GetRecordsCache getRecordsCache) {
         super();

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/RecordProcessorCheckpointer.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/RecordProcessorCheckpointer.java
@@ -37,7 +37,7 @@ import com.amazonaws.services.kinesis.model.Record;
  * The Amazon Kinesis Client Library will instantiate an object and provide a reference to the application
  * RecordProcessor instance. Amazon Kinesis Client Library will create one instance per shard assignment.
  */
-class RecordProcessorCheckpointer implements IRecordProcessorCheckpointer {
+public class RecordProcessorCheckpointer implements IRecordProcessorCheckpointer {
 
     private static final Log LOG = LogFactory.getLog(RecordProcessorCheckpointer.class);
 
@@ -62,10 +62,10 @@ class RecordProcessorCheckpointer implements IRecordProcessorCheckpointer {
      * @param checkpoint Used to checkpoint progress of a RecordProcessor
      * @param validator Used for validating sequence numbers
      */
-    RecordProcessorCheckpointer(ShardInfo shardInfo,
-            ICheckpoint checkpoint,
-            SequenceNumberValidator validator,
-            IMetricsFactory metricsFactory) {
+    public RecordProcessorCheckpointer(ShardInfo shardInfo,
+                                       ICheckpoint checkpoint,
+                                       SequenceNumberValidator validator,
+                                       IMetricsFactory metricsFactory) {
         this.shardInfo = shardInfo;
         this.checkpoint = checkpoint;
         this.sequenceNumberValidator = validator;
@@ -231,7 +231,7 @@ class RecordProcessorCheckpointer implements IRecordProcessorCheckpointer {
     /**
      * @return the lastCheckpointValue
      */
-    ExtendedSequenceNumber getLastCheckpointValue() {
+    public ExtendedSequenceNumber getLastCheckpointValue() {
         return lastCheckpointValue;
     }
 
@@ -244,14 +244,14 @@ class RecordProcessorCheckpointer implements IRecordProcessorCheckpointer {
      *
      * @return the largest permitted checkpoint
      */
-    synchronized ExtendedSequenceNumber getLargestPermittedCheckpointValue() {
+    public synchronized ExtendedSequenceNumber getLargestPermittedCheckpointValue() {
         return largestPermittedCheckpointValue;
     }
 
     /**
      * @param largestPermittedCheckpointValue the largest permitted checkpoint
      */
-    synchronized void setLargestPermittedCheckpointValue(ExtendedSequenceNumber largestPermittedCheckpointValue) {
+    public synchronized void setLargestPermittedCheckpointValue(ExtendedSequenceNumber largestPermittedCheckpointValue) {
         this.largestPermittedCheckpointValue = largestPermittedCheckpointValue;
     }
 
@@ -262,7 +262,7 @@ class RecordProcessorCheckpointer implements IRecordProcessorCheckpointer {
      *
      * @param extendedSequenceNumber
      */
-    synchronized void setSequenceNumberAtShardEnd(ExtendedSequenceNumber extendedSequenceNumber) {
+    public synchronized void setSequenceNumberAtShardEnd(ExtendedSequenceNumber extendedSequenceNumber) {
         this.sequenceNumberAtShardEnd = extendedSequenceNumber;
     }
 

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/SequenceNumberValidator.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/SequenceNumberValidator.java
@@ -51,7 +51,7 @@ public class SequenceNumberValidator {
      * @param validateWithGetIterator Whether to attempt to get an iterator for this shard id and the sequence numbers
      *        being validated
      */
-    SequenceNumberValidator(IKinesisProxy proxy, String shardId, boolean validateWithGetIterator) {
+    public SequenceNumberValidator(IKinesisProxy proxy, String shardId, boolean validateWithGetIterator) {
         this.proxy = proxy;
         this.shardId = shardId;
         this.validateWithGetIterator = validateWithGetIterator;

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardEndShardSyncStrategy.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardEndShardSyncStrategy.java
@@ -17,10 +17,10 @@ class ShardEndShardSyncStrategy implements ShardSyncStrategy {
     private ShardSyncTaskManager shardSyncTaskManager;
 
     /** Runs periodic shard sync jobs in the background as an auditor process for shard-end syncs. */
-    private PeriodicShardSyncManager periodicShardSyncManager;
+    private IPeriodicShardSyncManager periodicShardSyncManager;
 
     ShardEndShardSyncStrategy(ShardSyncTaskManager shardSyncTaskManager,
-                              PeriodicShardSyncManager periodicShardSyncManager) {
+                              IPeriodicShardSyncManager periodicShardSyncManager) {
         this.shardSyncTaskManager = shardSyncTaskManager;
         this.periodicShardSyncManager = periodicShardSyncManager;
     }

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardSyncTask.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardSyncTask.java
@@ -30,7 +30,7 @@ import java.util.List;
  * It will clean up leases/activities for shards that have been completely processed (if
  * cleanupLeasesUponShardCompletion is true).
  */
-class ShardSyncTask implements ITask {
+public class ShardSyncTask implements ITask {
 
     private static final Log LOG = LogFactory.getLog(ShardSyncTask.class);
 
@@ -56,13 +56,13 @@ class ShardSyncTask implements ITask {
      * @param shardSyncer shardSyncer instance used to check and create new leases
      * @param latestShards latest snapshot of shards to reuse
      */
-    ShardSyncTask(IKinesisProxy kinesisProxy,
-            ILeaseManager<KinesisClientLease> leaseManager,
-            InitialPositionInStreamExtended initialPositionInStream,
-            boolean cleanupLeasesUponShardCompletion,
-            boolean ignoreUnexpectedChildShards,
-            long shardSyncTaskIdleTimeMillis,
-            ShardSyncer shardSyncer, List<Shard> latestShards) {
+    public ShardSyncTask(IKinesisProxy kinesisProxy,
+                         ILeaseManager<KinesisClientLease> leaseManager,
+                         InitialPositionInStreamExtended initialPositionInStream,
+                         boolean cleanupLeasesUponShardCompletion,
+                         boolean ignoreUnexpectedChildShards,
+                         long shardSyncTaskIdleTimeMillis,
+                         ShardSyncer shardSyncer, List<Shard> latestShards) {
         this.latestShards = latestShards;
         this.kinesisProxy = kinesisProxy;
         this.leaseManager = leaseManager;

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShutdownNotificationTask.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShutdownNotificationTask.java
@@ -21,14 +21,14 @@ import com.amazonaws.services.kinesis.clientlibrary.interfaces.v2.IShutdownNotif
 /**
  * Notifies record processor of incoming shutdown request, and gives them a chance to checkpoint.
  */
-class ShutdownNotificationTask implements ITask {
+public class ShutdownNotificationTask implements ITask {
 
     private final IRecordProcessor recordProcessor;
     private final IRecordProcessorCheckpointer recordProcessorCheckpointer;
     private final ShutdownNotification shutdownNotification;
     private final ShardInfo shardInfo;
 
-    ShutdownNotificationTask(IRecordProcessor recordProcessor, IRecordProcessorCheckpointer recordProcessorCheckpointer, ShutdownNotification shutdownNotification, ShardInfo shardInfo) {
+    public ShutdownNotificationTask(IRecordProcessor recordProcessor, IRecordProcessorCheckpointer recordProcessorCheckpointer, ShutdownNotification shutdownNotification, ShardInfo shardInfo) {
         this.recordProcessor = recordProcessor;
         this.recordProcessorCheckpointer = recordProcessorCheckpointer;
         this.shutdownNotification = shutdownNotification;

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShutdownReason.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShutdownReason.java
@@ -15,8 +15,8 @@
 package com.amazonaws.services.kinesis.clientlibrary.lib.worker;
 
 import com.amazonaws.services.kinesis.clientlibrary.types.ShutdownInput;
-import static com.amazonaws.services.kinesis.clientlibrary.lib.worker.ConsumerStates.ConsumerState;
-import static com.amazonaws.services.kinesis.clientlibrary.lib.worker.ConsumerStates.ShardConsumerState;
+import static com.amazonaws.services.kinesis.clientlibrary.lib.worker.KinesisConsumerStates.ConsumerState;
+import static com.amazonaws.services.kinesis.clientlibrary.lib.worker.KinesisConsumerStates.ShardConsumerState;
 
 
 /**
@@ -72,7 +72,7 @@ public enum ShutdownReason {
         return reason.rank > this.rank;
     }
 
-    ConsumerState getShutdownState() {
+    public ConsumerState getShutdownState() {
         return shutdownState;
     }
 }

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/StreamConfig.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/StreamConfig.java
@@ -19,7 +19,7 @@ import com.amazonaws.services.kinesis.clientlibrary.proxies.IKinesisProxy;
 /**
  * Used to capture stream configuration and pass it along.
  */
-class StreamConfig {
+public class StreamConfig {
 
     private final IKinesisProxy streamProxy;
     private final int maxRecords;
@@ -38,11 +38,11 @@ class StreamConfig {
      * @param initialPositionInStream Initial position in stream
      */
     StreamConfig(IKinesisProxy proxy,
-            int maxRecords,
-            long idleTimeInMilliseconds,
-            boolean callProcessRecordsEvenForEmptyRecordList,
-            boolean validateSequenceNumberBeforeCheckpointing,
-            InitialPositionInStreamExtended initialPositionInStream) {
+                        int maxRecords,
+                        long idleTimeInMilliseconds,
+                        boolean callProcessRecordsEvenForEmptyRecordList,
+                        boolean validateSequenceNumberBeforeCheckpointing,
+                        InitialPositionInStreamExtended initialPositionInStream) {
         this.streamProxy = proxy;
         this.maxRecords = maxRecords;
         this.idleTimeInMilliseconds = idleTimeInMilliseconds;
@@ -54,7 +54,7 @@ class StreamConfig {
     /**
      * @return the streamProxy
      */
-    IKinesisProxy getStreamProxy() {
+    public IKinesisProxy getStreamProxy() {
         return streamProxy;
     }
 
@@ -82,14 +82,14 @@ class StreamConfig {
     /**
      * @return the initialPositionInStream
      */
-    InitialPositionInStreamExtended getInitialPositionInStream() {
+    public InitialPositionInStreamExtended getInitialPositionInStream() {
         return initialPositionInStream;
     }
 
     /**
      * @return validateSequenceNumberBeforeCheckpointing
      */
-    boolean shouldValidateSequenceNumberBeforeCheckpointing() {
+    public boolean shouldValidateSequenceNumberBeforeCheckpointing() {
         return validateSequenceNumberBeforeCheckpointing;
     }
 }

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/SynchronousGetRecordsRetrievalStrategy.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/SynchronousGetRecordsRetrievalStrategy.java
@@ -24,7 +24,7 @@ import lombok.NonNull;
 @Data
 public class SynchronousGetRecordsRetrievalStrategy implements GetRecordsRetrievalStrategy {
     @NonNull
-    private final KinesisDataFetcher dataFetcher;
+    private final IDataFetcher dataFetcher;
 
     @Override
     public GetRecordsResult getRecords(final int maxRecords) {
@@ -44,7 +44,7 @@ public class SynchronousGetRecordsRetrievalStrategy implements GetRecordsRetriev
     }
     
     @Override
-    public KinesisDataFetcher getDataFetcher() {
+    public IDataFetcher getDataFetcher() {
         return dataFetcher;
     }
 }

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/TaskResult.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/TaskResult.java
@@ -22,7 +22,7 @@ import java.util.List;
  * Used to capture information from a task that we want to communicate back to the higher layer.
  * E.g. exception thrown when executing the task, if we reach end of a shard.
  */
-class TaskResult {
+public class TaskResult {
 
     // Did we reach the end of the shard while processing this task.
     private boolean shardEndReached;
@@ -38,7 +38,7 @@ class TaskResult {
     /**
      * @return the shardEndReached
      */
-    protected boolean isShardEndReached() {
+    public boolean isShardEndReached() {
         return shardEndReached;
     }
 
@@ -77,7 +77,7 @@ class TaskResult {
     /**
      * @param e Any exception encountered when running the process task.
      */
-    TaskResult(Exception e) {
+    public TaskResult(Exception e) {
         this(e, false);
     }
 

--- a/src/main/java/com/amazonaws/services/kinesis/leases/impl/LeaseCleanupManager.java
+++ b/src/main/java/com/amazonaws/services/kinesis/leases/impl/LeaseCleanupManager.java
@@ -114,7 +114,7 @@ public class LeaseCleanupManager {
             completedLeaseStopwatch.start();
             garbageLeaseStopwatch.start();
             deletionThreadPool.scheduleAtFixedRate(new LeaseCleanupThread(), INITIAL_DELAY, leaseCleanupIntervalMillis,
-                                                   TimeUnit.MILLISECONDS);
+                    TimeUnit.MILLISECONDS);
             isRunning = true;
         } else {
             LOG.info("Lease cleanup thread already running, no need to start.");
@@ -241,7 +241,7 @@ public class LeaseCleanupManager {
             if (!cleanedUpCompletedLease && !alreadyCheckedForGarbageCollection && timeToCheckForGarbageShard) {
                 // throws ResourceNotFoundException
                 wereChildShardsPresent = !CollectionUtils
-                            .isNullOrEmpty(getChildShardsFromService(shardInfo));
+                        .isNullOrEmpty(getChildShardsFromService(shardInfo));
             }
         } catch (ResourceNotFoundException e) {
             wasResourceNotFound = true;
@@ -296,7 +296,7 @@ public class LeaseCleanupManager {
 
         for (String childShardLeaseKey : childShardLeaseKeys) {
             final KinesisClientLease childShardLease = Optional.ofNullable(
-                    leaseManager.getLease(childShardLeaseKey))
+                            leaseManager.getLease(childShardLeaseKey))
                     .orElseThrow(() -> new IllegalStateException(
                             "Child lease " + childShardLeaseKey + " for completed shard not found in "
                                     + "lease table - not cleaning up lease " + lease));

--- a/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ConsumerStatesTest.java
+++ b/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ConsumerStatesTest.java
@@ -14,8 +14,8 @@
  */
 package com.amazonaws.services.kinesis.clientlibrary.lib.worker;
 
-import static com.amazonaws.services.kinesis.clientlibrary.lib.worker.ConsumerStates.ConsumerState;
-import static com.amazonaws.services.kinesis.clientlibrary.lib.worker.ConsumerStates.ShardConsumerState;
+import static com.amazonaws.services.kinesis.clientlibrary.lib.worker.KinesisConsumerStates.ConsumerState;
+import static com.amazonaws.services.kinesis.clientlibrary.lib.worker.KinesisConsumerStates.ShardConsumerState;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -50,7 +50,7 @@ import com.amazonaws.services.kinesis.leases.interfaces.ILeaseManager;
 public class ConsumerStatesTest {
 
     @Mock
-    private ShardConsumer consumer;
+    private KinesisShardConsumer consumer;
     @Mock
     private StreamConfig streamConfig;
     @Mock
@@ -251,9 +251,9 @@ public class ConsumerStatesTest {
                 equalTo((IRecordProcessorCheckpointer) recordProcessorCheckpointer)));
         assertThat(task, shutdownReqTask(ShutdownNotification.class, "shutdownNotification", equalTo(shutdownNotification)));
 
-        assertThat(state.successTransition(), equalTo(ConsumerStates.SHUTDOWN_REQUEST_COMPLETION_STATE));
+        assertThat(state.successTransition(), equalTo(KinesisConsumerStates.SHUTDOWN_REQUEST_COMPLETION_STATE));
         assertThat(state.shutdownTransition(ShutdownReason.REQUESTED),
-                equalTo(ConsumerStates.SHUTDOWN_REQUEST_COMPLETION_STATE));
+                equalTo(KinesisConsumerStates.SHUTDOWN_REQUEST_COMPLETION_STATE));
         assertThat(state.shutdownTransition(ShutdownReason.ZOMBIE),
                 equalTo(ShardConsumerState.SHUTTING_DOWN.getConsumerState()));
         assertThat(state.shutdownTransition(ShutdownReason.TERMINATE),
@@ -266,7 +266,7 @@ public class ConsumerStatesTest {
 
     @Test
     public void shutdownRequestCompleteStateTest() {
-        ConsumerState state = ConsumerStates.SHUTDOWN_REQUEST_COMPLETION_STATE;
+        ConsumerState state = KinesisConsumerStates.SHUTDOWN_REQUEST_COMPLETION_STATE;
 
         assertThat(state.createTask(consumer), nullValue());
 
@@ -345,9 +345,9 @@ public class ConsumerStatesTest {
         verify(shutdownNotification, never()).shutdownComplete();
     }
 
-    static <ValueType> ReflectionPropertyMatcher<ShutdownTask, ValueType> shutdownTask(Class<ValueType> valueTypeClass,
+    static <ValueType> ReflectionPropertyMatcher<KinesisShutdownTask, ValueType> shutdownTask(Class<ValueType> valueTypeClass,
                                                                                        String propertyName, Matcher<ValueType> matcher) {
-        return taskWith(ShutdownTask.class, valueTypeClass, propertyName, matcher);
+        return taskWith(KinesisShutdownTask.class, valueTypeClass, propertyName, matcher);
     }
 
     static <ValueType> ReflectionPropertyMatcher<ShutdownNotificationTask, ValueType> shutdownReqTask(

--- a/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/GracefulShutdownCoordinatorTest.java
+++ b/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/GracefulShutdownCoordinatorTest.java
@@ -49,7 +49,7 @@ public class GracefulShutdownCoordinatorTest {
     @Mock
     private Callable<GracefulShutdownContext> contextCallable;
     @Mock
-    private ConcurrentMap<ShardInfo, ShardConsumer> shardInfoConsumerMap;
+    private ConcurrentMap<ShardInfo, IShardConsumer> shardInfoConsumerMap;
 
     @Test
     public void testAllShutdownCompletedAlready() throws Exception {

--- a/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/PeriodicShardSyncManagerTest.java
+++ b/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/PeriodicShardSyncManagerTest.java
@@ -39,8 +39,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static com.amazonaws.services.kinesis.clientlibrary.lib.worker.PeriodicShardSyncManager.MAX_HASH_KEY;
-import static com.amazonaws.services.kinesis.clientlibrary.lib.worker.PeriodicShardSyncManager.MIN_HASH_KEY;
+import static com.amazonaws.services.kinesis.clientlibrary.lib.worker.KinesisPeriodicShardSyncManager.MAX_HASH_KEY;
+import static com.amazonaws.services.kinesis.clientlibrary.lib.worker.KinesisPeriodicShardSyncManager.MIN_HASH_KEY;
 import static com.amazonaws.services.kinesis.leases.impl.HashKeyRangeForLease.deserialize;
 import static org.mockito.Mockito.when;
 
@@ -52,10 +52,10 @@ public class PeriodicShardSyncManagerTest {
     public static final int LEASES_RECOVERY_AUDITOR_INCONSISTENCY_CONFIDENCE_THRESHOLD = 3;
 
     /** Manager for PERIODIC shard sync strategy */
-    private PeriodicShardSyncManager periodicShardSyncManager;
+    private KinesisPeriodicShardSyncManager periodicShardSyncManager;
 
     /** Manager for SHARD_END shard sync strategy */
-    private PeriodicShardSyncManager auditorPeriodicShardSyncManager;
+    private KinesisPeriodicShardSyncManager auditorPeriodicShardSyncManager;
 
     @Mock
     private LeaderDecider leaderDecider;
@@ -70,10 +70,10 @@ public class PeriodicShardSyncManagerTest {
 
     @Before
     public void setup() {
-        periodicShardSyncManager = new PeriodicShardSyncManager(WORKER_ID, leaderDecider, shardSyncTask,
+        periodicShardSyncManager = new KinesisPeriodicShardSyncManager(WORKER_ID, leaderDecider, shardSyncTask,
                 metricsFactory, leaseManager, kinesisProxy, false, LEASES_RECOVERY_AUDITOR_EXECUTION_FREQUENCY_MILLIS,
                 LEASES_RECOVERY_AUDITOR_INCONSISTENCY_CONFIDENCE_THRESHOLD);
-        auditorPeriodicShardSyncManager = new PeriodicShardSyncManager(WORKER_ID, leaderDecider, shardSyncTask,
+        auditorPeriodicShardSyncManager = new KinesisPeriodicShardSyncManager(WORKER_ID, leaderDecider, shardSyncTask,
                 metricsFactory, leaseManager, kinesisProxy, true, LEASES_RECOVERY_AUDITOR_EXECUTION_FREQUENCY_MILLIS, 
                 LEASES_RECOVERY_AUDITOR_INCONSISTENCY_CONFIDENCE_THRESHOLD);
     }
@@ -92,7 +92,7 @@ public class PeriodicShardSyncManagerTest {
             lease.setCheckpoint(ExtendedSequenceNumber.TRIM_HORIZON);
             return lease;
         }).collect(Collectors.toList());
-        Assert.assertTrue(PeriodicShardSyncManager
+        Assert.assertTrue(KinesisPeriodicShardSyncManager
                 .checkForHoleInHashKeyRanges(hashRanges).isPresent());
     }
 
@@ -110,7 +110,7 @@ public class PeriodicShardSyncManagerTest {
             lease.setCheckpoint(ExtendedSequenceNumber.TRIM_HORIZON);
             return lease;
         }).collect(Collectors.toList());
-        Assert.assertFalse(PeriodicShardSyncManager
+        Assert.assertFalse(KinesisPeriodicShardSyncManager
                 .checkForHoleInHashKeyRanges(hashRanges).isPresent());
     }
 
@@ -128,7 +128,7 @@ public class PeriodicShardSyncManagerTest {
             lease.setCheckpoint(ExtendedSequenceNumber.TRIM_HORIZON);
             return lease;
         }).collect(Collectors.toList());
-        Assert.assertFalse(PeriodicShardSyncManager
+        Assert.assertFalse(KinesisPeriodicShardSyncManager
                 .checkForHoleInHashKeyRanges(hashRanges).isPresent());
     }
 
@@ -147,7 +147,7 @@ public class PeriodicShardSyncManagerTest {
             lease.setCheckpoint(ExtendedSequenceNumber.TRIM_HORIZON);
             return lease;
         }).collect(Collectors.toList());
-        Assert.assertFalse(PeriodicShardSyncManager
+        Assert.assertFalse(KinesisPeriodicShardSyncManager
                 .checkForHoleInHashKeyRanges(hashRanges).isPresent());
     }
 

--- a/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardConsumerTest.java
+++ b/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardConsumerTest.java
@@ -85,7 +85,7 @@ import com.amazonaws.services.kinesis.model.Shard;
 import com.amazonaws.services.kinesis.model.ShardIteratorType;
 
 /**
- * Unit tests of {@link ShardConsumer}.
+ * Unit tests of {@link KinesisShardConsumer}.
  */
 @RunWith(MockitoJUnitRunner.class)
 public class ShardConsumerTest {
@@ -160,8 +160,8 @@ public class ShardConsumerTest {
                         callProcessRecordsForEmptyRecordList,
                         skipCheckpointValidationValue, INITIAL_POSITION_LATEST);
 
-        ShardConsumer consumer =
-                new ShardConsumer(shardInfo,
+        KinesisShardConsumer consumer =
+                new KinesisShardConsumer(shardInfo,
                         streamConfig,
                         checkpoint,
                         processor,
@@ -175,19 +175,19 @@ public class ShardConsumerTest {
                         config,
                         shardSyncer,
                         shardSyncStrategy);
-        assertThat(consumer.getCurrentState(), is(equalTo(ConsumerStates.ShardConsumerState.WAITING_ON_PARENT_SHARDS)));
+        assertThat(consumer.getCurrentState(), is(equalTo(KinesisConsumerStates.ShardConsumerState.WAITING_ON_PARENT_SHARDS)));
         consumer.consumeShard(); // initialize
         Thread.sleep(50L);
-        assertThat(consumer.getCurrentState(), is(equalTo(ConsumerStates.ShardConsumerState.WAITING_ON_PARENT_SHARDS)));
+        assertThat(consumer.getCurrentState(), is(equalTo(KinesisConsumerStates.ShardConsumerState.WAITING_ON_PARENT_SHARDS)));
         consumer.consumeShard(); // initialize
         Thread.sleep(50L);
-        assertThat(consumer.getCurrentState(), is(equalTo(ConsumerStates.ShardConsumerState.INITIALIZING)));
+        assertThat(consumer.getCurrentState(), is(equalTo(KinesisConsumerStates.ShardConsumerState.INITIALIZING)));
         consumer.consumeShard(); // initialize
         Thread.sleep(50L);
-        assertThat(consumer.getCurrentState(), is(equalTo(ConsumerStates.ShardConsumerState.INITIALIZING)));
+        assertThat(consumer.getCurrentState(), is(equalTo(KinesisConsumerStates.ShardConsumerState.INITIALIZING)));
         consumer.consumeShard(); // initialize
         Thread.sleep(50L);
-        assertThat(consumer.getCurrentState(), is(equalTo(ConsumerStates.ShardConsumerState.INITIALIZING)));
+        assertThat(consumer.getCurrentState(), is(equalTo(KinesisConsumerStates.ShardConsumerState.INITIALIZING)));
     }
 
     /**
@@ -210,8 +210,8 @@ public class ShardConsumerTest {
                         callProcessRecordsForEmptyRecordList,
                         skipCheckpointValidationValue, INITIAL_POSITION_LATEST);
 
-        ShardConsumer consumer =
-                new ShardConsumer(shardInfo,
+        KinesisShardConsumer consumer =
+                new KinesisShardConsumer(shardInfo,
                         streamConfig,
                         checkpoint,
                         processor,
@@ -226,21 +226,21 @@ public class ShardConsumerTest {
                         shardSyncer,
                         shardSyncStrategy);
 
-        assertThat(consumer.getCurrentState(), is(equalTo(ConsumerStates.ShardConsumerState.WAITING_ON_PARENT_SHARDS)));
+        assertThat(consumer.getCurrentState(), is(equalTo(KinesisConsumerStates.ShardConsumerState.WAITING_ON_PARENT_SHARDS)));
         consumer.consumeShard(); // initialize
         Thread.sleep(50L);
-        assertThat(consumer.getCurrentState(), is(equalTo(ConsumerStates.ShardConsumerState.WAITING_ON_PARENT_SHARDS)));
+        assertThat(consumer.getCurrentState(), is(equalTo(KinesisConsumerStates.ShardConsumerState.WAITING_ON_PARENT_SHARDS)));
 
         doThrow(new RejectedExecutionException()).when(spyExecutorService).submit(any(InitializeTask.class));
         consumer.consumeShard(); // initialize
         Thread.sleep(50L);
-        assertThat(consumer.getCurrentState(), is(equalTo(ConsumerStates.ShardConsumerState.INITIALIZING)));
+        assertThat(consumer.getCurrentState(), is(equalTo(KinesisConsumerStates.ShardConsumerState.INITIALIZING)));
         consumer.consumeShard(); // initialize
         Thread.sleep(50L);
-        assertThat(consumer.getCurrentState(), is(equalTo(ConsumerStates.ShardConsumerState.INITIALIZING)));
+        assertThat(consumer.getCurrentState(), is(equalTo(KinesisConsumerStates.ShardConsumerState.INITIALIZING)));
         consumer.consumeShard(); // initialize
         Thread.sleep(50L);
-        assertThat(consumer.getCurrentState(), is(equalTo(ConsumerStates.ShardConsumerState.INITIALIZING)));
+        assertThat(consumer.getCurrentState(), is(equalTo(KinesisConsumerStates.ShardConsumerState.INITIALIZING)));
     }
 
     @Test
@@ -258,8 +258,8 @@ public class ShardConsumerTest {
                         callProcessRecordsForEmptyRecordList,
                         skipCheckpointValidationValue, INITIAL_POSITION_LATEST);
 
-        ShardConsumer consumer =
-                new ShardConsumer(shardInfo,
+        KinesisShardConsumer consumer =
+                new KinesisShardConsumer(shardInfo,
                         streamConfig,
                         checkpoint,
                         processor,
@@ -273,19 +273,19 @@ public class ShardConsumerTest {
                         config,
                         shardSyncer,
                         shardSyncStrategy);
-        assertThat(consumer.getCurrentState(), is(equalTo(ConsumerStates.ShardConsumerState.WAITING_ON_PARENT_SHARDS)));
+        assertThat(consumer.getCurrentState(), is(equalTo(KinesisConsumerStates.ShardConsumerState.WAITING_ON_PARENT_SHARDS)));
         consumer.consumeShard();
         Thread.sleep(50L);
-        assertThat(consumer.getCurrentState(), is(equalTo(ConsumerStates.ShardConsumerState.WAITING_ON_PARENT_SHARDS)));
+        assertThat(consumer.getCurrentState(), is(equalTo(KinesisConsumerStates.ShardConsumerState.WAITING_ON_PARENT_SHARDS)));
         consumer.consumeShard();
         Thread.sleep(50L);
-        assertThat(consumer.getCurrentState(), is(equalTo(ConsumerStates.ShardConsumerState.INITIALIZING)));
+        assertThat(consumer.getCurrentState(), is(equalTo(KinesisConsumerStates.ShardConsumerState.INITIALIZING)));
         consumer.consumeShard();
         Thread.sleep(50L);
-        assertThat(consumer.getCurrentState(), is(equalTo(ConsumerStates.ShardConsumerState.SHUTTING_DOWN)));
+        assertThat(consumer.getCurrentState(), is(equalTo(KinesisConsumerStates.ShardConsumerState.SHUTTING_DOWN)));
         consumer.consumeShard();
         Thread.sleep(50L);
-        assertThat(consumer.getCurrentState(), is(equalTo(ConsumerStates.ShardConsumerState.SHUTDOWN_COMPLETE)));
+        assertThat(consumer.getCurrentState(), is(equalTo(KinesisConsumerStates.ShardConsumerState.SHUTDOWN_COMPLETE)));
     }
 
 
@@ -300,8 +300,8 @@ public class ShardConsumerTest {
                         callProcessRecordsForEmptyRecordList,
                         skipCheckpointValidationValue, INITIAL_POSITION_LATEST);
 
-        ShardConsumer consumer =
-                new ShardConsumer(shardInfo,
+        KinesisShardConsumer consumer =
+                new KinesisShardConsumer(shardInfo,
                         streamConfig,
                         checkpoint,
                         processor,
@@ -324,10 +324,10 @@ public class ShardConsumerTest {
         when(checkpoint.getCheckpointObject(anyString())).thenReturn(
                 new Checkpoint(checkpointSequenceNumber, pendingCheckpointSequenceNumber));
 
-        assertThat(consumer.getCurrentState(), is(equalTo(ConsumerStates.ShardConsumerState.WAITING_ON_PARENT_SHARDS)));
+        assertThat(consumer.getCurrentState(), is(equalTo(KinesisConsumerStates.ShardConsumerState.WAITING_ON_PARENT_SHARDS)));
         consumer.consumeShard(); // submit BlockOnParentShardTask
         Thread.sleep(50L);
-        assertThat(consumer.getCurrentState(), is(equalTo(ConsumerStates.ShardConsumerState.WAITING_ON_PARENT_SHARDS)));
+        assertThat(consumer.getCurrentState(), is(equalTo(KinesisConsumerStates.ShardConsumerState.WAITING_ON_PARENT_SHARDS)));
         verify(processor, times(0)).initialize(any(InitializationInput.class));
 
         // Throw Error when IRecordProcessor.initialize() is invoked.
@@ -335,7 +335,7 @@ public class ShardConsumerTest {
 
         consumer.consumeShard(); // submit InitializeTask
         Thread.sleep(50L);
-        assertThat(consumer.getCurrentState(), is(equalTo(ConsumerStates.ShardConsumerState.INITIALIZING)));
+        assertThat(consumer.getCurrentState(), is(equalTo(KinesisConsumerStates.ShardConsumerState.INITIALIZING)));
         verify(processor, times(1)).initialize(argThat(
                 initializationInputMatcher(checkpointSequenceNumber, pendingCheckpointSequenceNumber)));
 
@@ -347,7 +347,7 @@ public class ShardConsumerTest {
             assertThat(e.getCause(), instanceOf(ExecutionException.class));
         }
         Thread.sleep(50L);
-        assertThat(consumer.getCurrentState(), is(equalTo(ConsumerStates.ShardConsumerState.INITIALIZING)));
+        assertThat(consumer.getCurrentState(), is(equalTo(KinesisConsumerStates.ShardConsumerState.INITIALIZING)));
         verify(processor, times(1)).initialize(argThat(
                 initializationInputMatcher(checkpointSequenceNumber, pendingCheckpointSequenceNumber)));
 
@@ -355,7 +355,7 @@ public class ShardConsumerTest {
 
         consumer.consumeShard(); // submit InitializeTask again.
         Thread.sleep(50L);
-        assertThat(consumer.getCurrentState(), is(equalTo(ConsumerStates.ShardConsumerState.INITIALIZING)));
+        assertThat(consumer.getCurrentState(), is(equalTo(KinesisConsumerStates.ShardConsumerState.INITIALIZING)));
         verify(processor, times(2)).initialize(argThat(
                 initializationInputMatcher(checkpointSequenceNumber, pendingCheckpointSequenceNumber)));
         verify(processor, times(2)).initialize(any(InitializationInput.class)); // no other calls with different args
@@ -363,11 +363,11 @@ public class ShardConsumerTest {
         // Checking the status of submitted InitializeTask from above should pass.
         consumer.consumeShard();
         Thread.sleep(50L);
-        assertThat(consumer.getCurrentState(), is(equalTo(ConsumerStates.ShardConsumerState.PROCESSING)));
+        assertThat(consumer.getCurrentState(), is(equalTo(KinesisConsumerStates.ShardConsumerState.PROCESSING)));
     }
 
     /**
-     * Test method for {@link ShardConsumer#consumeShard()}
+     * Test method for {@link KinesisShardConsumer#consumeShard()}
      */
     @Test
     public final void testConsumeShard() throws Exception {
@@ -420,8 +420,8 @@ public class ShardConsumerTest {
                 any(IMetricsFactory.class), anyInt()))
                 .thenReturn(getRecordsCache);
 
-        ShardConsumer consumer =
-                new ShardConsumer(shardInfo,
+        KinesisShardConsumer consumer =
+                new KinesisShardConsumer(shardInfo,
                         streamConfig,
                         checkpoint,
                         processor,
@@ -440,11 +440,11 @@ public class ShardConsumerTest {
                         shardSyncer,
                         shardSyncStrategy);
 
-        assertThat(consumer.getCurrentState(), is(equalTo(ConsumerStates.ShardConsumerState.WAITING_ON_PARENT_SHARDS)));
+        assertThat(consumer.getCurrentState(), is(equalTo(KinesisConsumerStates.ShardConsumerState.WAITING_ON_PARENT_SHARDS)));
         consumer.consumeShard(); // check on parent shards
         Thread.sleep(50L);
         consumer.consumeShard(); // start initialization
-        assertThat(consumer.getCurrentState(), is(equalTo(ConsumerStates.ShardConsumerState.INITIALIZING)));
+        assertThat(consumer.getCurrentState(), is(equalTo(KinesisConsumerStates.ShardConsumerState.INITIALIZING)));
         consumer.consumeShard(); // initialize
         processor.getInitializeLatch().await(5, TimeUnit.SECONDS);
         verify(getRecordsCache).start();
@@ -454,7 +454,7 @@ public class ShardConsumerTest {
             boolean newTaskSubmitted = consumer.consumeShard();
             if (newTaskSubmitted) {
                 LOG.debug("New processing task was submitted, call # " + i);
-                assertThat(consumer.getCurrentState(), is(equalTo(ConsumerStates.ShardConsumerState.PROCESSING)));
+                assertThat(consumer.getCurrentState(), is(equalTo(KinesisConsumerStates.ShardConsumerState.PROCESSING)));
                 // CHECKSTYLE:IGNORE ModifiedControlVariable FOR NEXT 1 LINES
                 i += maxRecords;
             }
@@ -469,21 +469,21 @@ public class ShardConsumerTest {
         assertThat(processor.getNotifyShutdownLatch().await(1, TimeUnit.SECONDS), is(true));
         Thread.sleep(50);
         assertThat(consumer.getShutdownReason(), equalTo(ShutdownReason.REQUESTED));
-        assertThat(consumer.getCurrentState(), equalTo(ConsumerStates.ShardConsumerState.SHUTDOWN_REQUESTED));
+        assertThat(consumer.getCurrentState(), equalTo(KinesisConsumerStates.ShardConsumerState.SHUTDOWN_REQUESTED));
         verify(shutdownNotification).shutdownNotificationComplete();
         assertThat(processor.isShutdownNotificationCalled(), equalTo(true));
         consumer.consumeShard();
         Thread.sleep(50);
-        assertThat(consumer.getCurrentState(), equalTo(ConsumerStates.ShardConsumerState.SHUTDOWN_REQUESTED));
+        assertThat(consumer.getCurrentState(), equalTo(KinesisConsumerStates.ShardConsumerState.SHUTDOWN_REQUESTED));
 
         consumer.beginShutdown();
         Thread.sleep(50L);
         assertThat(consumer.getShutdownReason(), equalTo(ShutdownReason.ZOMBIE));
-        assertThat(consumer.getCurrentState(), is(equalTo(ConsumerStates.ShardConsumerState.SHUTTING_DOWN)));
+        assertThat(consumer.getCurrentState(), is(equalTo(KinesisConsumerStates.ShardConsumerState.SHUTTING_DOWN)));
         consumer.beginShutdown();
         consumer.consumeShard();
         verify(shutdownNotification, atLeastOnce()).shutdownComplete();
-        assertThat(consumer.getCurrentState(), is(equalTo(ConsumerStates.ShardConsumerState.SHUTDOWN_COMPLETE)));
+        assertThat(consumer.getCurrentState(), is(equalTo(KinesisConsumerStates.ShardConsumerState.SHUTDOWN_COMPLETE)));
         assertThat(processor.getShutdownReason(), is(equalTo(ShutdownReason.ZOMBIE)));
 
         verify(getRecordsCache).shutdown();
@@ -524,8 +524,8 @@ public class ShardConsumerTest {
         when(recordProcessorCheckpointer.getLastCheckpointValue()).thenReturn(ExtendedSequenceNumber.SHARD_END);
         when(streamConfig.getStreamProxy()).thenReturn(streamProxy);
 
-        final ShardConsumer consumer =
-                new ShardConsumer(shardInfo,
+        final KinesisShardConsumer consumer =
+                new KinesisShardConsumer(shardInfo,
                         streamConfig,
                         checkpoint,
                         processor,
@@ -544,21 +544,21 @@ public class ShardConsumerTest {
                         shardSyncer,
                         shardSyncStrategy);
 
-        assertThat(consumer.getCurrentState(), is(equalTo(ConsumerStates.ShardConsumerState.WAITING_ON_PARENT_SHARDS)));
+        assertThat(consumer.getCurrentState(), is(equalTo(KinesisConsumerStates.ShardConsumerState.WAITING_ON_PARENT_SHARDS)));
         verify(parentLease, times(0)).getCheckpoint();
         consumer.consumeShard(); // check on parent shards
         Thread.sleep(parentShardPollIntervalMillis * 2);
-        assertThat(consumer.getCurrentState(), is(equalTo(ConsumerStates.ShardConsumerState.WAITING_ON_PARENT_SHARDS)));
+        assertThat(consumer.getCurrentState(), is(equalTo(KinesisConsumerStates.ShardConsumerState.WAITING_ON_PARENT_SHARDS)));
         verify(parentLease, times(1)).getCheckpoint();
         consumer.notifyShutdownRequested(shutdownNotification);
         verify(shutdownNotification, times(0)).shutdownComplete();
         assertThat(consumer.getShutdownReason(), equalTo(ShutdownReason.REQUESTED));
-        assertThat(consumer.getCurrentState(), is(equalTo(ConsumerStates.ShardConsumerState.WAITING_ON_PARENT_SHARDS)));
+        assertThat(consumer.getCurrentState(), is(equalTo(KinesisConsumerStates.ShardConsumerState.WAITING_ON_PARENT_SHARDS)));
         consumer.consumeShard();
-        assertThat(consumer.getCurrentState(), is(equalTo(ConsumerStates.ShardConsumerState.SHUTTING_DOWN)));
+        assertThat(consumer.getCurrentState(), is(equalTo(KinesisConsumerStates.ShardConsumerState.SHUTTING_DOWN)));
         Thread.sleep(50L);
         consumer.beginShutdown();
-        assertThat(consumer.getCurrentState(), is(equalTo(ConsumerStates.ShardConsumerState.SHUTDOWN_COMPLETE)));
+        assertThat(consumer.getCurrentState(), is(equalTo(KinesisConsumerStates.ShardConsumerState.SHUTDOWN_COMPLETE)));
         assertThat(consumer.isShutdown(), is(true));
         verify(shutdownNotification, times(1)).shutdownComplete();
         consumer.beginShutdown();
@@ -583,7 +583,7 @@ public class ShardConsumerTest {
     }
 
     /**
-     * Test method for {@link ShardConsumer#consumeShard()} that ensures a transient error thrown from the record
+     * Test method for {@link KinesisShardConsumer#consumeShard()} that ensures a transient error thrown from the record
      * processor's shutdown method with reason zombie will be retried.
      */
     @Test
@@ -646,8 +646,8 @@ public class ShardConsumerTest {
                 metricsFactory
         );
 
-        ShardConsumer consumer =
-                new ShardConsumer(shardInfo,
+        KinesisShardConsumer consumer =
+                new KinesisShardConsumer(shardInfo,
                         streamConfig,
                         checkpoint,
                         processor,
@@ -667,11 +667,11 @@ public class ShardConsumerTest {
                         shardSyncStrategy);
 
         when(leaseCoordinator.updateLease(any(KinesisClientLease.class), any(UUID.class))).thenReturn(true);
-        assertThat(consumer.getCurrentState(), is(equalTo(ConsumerStates.ShardConsumerState.WAITING_ON_PARENT_SHARDS)));
+        assertThat(consumer.getCurrentState(), is(equalTo(KinesisConsumerStates.ShardConsumerState.WAITING_ON_PARENT_SHARDS)));
         consumer.consumeShard(); // check on parent shards
         Thread.sleep(50L);
         consumer.consumeShard(); // start initialization
-        assertThat(consumer.getCurrentState(), is(equalTo(ConsumerStates.ShardConsumerState.INITIALIZING)));
+        assertThat(consumer.getCurrentState(), is(equalTo(KinesisConsumerStates.ShardConsumerState.INITIALIZING)));
         consumer.consumeShard(); // initialize
         processor.getInitializeLatch().await(5, TimeUnit.SECONDS);
         verify(getRecordsCache).start();
@@ -681,7 +681,7 @@ public class ShardConsumerTest {
             boolean newTaskSubmitted = consumer.consumeShard();
             if (newTaskSubmitted) {
                 LOG.debug("New processing task was submitted, call # " + i);
-                assertThat(consumer.getCurrentState(), is(equalTo(ConsumerStates.ShardConsumerState.PROCESSING)));
+                assertThat(consumer.getCurrentState(), is(equalTo(KinesisConsumerStates.ShardConsumerState.PROCESSING)));
                 // CHECKSTYLE:IGNORE ModifiedControlVariable FOR NEXT 1 LINES
                 i += maxRecords;
             }
@@ -709,12 +709,12 @@ public class ShardConsumerTest {
         // Wait for shutdown complete now that terminate shutdown is successful
         for (int i = 0; i < 100; i++) {
             consumer.consumeShard();
-            if (consumer.getCurrentState() == ConsumerStates.ShardConsumerState.SHUTDOWN_COMPLETE) {
+            if (consumer.getCurrentState() == KinesisConsumerStates.ShardConsumerState.SHUTDOWN_COMPLETE) {
                 break;
             }
             Thread.sleep(50L);
         }
-        assertThat(consumer.getCurrentState(), equalTo(ConsumerStates.ShardConsumerState.SHUTDOWN_COMPLETE));
+        assertThat(consumer.getCurrentState(), equalTo(KinesisConsumerStates.ShardConsumerState.SHUTDOWN_COMPLETE));
 
         assertThat(processor.getShutdownReason(), is(equalTo(ShutdownReason.TERMINATE)));
 
@@ -732,7 +732,7 @@ public class ShardConsumerTest {
 
 
     /**
-     * Test method for {@link ShardConsumer#consumeShard()} that ensures the shardConsumer gets shutdown with shutdown
+     * Test method for {@link KinesisShardConsumer#consumeShard()} that ensures the shardConsumer gets shutdown with shutdown
      * reason TERMINATE when the shard end is reached.
      */
     @Test
@@ -795,8 +795,8 @@ public class ShardConsumerTest {
                 metricsFactory
         );
 
-        ShardConsumer consumer =
-                new ShardConsumer(shardInfo,
+        KinesisShardConsumer consumer =
+                new KinesisShardConsumer(shardInfo,
                         streamConfig,
                         checkpoint,
                         processor,
@@ -818,11 +818,11 @@ public class ShardConsumerTest {
         when(leaseCoordinator.getCurrentlyHeldLease(shardInfo.getShardId())).thenReturn(currentLease);
         when(leaseCoordinator.updateLease(any(KinesisClientLease.class), any(UUID.class))).thenReturn(true);
 
-        assertThat(consumer.getCurrentState(), is(equalTo(ConsumerStates.ShardConsumerState.WAITING_ON_PARENT_SHARDS)));
+        assertThat(consumer.getCurrentState(), is(equalTo(KinesisConsumerStates.ShardConsumerState.WAITING_ON_PARENT_SHARDS)));
         consumer.consumeShard(); // check on parent shards
         Thread.sleep(50L);
         consumer.consumeShard(); // start initialization
-        assertThat(consumer.getCurrentState(), is(equalTo(ConsumerStates.ShardConsumerState.INITIALIZING)));
+        assertThat(consumer.getCurrentState(), is(equalTo(KinesisConsumerStates.ShardConsumerState.INITIALIZING)));
         consumer.consumeShard(); // initialize
         processor.getInitializeLatch().await(5, TimeUnit.SECONDS);
         verify(getRecordsCache).start();
@@ -832,7 +832,7 @@ public class ShardConsumerTest {
             boolean newTaskSubmitted = consumer.consumeShard();
             if (newTaskSubmitted) {
                 LOG.debug("New processing task was submitted, call # " + i);
-                assertThat(consumer.getCurrentState(), is(equalTo(ConsumerStates.ShardConsumerState.PROCESSING)));
+                assertThat(consumer.getCurrentState(), is(equalTo(KinesisConsumerStates.ShardConsumerState.PROCESSING)));
                 // CHECKSTYLE:IGNORE ModifiedControlVariable FOR NEXT 1 LINES
                 i += maxRecords;
             }
@@ -860,12 +860,12 @@ public class ShardConsumerTest {
         // Wait for shutdown complete now that terminate shutdown is successful
         for (int i = 0; i < 100; i++) {
             consumer.consumeShard();
-            if (consumer.getCurrentState() == ConsumerStates.ShardConsumerState.SHUTDOWN_COMPLETE) {
+            if (consumer.getCurrentState() == KinesisConsumerStates.ShardConsumerState.SHUTDOWN_COMPLETE) {
                 break;
             }
             Thread.sleep(50L);
         }
-        assertThat(consumer.getCurrentState(), equalTo(ConsumerStates.ShardConsumerState.SHUTDOWN_COMPLETE));
+        assertThat(consumer.getCurrentState(), equalTo(KinesisConsumerStates.ShardConsumerState.SHUTDOWN_COMPLETE));
 
         assertThat(processor.getShutdownReason(), is(equalTo(ShutdownReason.TERMINATE)));
 
@@ -881,7 +881,7 @@ public class ShardConsumerTest {
     }
 
     /**
-     * Test method for {@link ShardConsumer#consumeShard()} that starts from initial position of type AT_TIMESTAMP.
+     * Test method for {@link KinesisShardConsumer#consumeShard()} that starts from initial position of type AT_TIMESTAMP.
      */
     @Test
     public final void testConsumeShardWithInitialPositionAtTimestamp() throws Exception {
@@ -938,8 +938,8 @@ public class ShardConsumerTest {
                 any(IMetricsFactory.class), anyInt()))
                 .thenReturn(getRecordsCache);
 
-        ShardConsumer consumer =
-                new ShardConsumer(shardInfo,
+        KinesisShardConsumer consumer =
+                new KinesisShardConsumer(shardInfo,
                         streamConfig,
                         checkpoint,
                         processor,
@@ -958,11 +958,11 @@ public class ShardConsumerTest {
                         shardSyncer,
                         shardSyncStrategy);
 
-        assertThat(consumer.getCurrentState(), is(equalTo(ConsumerStates.ShardConsumerState.WAITING_ON_PARENT_SHARDS)));
+        assertThat(consumer.getCurrentState(), is(equalTo(KinesisConsumerStates.ShardConsumerState.WAITING_ON_PARENT_SHARDS)));
         consumer.consumeShard(); // check on parent shards
         Thread.sleep(50L);
         consumer.consumeShard(); // start initialization
-        assertThat(consumer.getCurrentState(), is(equalTo(ConsumerStates.ShardConsumerState.INITIALIZING)));
+        assertThat(consumer.getCurrentState(), is(equalTo(KinesisConsumerStates.ShardConsumerState.INITIALIZING)));
         consumer.consumeShard(); // initialize
         Thread.sleep(50L);
 
@@ -973,7 +973,7 @@ public class ShardConsumerTest {
             boolean newTaskSubmitted = consumer.consumeShard();
             if (newTaskSubmitted) {
                 LOG.debug("New processing task was submitted, call # " + i);
-                assertThat(consumer.getCurrentState(), is(equalTo(ConsumerStates.ShardConsumerState.PROCESSING)));
+                assertThat(consumer.getCurrentState(), is(equalTo(KinesisConsumerStates.ShardConsumerState.PROCESSING)));
                 // CHECKSTYLE:IGNORE ModifiedControlVariable FOR NEXT 1 LINES
                 i += maxRecords;
             }
@@ -985,9 +985,9 @@ public class ShardConsumerTest {
         assertThat(processor.getShutdownReason(), nullValue());
         consumer.beginShutdown();
         Thread.sleep(50L);
-        assertThat(consumer.getCurrentState(), is(equalTo(ConsumerStates.ShardConsumerState.SHUTTING_DOWN)));
+        assertThat(consumer.getCurrentState(), is(equalTo(KinesisConsumerStates.ShardConsumerState.SHUTTING_DOWN)));
         consumer.beginShutdown();
-        assertThat(consumer.getCurrentState(), is(equalTo(ConsumerStates.ShardConsumerState.SHUTDOWN_COMPLETE)));
+        assertThat(consumer.getCurrentState(), is(equalTo(KinesisConsumerStates.ShardConsumerState.SHUTDOWN_COMPLETE)));
         assertThat(processor.getShutdownReason(), is(equalTo(ShutdownReason.ZOMBIE)));
 
         executorService.shutdown();
@@ -1014,8 +1014,8 @@ public class ShardConsumerTest {
                         callProcessRecordsForEmptyRecordList,
                         skipCheckpointValidationValue, INITIAL_POSITION_LATEST);
 
-        ShardConsumer consumer =
-                new ShardConsumer(shardInfo,
+        KinesisShardConsumer consumer =
+                new KinesisShardConsumer(shardInfo,
                         streamConfig,
                         checkpoint,
                         processor,
@@ -1041,22 +1041,22 @@ public class ShardConsumerTest {
         when(checkpoint.getCheckpointObject(anyString())).thenReturn(
                 new Checkpoint(checkpointSequenceNumber, pendingCheckpointSequenceNumber));
 
-        assertThat(consumer.getCurrentState(), is(equalTo(ConsumerStates.ShardConsumerState.WAITING_ON_PARENT_SHARDS)));
+        assertThat(consumer.getCurrentState(), is(equalTo(KinesisConsumerStates.ShardConsumerState.WAITING_ON_PARENT_SHARDS)));
         consumer.consumeShard(); // submit BlockOnParentShardTask
         Thread.sleep(50L);
-        assertThat(consumer.getCurrentState(), is(equalTo(ConsumerStates.ShardConsumerState.WAITING_ON_PARENT_SHARDS)));
+        assertThat(consumer.getCurrentState(), is(equalTo(KinesisConsumerStates.ShardConsumerState.WAITING_ON_PARENT_SHARDS)));
         verify(processor, times(0)).initialize(any(InitializationInput.class));
 
         consumer.consumeShard(); // submit InitializeTask
         Thread.sleep(50L);
-        assertThat(consumer.getCurrentState(), is(equalTo(ConsumerStates.ShardConsumerState.INITIALIZING)));
+        assertThat(consumer.getCurrentState(), is(equalTo(KinesisConsumerStates.ShardConsumerState.INITIALIZING)));
         verify(processor, times(1)).initialize(argThat(
                 initializationInputMatcher(checkpointSequenceNumber, pendingCheckpointSequenceNumber)));
         verify(processor, times(1)).initialize(any(InitializationInput.class)); // no other calls with different args
 
         consumer.consumeShard();
         Thread.sleep(50L);
-        assertThat(consumer.getCurrentState(), is(equalTo(ConsumerStates.ShardConsumerState.PROCESSING)));
+        assertThat(consumer.getCurrentState(), is(equalTo(KinesisConsumerStates.ShardConsumerState.PROCESSING)));
     }
 
     @Test
@@ -1069,8 +1069,8 @@ public class ShardConsumerTest {
                         callProcessRecordsForEmptyRecordList,
                         skipCheckpointValidationValue, INITIAL_POSITION_LATEST);
 
-        ShardConsumer shardConsumer =
-                new ShardConsumer(shardInfo,
+        KinesisShardConsumer shardConsumer =
+                new KinesisShardConsumer(shardInfo,
                         streamConfig,
                         checkpoint,
                         processor,
@@ -1101,8 +1101,8 @@ public class ShardConsumerTest {
                         callProcessRecordsForEmptyRecordList,
                         skipCheckpointValidationValue, INITIAL_POSITION_LATEST);
 
-        ShardConsumer shardConsumer =
-                new ShardConsumer(shardInfo,
+        KinesisShardConsumer shardConsumer =
+                new KinesisShardConsumer(shardInfo,
                         streamConfig,
                         checkpoint,
                         processor,
@@ -1144,7 +1144,7 @@ public class ShardConsumerTest {
                 skipCheckpointValidationValue,
                 INITIAL_POSITION_LATEST);
 
-        ShardConsumer shardConsumer = new ShardConsumer(
+        KinesisShardConsumer shardConsumer = new KinesisShardConsumer(
                 shardInfo,
                 streamConfig,
                 checkpoint,

--- a/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShutdownTaskTest.java
+++ b/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShutdownTaskTest.java
@@ -66,7 +66,7 @@ import com.amazonaws.services.kinesis.leases.interfaces.ILeaseManager;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
-import static com.amazonaws.services.kinesis.clientlibrary.lib.worker.ShutdownTask.RETRY_RANDOM_MAX_RANGE;
+import static com.amazonaws.services.kinesis.clientlibrary.lib.worker.KinesisShutdownTask.RETRY_RANDOM_MAX_RANGE;
 
 /**
  *
@@ -139,7 +139,7 @@ public class ShutdownTaskTest {
     }
 
     /**
-     * Test method for {@link ShutdownTask#call()}.
+     * Test method for {@link KinesisShutdownTask#call()}.
      */
     @Test
     public final void testCallWhenApplicationDoesNotCheckpoint() {
@@ -148,7 +148,7 @@ public class ShutdownTaskTest {
         when(leaseCoordinator.getLeaseManager()).thenReturn(leaseManager);
         boolean cleanupLeasesOfCompletedShards = false;
         boolean ignoreUnexpectedChildShards = false;
-        ShutdownTask task = new ShutdownTask(defaultShardInfo,
+        KinesisShutdownTask task = new KinesisShutdownTask(defaultShardInfo,
                 defaultRecordProcessor,
                 checkpointer,
                 ShutdownReason.TERMINATE,
@@ -171,7 +171,7 @@ public class ShutdownTaskTest {
     }
 
     /**
-     * Test method for {@link ShutdownTask#call()}.
+     * Test method for {@link KinesisShutdownTask#call()}.
      */
     @Test
     public final void testCallWhenCreatingLeaseThrows() throws Exception {
@@ -183,7 +183,7 @@ public class ShutdownTaskTest {
 
         final String exceptionMessage = "InvalidStateException is thrown.";
         when(leaseManager.createLeaseIfNotExists(any(KinesisClientLease.class))).thenThrow(new InvalidStateException(exceptionMessage));
-        ShutdownTask task = new ShutdownTask(defaultShardInfo,
+        KinesisShutdownTask task = new KinesisShutdownTask(defaultShardInfo,
                 defaultRecordProcessor,
                 checkpointer,
                 ShutdownReason.TERMINATE,
@@ -226,7 +226,7 @@ public class ShutdownTaskTest {
 
         // Make first 5 attempts with partial parent info in lease table
         for (int i = 0; i < 5; i++) {
-            ShutdownTask task = spy(new ShutdownTask(defaultShardInfo,
+            KinesisShutdownTask task = spy(new KinesisShutdownTask(defaultShardInfo,
                                                      defaultRecordProcessor,
                                                      checkpointer,
                                                      ShutdownReason.TERMINATE,
@@ -252,7 +252,7 @@ public class ShutdownTaskTest {
         }
 
         // Make next attempt with complete parent info in lease table
-        ShutdownTask task = spy(new ShutdownTask(defaultShardInfo,
+        KinesisShutdownTask task = spy(new KinesisShutdownTask(defaultShardInfo,
                                                  defaultRecordProcessor,
                                                  checkpointer,
                                                  ShutdownReason.TERMINATE,
@@ -290,7 +290,7 @@ public class ShutdownTaskTest {
         when(leaseManager.getLease("ShardId-1")).thenReturn(null, null, null, null, null, null, null, null, null, null, null);
 
         for (int i = 0; i < 10; i++) {
-            ShutdownTask task = spy(new ShutdownTask(defaultShardInfo,
+            KinesisShutdownTask task = spy(new KinesisShutdownTask(defaultShardInfo,
                                                      defaultRecordProcessor,
                                                      checkpointer,
                                                      ShutdownReason.TERMINATE,
@@ -315,7 +315,7 @@ public class ShutdownTaskTest {
             verify(defaultRecordProcessor, never()).shutdown(any(ShutdownInput.class));
         }
 
-        ShutdownTask task = spy(new ShutdownTask(defaultShardInfo,
+        KinesisShutdownTask task = spy(new KinesisShutdownTask(defaultShardInfo,
                                                  defaultRecordProcessor,
                                                  checkpointer,
                                                  ShutdownReason.TERMINATE,
@@ -351,7 +351,7 @@ public class ShutdownTaskTest {
         boolean cleanupLeasesOfCompletedShards = false;
         boolean ignoreUnexpectedChildShards = false;
 
-        ShutdownTask task = new ShutdownTask(defaultShardInfo,
+        KinesisShutdownTask task = new KinesisShutdownTask(defaultShardInfo,
                                              defaultRecordProcessor,
                                              checkpointer,
                                              ShutdownReason.TERMINATE,
@@ -385,7 +385,7 @@ public class ShutdownTaskTest {
         boolean cleanupLeasesOfCompletedShards = false;
         boolean ignoreUnexpectedChildShards = false;
 
-        ShutdownTask task = new ShutdownTask(shardInfo,
+        KinesisShutdownTask task = new KinesisShutdownTask(shardInfo,
                                              defaultRecordProcessor,
                                              checkpointer,
                                              ShutdownReason.TERMINATE,
@@ -415,7 +415,7 @@ public class ShutdownTaskTest {
         boolean cleanupLeasesOfCompletedShards = false;
         boolean ignoreUnexpectedChildShards = false;
 
-        ShutdownTask task = new ShutdownTask(defaultShardInfo,
+        KinesisShutdownTask task = new KinesisShutdownTask(defaultShardInfo,
                                              defaultRecordProcessor,
                                              checkpointer,
                                              ShutdownReason.ZOMBIE,
@@ -438,12 +438,12 @@ public class ShutdownTaskTest {
     }
 
     /**
-     * Test method for {@link ShutdownTask#getTaskType()}.
+     * Test method for {@link KinesisShutdownTask#getTaskType()}.
      */
     @Test
     public final void testGetTaskType() {
         KinesisClientLibLeaseCoordinator leaseCoordinator = mock(KinesisClientLibLeaseCoordinator.class);
-        ShutdownTask task = new ShutdownTask(null, null, null, null,
+        KinesisShutdownTask task = new KinesisShutdownTask(null, null, null, null,
                                              null, null, false,
                                              false, leaseCoordinator, 0,
                                              getRecordsCache, shardSyncer, shardSyncStrategy, Collections.emptyList(), leaseCleanupManager);

--- a/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/WorkerTest.java
+++ b/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/WorkerTest.java
@@ -186,7 +186,7 @@ public class WorkerTest {
     @Mock
     private IRecordProcessor v2RecordProcessor;
     @Mock
-    private ShardConsumer shardConsumer;
+    private IShardConsumer shardConsumer;
     @Mock
     private Future<TaskResult> taskFuture;
     @Mock
@@ -297,13 +297,13 @@ public class WorkerTest {
                         KinesisClientLibConfiguration.DEFAULT_SKIP_SHARD_SYNC_AT_STARTUP_IF_LEASES_EXIST,
                         shardPrioritization);
         ShardInfo shardInfo = new ShardInfo(dummyKinesisShardId, testConcurrencyToken, null, ExtendedSequenceNumber.TRIM_HORIZON);
-        ShardConsumer consumer = worker.createOrGetShardConsumer(shardInfo, streamletFactory);
+        IShardConsumer consumer = worker.createOrGetShardConsumer(shardInfo, streamletFactory);
         Assert.assertNotNull(consumer);
-        ShardConsumer consumer2 = worker.createOrGetShardConsumer(shardInfo, streamletFactory);
+        IShardConsumer consumer2 = worker.createOrGetShardConsumer(shardInfo, streamletFactory);
         Assert.assertSame(consumer, consumer2);
         ShardInfo shardInfoWithSameShardIdButDifferentConcurrencyToken =
                 new ShardInfo(dummyKinesisShardId, anotherConcurrencyToken, null, ExtendedSequenceNumber.TRIM_HORIZON);
-        ShardConsumer consumer3 =
+        IShardConsumer consumer3 =
                 worker.createOrGetShardConsumer(shardInfoWithSameShardIdButDifferentConcurrencyToken, streamletFactory);
         Assert.assertNotNull(consumer3);
         Assert.assertNotSame(consumer3, consumer);
@@ -419,10 +419,10 @@ public class WorkerTest {
                 new ShardInfo(dummyKinesisShardId, anotherConcurrencyToken, null, ExtendedSequenceNumber.TRIM_HORIZON);
         ShardInfo shardInfo2 = new ShardInfo(anotherDummyKinesisShardId, concurrencyToken, null, ExtendedSequenceNumber.TRIM_HORIZON);
 
-        ShardConsumer consumerOfShardInfo1 = worker.createOrGetShardConsumer(shardInfo1, streamletFactory);
-        ShardConsumer consumerOfDuplicateOfShardInfo1ButWithAnotherConcurrencyToken =
+        IShardConsumer consumerOfShardInfo1 = worker.createOrGetShardConsumer(shardInfo1, streamletFactory);
+        IShardConsumer consumerOfDuplicateOfShardInfo1ButWithAnotherConcurrencyToken =
                 worker.createOrGetShardConsumer(duplicateOfShardInfo1ButWithAnotherConcurrencyToken, streamletFactory);
-        ShardConsumer consumerOfShardInfo2 = worker.createOrGetShardConsumer(shardInfo2, streamletFactory);
+        IShardConsumer consumerOfShardInfo2 = worker.createOrGetShardConsumer(shardInfo2, streamletFactory);
 
         Set<ShardInfo> assignedShards = new HashSet<ShardInfo>();
         assignedShards.add(shardInfo1);
@@ -1219,11 +1219,11 @@ public class WorkerTest {
                 false,
                 shardPrioritization);
 
-        final Map<ShardInfo, ShardConsumer> shardInfoShardConsumerMap = worker.getShardInfoShardConsumerMap();
+        final Map<ShardInfo, IShardConsumer> shardInfoShardConsumerMap = worker.getShardInfoShardConsumerMap();
         final ShardInfo completedShardInfo = KinesisClientLibLeaseCoordinator.convertLeaseToAssignment(completedLease);
-        final ShardConsumer completedShardConsumer = mock(ShardConsumer.class);
+        final KinesisShardConsumer completedShardConsumer = mock(KinesisShardConsumer.class);
         shardInfoShardConsumerMap.put(completedShardInfo, completedShardConsumer);
-        when(completedShardConsumer.getCurrentState()).thenReturn(ConsumerStates.ShardConsumerState.SHUTDOWN_COMPLETE);
+        when(completedShardConsumer.getCurrentState()).thenReturn(KinesisConsumerStates.ShardConsumerState.SHUTDOWN_COMPLETE);
 
         Callable<GracefulShutdownContext> callable = worker.createWorkerShutdownCallable();
         assertThat(worker.hasGracefulShutdownStarted(), equalTo(false));
@@ -1338,11 +1338,11 @@ public class WorkerTest {
 
         verify(executorService).submit(argThat(both(isA(MetricsCollectingTaskDecorator.class))
                 .and(TaskTypeMatcher.isOfType(TaskType.SHUTDOWN)).and(ReflectionFieldMatcher
-                        .withField(ShutdownTask.class, "shardInfo", equalTo(shardInfo1)))));
+                        .withField(KinesisShutdownTask.class, "shardInfo", equalTo(shardInfo1)))));
 
         verify(executorService, never()).submit(argThat(both(isA(MetricsCollectingTaskDecorator.class))
                 .and(TaskTypeMatcher.isOfType(TaskType.SHUTDOWN)).and(ReflectionFieldMatcher
-                        .withField(ShutdownTask.class, "shardInfo", equalTo(shardInfo2)))));
+                        .withField(KinesisShutdownTask.class, "shardInfo", equalTo(shardInfo2)))));
 
     }
 
@@ -1451,11 +1451,11 @@ public class WorkerTest {
 
         verify(executorService, never()).submit(argThat(both(isA(MetricsCollectingTaskDecorator.class))
                 .and(TaskTypeMatcher.isOfType(TaskType.SHUTDOWN)).and(ReflectionFieldMatcher
-                        .withField(ShutdownTask.class, "shardInfo", equalTo(shardInfo1)))));
+                        .withField(KinesisShutdownTask.class, "shardInfo", equalTo(shardInfo1)))));
 
         verify(executorService, never()).submit(argThat(both(isA(MetricsCollectingTaskDecorator.class))
                 .and(TaskTypeMatcher.isOfType(TaskType.SHUTDOWN)).and(ReflectionFieldMatcher
-                        .withField(ShutdownTask.class, "shardInfo", equalTo(shardInfo2)))));
+                        .withField(KinesisShutdownTask.class, "shardInfo", equalTo(shardInfo2)))));
 
 
 
@@ -2013,19 +2013,19 @@ public class WorkerTest {
         @Override
         protected boolean matchesSafely(MetricsCollectingTaskDecorator item, Description mismatchDescription) {
             return Condition.matched(item, mismatchDescription)
-                    .and(new Condition.Step<MetricsCollectingTaskDecorator, ShutdownTask>() {
+                    .and(new Condition.Step<MetricsCollectingTaskDecorator, KinesisShutdownTask>() {
                         @Override
-                        public Condition<ShutdownTask> apply(MetricsCollectingTaskDecorator value,
+                        public Condition<KinesisShutdownTask> apply(MetricsCollectingTaskDecorator value,
                                 Description mismatch) {
-                            if (!(value.getOther() instanceof ShutdownTask)) {
+                            if (!(value.getOther() instanceof KinesisShutdownTask)) {
                                 mismatch.appendText("Wrapped task isn't a shutdown task");
                                 return Condition.notMatched();
                             }
-                            return Condition.matched((ShutdownTask) value.getOther(), mismatch);
+                            return Condition.matched((KinesisShutdownTask) value.getOther(), mismatch);
                         }
-                    }).and(new Condition.Step<ShutdownTask, ShutdownReason>() {
+                    }).and(new Condition.Step<KinesisShutdownTask, ShutdownReason>() {
                         @Override
-                        public Condition<ShutdownReason> apply(ShutdownTask value, Description mismatch) {
+                        public Condition<ShutdownReason> apply(KinesisShutdownTask value, Description mismatch) {
                             return Condition.matched(value.getReason(), mismatch);
                         }
                     }).matching(matcher);


### PR DESCRIPTION
Description of changes: Changes to KCL 1.14.x that re-allows for compatibility with the DynamoDBStreamsKinesisAdapter. The majority of changes consist of creating interfaces for key classes like the ShardConsumer, renaming these preexisting classes to include the Kinesis prefix (ShardConsumer -> KinesisShardConsumer) to distinguish from any classes that will use the new interfaces (i.e. DynamoDBStreamsShardConsumer), and making several utility classes and functions public so they could be accessed by the adapter or interfaces, such as the InitializationTask.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
