### PR TITLE
Added support for faster shard reallocation on graceful shutdown

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@ target/
 AwsCredentials.properties
 .idea
 *.iml
-
+.sdkmanrc
+.vscode

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/common/CommonCalculations.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/common/CommonCalculations.java
@@ -28,4 +28,22 @@ public class CommonCalculations {
     public static long getRenewerTakerIntervalMillis(long leaseDurationMillis, long epsilonMillis) {
         return leaseDurationMillis / 3 - epsilonMillis;
     }
+
+    /**
+     * Convenience method for calculating lease taker intervals in milliseconds.
+     *
+     * @param leaseTakerIntervalMillis Current value for interval (from default or overriden).
+     * @param leaseDurationMillis Duration of a lease
+     * @param epsilonMillis Allow for some variance when calculating lease expirations
+     * @return lease taker interval.
+     */
+    public static long getLeaseTakerIntervalMillis(
+      long leaseTakerIntervalMillis, long leaseDurationMillis, long epsilonMillis
+    ) {
+      if (leaseTakerIntervalMillis > 0) {
+        return leaseTakerIntervalMillis;
+      }
+
+      return (leaseDurationMillis + epsilonMillis) * 2;
+    }
 }

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/coordinator/Scheduler.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/coordinator/Scheduler.java
@@ -945,7 +945,8 @@ public class Scheduler implements Runnable {
                 hierarchicalShardSyncerProvider.apply(streamConfig),
                 metricsFactory,
                 leaseCleanupManager,
-                schemaRegistryDecoder
+                schemaRegistryDecoder,
+                leaseManagementConfig.evictLeaseOnShutdown()
             );
         return new ShardConsumer(cache, executorService, shardInfo, lifecycleConfig.logWarningForTaskAfterMillis(),
                 argument, lifecycleConfig.taskExecutionListener(), lifecycleConfig.readTimeoutsToIgnoreBeforeWarning());

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/leases/Lease.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/leases/Lease.java
@@ -44,7 +44,7 @@ import software.amazon.kinesis.retrieval.kpl.ExtendedSequenceNumber;
 public class Lease {
     /*
      * See javadoc for System.nanoTime - summary:
-     * 
+     *
      * Sometimes System.nanoTime's return values will wrap due to overflow. When they do, the difference between two
      * values will be very large. We will consider leases to be expired if they are more than a year old.
      */
@@ -111,7 +111,7 @@ public class Lease {
 
     /**
      * Copy constructor, used by clone().
-     * 
+     *
      * @param lease lease to copy
      */
     protected Lease(Lease lease) {
@@ -164,7 +164,7 @@ public class Lease {
     /**
      * Updates this Lease's mutable, application-specific fields based on the passed-in lease object. Does not update
      * fields that are internal to the leasing library (leaseKey, leaseOwner, leaseCounter).
-     * 
+     *
      * @param lease
      */
     public void update(final Lease lease) {
@@ -196,8 +196,15 @@ public class Lease {
     }
 
     /**
+     * @return true if this lease is unassigned (no assigned owner), false otherwise.
+     */
+    public boolean isUnassigned() {
+        return leaseOwner == null;
+    }
+
+    /**
      * Sets lastCounterIncrementNanos
-     * 
+     *
      * @param lastCounterIncrementNanos last renewal in nanoseconds since the epoch
      */
     public void lastCounterIncrementNanos(Long lastCounterIncrementNanos) {
@@ -206,7 +213,7 @@ public class Lease {
 
     /**
      * Sets concurrencyToken.
-     * 
+     *
      * @param concurrencyToken may not be null
      */
     public void concurrencyToken(@NonNull final UUID concurrencyToken) {
@@ -215,7 +222,7 @@ public class Lease {
 
     /**
      * Sets leaseKey. LeaseKey is immutable once set.
-     * 
+     *
      * @param leaseKey may not be null.
      */
     public void leaseKey(@NonNull final String leaseKey) {
@@ -227,7 +234,7 @@ public class Lease {
 
     /**
      * Sets leaseCounter.
-     * 
+     *
      * @param leaseCounter may not be null
      */
     public void leaseCounter(@NonNull final Long leaseCounter) {
@@ -303,7 +310,7 @@ public class Lease {
 
     /**
      * Sets leaseOwner.
-     * 
+     *
      * @param leaseOwner may be null.
      */
     public void leaseOwner(String leaseOwner) {
@@ -312,12 +319,10 @@ public class Lease {
 
     /**
      * Returns a deep copy of this object. Type-unsafe - there aren't good mechanisms for copy-constructing generics.
-     * 
+     *
      * @return A deep copy of this object.
      */
     public Lease copy() {
         return new Lease(this);
     }
-
-
 }

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/leases/LeaseManagementConfig.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/leases/LeaseManagementConfig.java
@@ -224,6 +224,18 @@ public class LeaseManagementConfig {
     private long listShardsCacheAllowedAgeInSeconds = 30;
     private int cacheMissWarningModulus = 250;
 
+    /**
+     * Interval at which the lease taker will execute.
+     * If unspecified, an interval will be calculated based on the lease duration.
+     */
+    private long leaseTakerIntervalMillis = -1L;
+
+    /**
+     * If leases should be evicted or not on shutdown requested.
+     * By default, leases are not evicted.
+     */
+    private boolean evictLeaseOnShutdown = false;
+
     private MetricsFactory metricsFactory = new NullMetricsFactory();
 
     @Deprecated
@@ -326,6 +338,7 @@ public class LeaseManagementConfig {
                     initialPositionInStream(),
                     failoverTimeMillis(),
                     epsilonMillis(),
+                    leaseTakerIntervalMillis,
                     maxLeasesForWorker(),
                     maxLeasesToStealAtOneTime(),
                     maxLeaseRenewalThreads(),
@@ -361,6 +374,7 @@ public class LeaseManagementConfig {
                     executorService(),
                     failoverTimeMillis(),
                     epsilonMillis(),
+                    leaseTakerIntervalMillis,
                     maxLeasesForWorker(),
                     maxLeasesToStealAtOneTime(),
                     maxLeaseRenewalThreads(),

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/leases/dynamodb/DynamoDBLeaseManagementFactory.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/leases/dynamodb/DynamoDBLeaseManagementFactory.java
@@ -68,6 +68,7 @@ public class DynamoDBLeaseManagementFactory implements LeaseManagementFactory {
 
     private final long failoverTimeMillis;
     private final long epsilonMillis;
+    private final long leaseTakerIntervalMillis;
     private final int maxLeasesForWorker;
     private final int maxLeasesToStealAtOneTime;
     private final int maxLeaseRenewalThreads;
@@ -119,14 +120,14 @@ public class DynamoDBLeaseManagementFactory implements LeaseManagementFactory {
     public DynamoDBLeaseManagementFactory(final KinesisAsyncClient kinesisClient, final String streamName,
             final DynamoDbAsyncClient dynamoDBClient, final String tableName, final String workerIdentifier,
             final ExecutorService executorService, final InitialPositionInStreamExtended initialPositionInStream,
-            final long failoverTimeMillis, final long epsilonMillis, final int maxLeasesForWorker,
+            final long failoverTimeMillis, final long epsilonMillis, final long leaseTakerIntervalMillis, final int maxLeasesForWorker,
             final int maxLeasesToStealAtOneTime, final int maxLeaseRenewalThreads,
             final boolean cleanupLeasesUponShardCompletion, final boolean ignoreUnexpectedChildShards,
             final long shardSyncIntervalMillis, final boolean consistentReads, final long listShardsBackoffTimeMillis,
             final int maxListShardsRetryAttempts, final int maxCacheMissesBeforeReload,
             final long listShardsCacheAllowedAgeInSeconds, final int cacheMissWarningModulus) {
         this(kinesisClient, streamName, dynamoDBClient, tableName, workerIdentifier, executorService,
-                initialPositionInStream, failoverTimeMillis, epsilonMillis, maxLeasesForWorker,
+                initialPositionInStream, failoverTimeMillis, epsilonMillis, leaseTakerIntervalMillis, maxLeasesForWorker,
                 maxLeasesToStealAtOneTime, maxLeaseRenewalThreads, cleanupLeasesUponShardCompletion,
                 ignoreUnexpectedChildShards, shardSyncIntervalMillis, consistentReads, listShardsBackoffTimeMillis,
                 maxListShardsRetryAttempts, maxCacheMissesBeforeReload, listShardsCacheAllowedAgeInSeconds,
@@ -169,7 +170,7 @@ public class DynamoDBLeaseManagementFactory implements LeaseManagementFactory {
     public DynamoDBLeaseManagementFactory(final KinesisAsyncClient kinesisClient, final String streamName,
             final DynamoDbAsyncClient dynamoDBClient, final String tableName, final String workerIdentifier,
             final ExecutorService executorService, final InitialPositionInStreamExtended initialPositionInStream,
-            final long failoverTimeMillis, final long epsilonMillis, final int maxLeasesForWorker,
+            final long failoverTimeMillis, final long epsilonMillis, final long leaseTakerIntervalMillis, final int maxLeasesForWorker,
             final int maxLeasesToStealAtOneTime, final int maxLeaseRenewalThreads,
             final boolean cleanupLeasesUponShardCompletion, final boolean ignoreUnexpectedChildShards,
             final long shardSyncIntervalMillis, final boolean consistentReads, final long listShardsBackoffTimeMillis,
@@ -177,7 +178,7 @@ public class DynamoDBLeaseManagementFactory implements LeaseManagementFactory {
             final long listShardsCacheAllowedAgeInSeconds, final int cacheMissWarningModulus,
             final long initialLeaseTableReadCapacity, final long initialLeaseTableWriteCapacity) {
         this(kinesisClient, streamName, dynamoDBClient, tableName, workerIdentifier, executorService,
-                initialPositionInStream, failoverTimeMillis, epsilonMillis, maxLeasesForWorker,
+                initialPositionInStream, failoverTimeMillis, epsilonMillis, leaseTakerIntervalMillis, maxLeasesForWorker,
                 maxLeasesToStealAtOneTime, maxLeaseRenewalThreads, cleanupLeasesUponShardCompletion,
                 ignoreUnexpectedChildShards, shardSyncIntervalMillis, consistentReads, listShardsBackoffTimeMillis,
                 maxListShardsRetryAttempts, maxCacheMissesBeforeReload, listShardsCacheAllowedAgeInSeconds,
@@ -219,7 +220,7 @@ public class DynamoDBLeaseManagementFactory implements LeaseManagementFactory {
     public DynamoDBLeaseManagementFactory(final KinesisAsyncClient kinesisClient, final String streamName,
             final DynamoDbAsyncClient dynamoDBClient, final String tableName, final String workerIdentifier,
             final ExecutorService executorService, final InitialPositionInStreamExtended initialPositionInStream,
-            final long failoverTimeMillis, final long epsilonMillis, final int maxLeasesForWorker,
+            final long failoverTimeMillis, final long epsilonMillis, final long leaseTakerIntervalMillis, final int maxLeasesForWorker,
             final int maxLeasesToStealAtOneTime, final int maxLeaseRenewalThreads,
             final boolean cleanupLeasesUponShardCompletion, final boolean ignoreUnexpectedChildShards,
             final long shardSyncIntervalMillis, final boolean consistentReads, final long listShardsBackoffTimeMillis,
@@ -228,7 +229,7 @@ public class DynamoDBLeaseManagementFactory implements LeaseManagementFactory {
             final long initialLeaseTableReadCapacity, final long initialLeaseTableWriteCapacity,
             final HierarchicalShardSyncer hierarchicalShardSyncer, final TableCreatorCallback tableCreatorCallback) {
         this(kinesisClient, streamName, dynamoDBClient, tableName, workerIdentifier, executorService,
-                initialPositionInStream, failoverTimeMillis, epsilonMillis, maxLeasesForWorker,
+                initialPositionInStream, failoverTimeMillis, epsilonMillis, leaseTakerIntervalMillis, maxLeasesForWorker,
                 maxLeasesToStealAtOneTime, maxLeaseRenewalThreads, cleanupLeasesUponShardCompletion,
                 ignoreUnexpectedChildShards, shardSyncIntervalMillis, consistentReads, listShardsBackoffTimeMillis,
                 maxListShardsRetryAttempts, maxCacheMissesBeforeReload, listShardsCacheAllowedAgeInSeconds,
@@ -270,7 +271,7 @@ public class DynamoDBLeaseManagementFactory implements LeaseManagementFactory {
     public DynamoDBLeaseManagementFactory(final KinesisAsyncClient kinesisClient, final String streamName,
             final DynamoDbAsyncClient dynamoDBClient, final String tableName, final String workerIdentifier,
             final ExecutorService executorService, final InitialPositionInStreamExtended initialPositionInStream,
-            final long failoverTimeMillis, final long epsilonMillis, final int maxLeasesForWorker,
+            final long failoverTimeMillis, final long epsilonMillis, final long leaseTakerIntervalMillis, final int maxLeasesForWorker,
             final int maxLeasesToStealAtOneTime, final int maxLeaseRenewalThreads,
             final boolean cleanupLeasesUponShardCompletion, final boolean ignoreUnexpectedChildShards,
             final long shardSyncIntervalMillis, final boolean consistentReads, final long listShardsBackoffTimeMillis,
@@ -280,7 +281,7 @@ public class DynamoDBLeaseManagementFactory implements LeaseManagementFactory {
             final HierarchicalShardSyncer hierarchicalShardSyncer, final TableCreatorCallback tableCreatorCallback,
             Duration dynamoDbRequestTimeout) {
         this(kinesisClient, streamName, dynamoDBClient, tableName, workerIdentifier, executorService,
-                initialPositionInStream, failoverTimeMillis, epsilonMillis, maxLeasesForWorker,
+                initialPositionInStream, failoverTimeMillis, epsilonMillis, leaseTakerIntervalMillis, maxLeasesForWorker,
                 maxLeasesToStealAtOneTime, maxLeaseRenewalThreads, cleanupLeasesUponShardCompletion,
                 ignoreUnexpectedChildShards, shardSyncIntervalMillis, consistentReads, listShardsBackoffTimeMillis,
                 maxListShardsRetryAttempts, maxCacheMissesBeforeReload, listShardsCacheAllowedAgeInSeconds,
@@ -323,7 +324,7 @@ public class DynamoDBLeaseManagementFactory implements LeaseManagementFactory {
     public DynamoDBLeaseManagementFactory(final KinesisAsyncClient kinesisClient, final String streamName,
             final DynamoDbAsyncClient dynamoDBClient, final String tableName, final String workerIdentifier,
             final ExecutorService executorService, final InitialPositionInStreamExtended initialPositionInStream,
-            final long failoverTimeMillis, final long epsilonMillis, final int maxLeasesForWorker,
+            final long failoverTimeMillis, final long epsilonMillis, final long leaseTakerIntervalMillis, final int maxLeasesForWorker,
             final int maxLeasesToStealAtOneTime, final int maxLeaseRenewalThreads,
             final boolean cleanupLeasesUponShardCompletion, final boolean ignoreUnexpectedChildShards,
             final long shardSyncIntervalMillis, final boolean consistentReads, final long listShardsBackoffTimeMillis,
@@ -334,7 +335,7 @@ public class DynamoDBLeaseManagementFactory implements LeaseManagementFactory {
             Duration dynamoDbRequestTimeout, BillingMode billingMode) {
 
         this(kinesisClient, new StreamConfig(StreamIdentifier.singleStreamInstance(streamName), initialPositionInStream), dynamoDBClient, tableName,
-                workerIdentifier, executorService, failoverTimeMillis, epsilonMillis, maxLeasesForWorker,
+                workerIdentifier, executorService, failoverTimeMillis, epsilonMillis, leaseTakerIntervalMillis, maxLeasesForWorker,
                 maxLeasesToStealAtOneTime, maxLeaseRenewalThreads, cleanupLeasesUponShardCompletion,
                 ignoreUnexpectedChildShards, shardSyncIntervalMillis, consistentReads, listShardsBackoffTimeMillis,
                 maxListShardsRetryAttempts, maxCacheMissesBeforeReload, listShardsCacheAllowedAgeInSeconds,
@@ -374,7 +375,7 @@ public class DynamoDBLeaseManagementFactory implements LeaseManagementFactory {
      */
     private DynamoDBLeaseManagementFactory(final KinesisAsyncClient kinesisClient, final StreamConfig streamConfig,
             final DynamoDbAsyncClient dynamoDBClient, final String tableName, final String workerIdentifier,
-            final ExecutorService executorService, final long failoverTimeMillis, final long epsilonMillis,
+            final ExecutorService executorService, final long failoverTimeMillis, final long epsilonMillis, final long leaseTakerIntervalMillis,
             final int maxLeasesForWorker, final int maxLeasesToStealAtOneTime, final int maxLeaseRenewalThreads,
             final boolean cleanupLeasesUponShardCompletion, final boolean ignoreUnexpectedChildShards,
             final long shardSyncIntervalMillis, final boolean consistentReads, final long listShardsBackoffTimeMillis,
@@ -384,7 +385,7 @@ public class DynamoDBLeaseManagementFactory implements LeaseManagementFactory {
             final HierarchicalShardSyncer deprecatedHierarchicalShardSyncer, final TableCreatorCallback tableCreatorCallback,
             Duration dynamoDbRequestTimeout, BillingMode billingMode, LeaseSerializer leaseSerializer) {
         this(kinesisClient, dynamoDBClient, tableName,
-                workerIdentifier, executorService, failoverTimeMillis, epsilonMillis, maxLeasesForWorker,
+                workerIdentifier, executorService, failoverTimeMillis, epsilonMillis, leaseTakerIntervalMillis, maxLeasesForWorker,
                 maxLeasesToStealAtOneTime, maxLeaseRenewalThreads, cleanupLeasesUponShardCompletion,
                 ignoreUnexpectedChildShards, shardSyncIntervalMillis, consistentReads, listShardsBackoffTimeMillis,
                 maxListShardsRetryAttempts, maxCacheMissesBeforeReload, listShardsCacheAllowedAgeInSeconds,
@@ -428,7 +429,7 @@ public class DynamoDBLeaseManagementFactory implements LeaseManagementFactory {
      */
     public DynamoDBLeaseManagementFactory(final KinesisAsyncClient kinesisClient,
             final DynamoDbAsyncClient dynamoDBClient, final String tableName, final String workerIdentifier,
-            final ExecutorService executorService, final long failoverTimeMillis, final long epsilonMillis,
+            final ExecutorService executorService, final long failoverTimeMillis, final long epsilonMillis, final long leaseTakerIntervalMillis,
             final int maxLeasesForWorker, final int maxLeasesToStealAtOneTime, final int maxLeaseRenewalThreads,
             final boolean cleanupLeasesUponShardCompletion, final boolean ignoreUnexpectedChildShards,
             final long shardSyncIntervalMillis, final boolean consistentReads, final long listShardsBackoffTimeMillis,
@@ -446,6 +447,7 @@ public class DynamoDBLeaseManagementFactory implements LeaseManagementFactory {
         this.executorService = executorService;
         this.failoverTimeMillis = failoverTimeMillis;
         this.epsilonMillis = epsilonMillis;
+        this.leaseTakerIntervalMillis = leaseTakerIntervalMillis;
         this.maxLeasesForWorker = maxLeasesForWorker;
         this.maxLeasesToStealAtOneTime = maxLeasesToStealAtOneTime;
         this.maxLeaseRenewalThreads = maxLeaseRenewalThreads;
@@ -476,6 +478,7 @@ public class DynamoDBLeaseManagementFactory implements LeaseManagementFactory {
                 workerIdentifier,
                 failoverTimeMillis,
                 epsilonMillis,
+                leaseTakerIntervalMillis,
                 maxLeasesForWorker,
                 maxLeasesToStealAtOneTime,
                 maxLeaseRenewalThreads,

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/leases/dynamodb/DynamoDBLeaseTaker.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/leases/dynamodb/DynamoDBLeaseTaker.java
@@ -191,9 +191,9 @@ public class DynamoDBLeaseTaker implements LeaseTaker {
                 return takenLeases;
             }
 
-            List<Lease> expiredLeases = getExpiredLeases();
+            List<Lease> availableLeases = getAvailableLeases();
 
-            Set<Lease> leasesToTake = computeLeasesToTake(expiredLeases);
+            Set<Lease> leasesToTake = computeLeasesToTake(availableLeases);
             leasesToTake = updateStaleLeasesWithLatestState(updateAllLeasesTotalTimeMillis, leasesToTake);
 
             Set<String> untakenLeaseKeys = new HashSet<>();
@@ -358,34 +358,43 @@ public class DynamoDBLeaseTaker implements LeaseTaker {
     }
 
     /**
-     * @return list of leases that were expired as of our last scan.
+     * @return list of leases that are available for the taking.
+     *  Expired leases and orphan leases (without owner) are considered available.
      */
-    private List<Lease> getExpiredLeases() {
-        List<Lease> expiredLeases = new ArrayList<>();
+    private List<Lease> getAvailableLeases() {
+        List<Lease> availableLeases = new ArrayList<>();
 
         for (Lease lease : allLeases.values()) {
-            if (lease.isExpired(leaseDurationNanos, lastScanTimeNanos)) {
-                expiredLeases.add(lease);
+            if (isExpired(lease) || isUnassigned(lease)) {
+                availableLeases.add(lease);
             }
         }
 
-        return expiredLeases;
+        return availableLeases;
+    }
+
+    private boolean isUnassigned(Lease lease) {
+        return lease.isUnassigned();
+    }
+
+    private boolean isExpired(Lease lease) {
+        return lease.isExpired(leaseDurationNanos, lastScanTimeNanos);
     }
 
     /**
      * Compute the number of leases I should try to take based on the state of the system.
      *
-     * @param expiredLeases list of leases we determined to be expired
+     * @param availableLeases list of leases we determined to be available
      * @return set of leases to take.
      */
-    private Set<Lease> computeLeasesToTake(List<Lease> expiredLeases) {
-        Map<String, Integer> leaseCounts = computeLeaseCounts(expiredLeases);
+    private Set<Lease> computeLeasesToTake(List<Lease> availableLeases) {
+        Map<String, Integer> leaseCounts = computeLeaseCounts(availableLeases);
         Set<Lease> leasesToTake = new HashSet<>();
         final MetricsScope scope = MetricsUtil.createMetricsWithOperation(metricsFactory, TAKE_LEASES_DIMENSION);
         MetricsUtil.addWorkerIdentifier(scope, workerIdentifier);
         List<Lease> veryOldLeases = new ArrayList<>();
 
-        final int numAvailableLeases = expiredLeases.size();
+        final int numAvailableLeases = availableLeases.size();
         int numLeases = 0;
         int numWorkers = 0;
         int numLeasesToReachTarget = 0;
@@ -454,16 +463,16 @@ public class DynamoDBLeaseTaker implements LeaseTaker {
                 return leasesToTake;
             }
 
-            // Shuffle expiredLeases so workers don't all try to contend for the same leases.
-            Collections.shuffle(expiredLeases);
+            // Shuffle availableLeases so workers don't all try to contend for the same leases.
+            Collections.shuffle(availableLeases);
 
-            if (expiredLeases.size() > 0) {
-                // If we have expired leases, get up to <needed> leases from expiredLeases
-                for (; numLeasesToReachTarget > 0 && expiredLeases.size() > 0; numLeasesToReachTarget--) {
-                    leasesToTake.add(expiredLeases.remove(0));
+            if (availableLeases.size() > 0) {
+                // If we have available leases, get up to <needed> leases from availableLeases
+                for (; numLeasesToReachTarget > 0 && availableLeases.size() > 0; numLeasesToReachTarget--) {
+                    leasesToTake.add(availableLeases.remove(0));
                 }
             } else {
-                // If there are no expired leases and we need a lease, consider stealing.
+                // If there are no available leases and we need a lease, consider stealing.
                 List<Lease> leasesToSteal = chooseLeasesToSteal(leaseCounts, numLeasesToReachTarget, target);
                 for (Lease leaseToSteal : leasesToSteal) {
                     log.info("Worker {} needed {} leases but none were expired, so it will steal lease {} from {}",
@@ -482,7 +491,7 @@ public class DynamoDBLeaseTaker implements LeaseTaker {
             }
 
         } finally {
-            scope.addData("ExpiredLeases", expiredLeases.size(), StandardUnit.COUNT, MetricsLevel.SUMMARY);
+            scope.addData("AvailableLeases", availableLeases.size(), StandardUnit.COUNT, MetricsLevel.SUMMARY);
             scope.addData("LeaseSpillover", leaseSpillover, StandardUnit.COUNT, MetricsLevel.SUMMARY);
             scope.addData("LeasesToTake", leasesToTake.size(), StandardUnit.COUNT, MetricsLevel.DETAILED);
             scope.addData("NeededLeases", Math.max(numLeasesToReachTarget, 0), StandardUnit.COUNT, MetricsLevel.DETAILED);

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/lifecycle/ShardConsumerArgument.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/lifecycle/ShardConsumerArgument.java
@@ -75,4 +75,5 @@ public class ShardConsumerArgument {
     private final MetricsFactory metricsFactory;
     private final LeaseCleanupManager leaseCleanupManager;
     private final SchemaRegistryDecoder schemaRegistryDecoder;
+    private final boolean evictLeaseOnShutdown;
 }

--- a/amazon-kinesis-client/src/test/java/software/amazon/kinesis/common/CommonCalculationTest.java
+++ b/amazon-kinesis-client/src/test/java/software/amazon/kinesis/common/CommonCalculationTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates.
+ * Licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package software.amazon.kinesis.common;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class CommonCalculationTest {
+
+  @Test
+  public void testGetLeaseTakerIntervalMillisWithDefault() {
+      long leaseTakerIntervalMillis = -1L;
+      long leaseDurationMillis = 10000L;
+      long epsilonMillis = 25L;
+
+      long expected = (leaseDurationMillis + epsilonMillis) * 2;
+
+      assertEquals(expected, CommonCalculations.getLeaseTakerIntervalMillis(
+          leaseTakerIntervalMillis, leaseDurationMillis, epsilonMillis));
+  }
+
+  @Test
+  public void testGetLeaseTakerIntervalMillisWhenOverriden() {
+      long leaseTakerIntervalMillis = 200L;
+      long leaseDurationMillis = 10000L;
+      long epsilonMillis = 25L;
+
+      long expected = leaseTakerIntervalMillis;
+
+      assertEquals(expected, CommonCalculations.getLeaseTakerIntervalMillis(
+          leaseTakerIntervalMillis, leaseDurationMillis, epsilonMillis));
+  }
+}

--- a/amazon-kinesis-client/src/test/java/software/amazon/kinesis/leases/LeaseCoordinatorExerciser.java
+++ b/amazon-kinesis-client/src/test/java/software/amazon/kinesis/leases/LeaseCoordinatorExerciser.java
@@ -46,6 +46,7 @@ import software.amazon.kinesis.retrieval.kpl.ExtendedSequenceNumber;
 
 @Slf4j
 public class LeaseCoordinatorExerciser {
+    private static final long LEASE_TAKER_INTERVAL_MILLIS = -1L;
     private static final int MAX_LEASES_FOR_WORKER = Integer.MAX_VALUE;
     private static final int MAX_LEASES_TO_STEAL_AT_ONE_TIME = 1;
     private static final int MAX_LEASE_RENEWER_THREAD_COUNT = 20;
@@ -85,7 +86,7 @@ public class LeaseCoordinatorExerciser {
             String workerIdentifier = "worker-" + Integer.toString(i);
 
             LeaseCoordinator coord = new DynamoDBLeaseCoordinator(leaseRefresher, workerIdentifier, leaseDurationMillis,
-                    epsilonMillis, MAX_LEASES_FOR_WORKER, MAX_LEASES_TO_STEAL_AT_ONE_TIME,
+                    epsilonMillis, LEASE_TAKER_INTERVAL_MILLIS, MAX_LEASES_FOR_WORKER, MAX_LEASES_TO_STEAL_AT_ONE_TIME,
                     MAX_LEASE_RENEWER_THREAD_COUNT, INITIAL_LEASE_TABLE_READ_CAPACITY,
                     INITIAL_LEASE_TABLE_WRITE_CAPACITY, metricsFactory);
 

--- a/amazon-kinesis-client/src/test/java/software/amazon/kinesis/leases/dynamodb/DynamoDBLeaseCoordinatorTest.java
+++ b/amazon-kinesis-client/src/test/java/software/amazon/kinesis/leases/dynamodb/DynamoDBLeaseCoordinatorTest.java
@@ -22,6 +22,7 @@ public class DynamoDBLeaseCoordinatorTest {
     private static final String WORKER_ID = UUID.randomUUID().toString();
     private static final long LEASE_DURATION_MILLIS = 5000L;
     private static final long EPSILON_MILLIS = 25L;
+    private static final long LEASE_TAKER_INTERVAL_MILLIS = -1L;
     private static final int MAX_LEASES_FOR_WORKER = Integer.MAX_VALUE;
     private static final int MAX_LEASES_TO_STEAL_AT_ONE_TIME = 1;
     private static final int MAX_LEASE_RENEWER_THREAD_COUNT = 20;
@@ -39,8 +40,8 @@ public class DynamoDBLeaseCoordinatorTest {
 
     @Before
     public void setup() {
-        this.leaseCoordinator = new DynamoDBLeaseCoordinator(leaseRefresher, WORKER_ID, LEASE_DURATION_MILLIS,
-                EPSILON_MILLIS, MAX_LEASES_FOR_WORKER, MAX_LEASES_TO_STEAL_AT_ONE_TIME, MAX_LEASE_RENEWER_THREAD_COUNT,
+        this.leaseCoordinator = new DynamoDBLeaseCoordinator(leaseRefresher, WORKER_ID, LEASE_DURATION_MILLIS, EPSILON_MILLIS,
+                LEASE_TAKER_INTERVAL_MILLIS, MAX_LEASES_FOR_WORKER, MAX_LEASES_TO_STEAL_AT_ONE_TIME, MAX_LEASE_RENEWER_THREAD_COUNT,
                 INITIAL_LEASE_TABLE_READ_CAPACITY, INITIAL_LEASE_TABLE_WRITE_CAPACITY, metricsFactory);
     }
 

--- a/amazon-kinesis-client/src/test/java/software/amazon/kinesis/leases/dynamodb/DynamoDBLeaseTakerIntegrationTest.java
+++ b/amazon-kinesis-client/src/test/java/software/amazon/kinesis/leases/dynamodb/DynamoDBLeaseTakerIntegrationTest.java
@@ -88,6 +88,21 @@ public class DynamoDBLeaseTakerIntegrationTest extends LeaseIntegrationTest {
         builder.takeMutateAssert(taker, "1");
     }
 
+    @Test
+    public void testTakeEvictedLease() throws LeasingException, InterruptedException {
+        TestHarnessBuilder builder = new TestHarnessBuilder(leaseRefresher);
+
+        builder.withLease("1", "bar").build();
+
+        // This should not take anything because the lease is new and owned.
+        builder.takeMutateAssert(taker);
+
+        builder.evictLease("1");
+
+        // This should take because the lease has been evicted
+        builder.takeMutateAssert(taker, "1");
+    }
+
     /**
      * Verify that we take leases non-greedily by setting up an environment where there are 4 leases and 2 workers,
      * only one of which holds a lease. This leaves 3 free leases, but LeaseTaker should decide it needs 2 leases and
@@ -203,7 +218,7 @@ public class DynamoDBLeaseTakerIntegrationTest extends LeaseIntegrationTest {
     /**
      * Verify that one activity is stolen from the highest loaded server when a server needs more than one lease and no
      * expired leases are available. Setup: 4 leases, server foo holds 0, bar holds 1, baz holds 5.
-     * 
+     *
      * Foo should steal from baz.
      */
     @Test

--- a/amazon-kinesis-client/src/test/java/software/amazon/kinesis/leases/dynamodb/TestHarnessBuilder.java
+++ b/amazon-kinesis-client/src/test/java/software/amazon/kinesis/leases/dynamodb/TestHarnessBuilder.java
@@ -30,6 +30,7 @@ import software.amazon.kinesis.leases.LeaseRenewer;
 import software.amazon.kinesis.leases.exceptions.DependencyException;
 import software.amazon.kinesis.leases.exceptions.InvalidStateException;
 import software.amazon.kinesis.leases.exceptions.LeasingException;
+import software.amazon.kinesis.leases.exceptions.ProvisionedThroughputException;
 import software.amazon.kinesis.retrieval.kpl.ExtendedSequenceNumber;
 
 public class TestHarnessBuilder {
@@ -94,6 +95,11 @@ public class TestHarnessBuilder {
 
     public void passTime(long millis) {
         currentTimeNanos += millis * 1000000;
+    }
+
+    public void evictLease(String shardId) throws DependencyException, InvalidStateException, ProvisionedThroughputException {
+      Lease lease = leases.get(shardId);
+      leaseRefresher.evictLease(lease);
     }
 
     public Map<String, Lease> takeMutateAssert(DynamoDBLeaseTaker taker, int numToTake)

--- a/amazon-kinesis-client/src/test/java/software/amazon/kinesis/lifecycle/ConsumerStatesTest.java
+++ b/amazon-kinesis-client/src/test/java/software/amazon/kinesis/lifecycle/ConsumerStatesTest.java
@@ -118,6 +118,7 @@ public class ConsumerStatesTest {
     private long idleTimeInMillis = 1000L;
     private Optional<Long> logWarningForTaskAfterMillis = Optional.empty();
     private SchemaRegistryDecoder schemaRegistryDecoder = null;
+    private boolean evictLeaseOnShutdown = false;
 
     @Before
     public void setup() {
@@ -126,7 +127,7 @@ public class ConsumerStatesTest {
                 taskBackoffTimeMillis, skipShardSyncAtWorkerInitializationIfLeasesExist, listShardsBackoffTimeInMillis,
                 maxListShardsRetryAttempts, shouldCallProcessRecordsEvenForEmptyRecordList, idleTimeInMillis,
                 INITIAL_POSITION_IN_STREAM, cleanupLeasesOfCompletedShards, ignoreUnexpectedChildShards, shardDetector,
-                new AggregatorUtil(), hierarchicalShardSyncer, metricsFactory, leaseCleanupManager, schemaRegistryDecoder);
+                new AggregatorUtil(), hierarchicalShardSyncer, metricsFactory, leaseCleanupManager, schemaRegistryDecoder, evictLeaseOnShutdown);
         when(shardInfo.shardId()).thenReturn("shardId-000000000000");
         when(shardInfo.streamIdentifierSerOpt()).thenReturn(Optional.of(StreamIdentifier.singleStreamInstance(STREAM_NAME).serialize()));
         consumer = spy(new ShardConsumer(recordsPublisher, executorService, shardInfo, logWarningForTaskAfterMillis,


### PR DESCRIPTION
*Issue #, if available:* https://github.com/awslabs/amazon-kinesis-client/issues/845

*Description of changes:*
We have this latency issue in production where on graceful shutdown we have seen up to 40s before records resume processing on a new container. 

The cause of it is that on graceful shutdown, the lease stays owned. Others wait for lease to expire before picking them up. See https://github.com/awslabs/amazon-kinesis-client/issues/845 for details, this is pretty well explained.

The changes im proposing here are:
- Consider unassigned lease (without owners) as available for the taking (inspired by https://github.com/awslabs/amazon-kinesis-client/pull/848)
- Evict lease on graceful shutdown
- Expose leaseTakerIntervalMillis option so we can set a value that isnt based on the lease duration

With these changes, I was able to go below 1s before records resumed consumption. 

So I would like some opinions on this. We will test this in various envs and see the impacts. If this goes through this would be a contribution by Autodesk.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
