### PR TITLE
Upgrade Lombok to version 1.18.24

### DIFF
--- a/amazon-kinesis-client/pom.xml
+++ b/amazon-kinesis-client/pom.xml
@@ -115,7 +115,7 @@
     <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
-      <version>1.18.22</version>
+      <version>1.18.24</version>
       <scope>provided</scope>
     </dependency>
 

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/polling/PrefetchRecordsPublisher.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/polling/PrefetchRecordsPublisher.java
@@ -409,7 +409,7 @@ public class PrefetchRecordsPublisher implements RecordsPublisher {
         final String lastBatchSequenceNumber;
         final String shardIterator;
         final BatchUniqueIdentifier batchUniqueIdentifier;
-        @Accessors() @Setter(AccessLevel.NONE) boolean dispatched = false;
+        @Accessors(fluent = false) @Setter(AccessLevel.NONE) boolean dispatched = false;
 
         PrefetchRecordsRetrieved prepareForPublish() {
             return new PrefetchRecordsRetrieved(processRecordsInput.toBuilder().cacheExitTime(Instant.now()).build(),


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Bumping Lombok version from 1.18.22 to 1.18.24 and fixing a resulting build error due to the `fluent` field not being explicitly set to `false`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
