### PR TITLE
Adapt DefaultCWMetricsPublisher to new CloudWatch PMD max batch size

### DIFF
--- a/src/main/java/com/amazonaws/services/kinesis/metrics/impl/DefaultCWMetricsPublisher.java
+++ b/src/main/java/com/amazonaws/services/kinesis/metrics/impl/DefaultCWMetricsPublisher.java
@@ -33,8 +33,8 @@ public class DefaultCWMetricsPublisher implements ICWMetricsPublisher<CWMetricKe
 
     private static final Log LOG = LogFactory.getLog(CWPublisherRunnable.class);
 
-    // CloudWatch API has a limit of 20 MetricDatums per request
-    private static final int BATCH_SIZE = 20;
+    // CloudWatch API has a limit of 1000 MetricDatums per request
+    private static final int BATCH_SIZE = 1000;
 
     private final String namespace;
     private final AmazonCloudWatch cloudWatchClient;


### PR DESCRIPTION
Adapting to the new CloudWatch API batch max size - cf. https://aws.amazon.com/about-aws/whats-new/2022/08/amazon-cloudwatch-metrics-increases-throughput/

*Issue #, if available:*

*Description of changes:*
CloudWatch PutMetricData now supports batching up to 1000 MetricDatums per call

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
