### PR TITLE
Use AFTER_SEQUENCE_NUMBER iterator type for expired iterator request

### DIFF
--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/IteratorBuilder.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/IteratorBuilder.java
@@ -42,12 +42,12 @@ public class IteratorBuilder {
     }
 
     /**
-     * Creates a GetShardIteratorRequest builder that uses AT_SEQUENCE_NUMBER GetShardIterator.
+     * Creates a GetShardIteratorRequest builder that uses AT_SEQUENCE_NUMBER ShardIteratorType.
      *
      * @param builder         An initial GetShardIteratorRequest builder to be updated.
      * @param sequenceNumber  The sequence number to restart the request from.
      * @param initialPosition One of LATEST, TRIM_HORIZON, or AT_TIMESTAMP.
-     * @return An updated GetShardIteratorRequest.Builder
+     * @return An updated GetShardIteratorRequest.Builder.
      */
     public static GetShardIteratorRequest.Builder request(GetShardIteratorRequest.Builder builder,
                                                           String sequenceNumber,
@@ -57,12 +57,12 @@ public class IteratorBuilder {
     }
 
     /**
-     * Creates a GetShardIteratorRequest builder that uses AFTER_SEQUENCE_NUMBER GetShardIterator.
+     * Creates a GetShardIteratorRequest builder that uses AFTER_SEQUENCE_NUMBER ShardIteratorType.
      *
      * @param builder         An initial GetShardIteratorRequest builder to be updated.
      * @param sequenceNumber  The sequence number to restart the request from.
      * @param initialPosition One of LATEST, TRIM_HORIZON, or AT_TIMESTAMP.
-     * @return An updated GetShardIteratorRequest.Builder
+     * @return An updated GetShardIteratorRequest.Builder.
      */
     public static GetShardIteratorRequest.Builder reconnectRequest(GetShardIteratorRequest.Builder builder,
                                                                    String sequenceNumber,

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/IteratorBuilder.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/IteratorBuilder.java
@@ -42,10 +42,25 @@ public class IteratorBuilder {
     }
 
     public static GetShardIteratorRequest.Builder request(GetShardIteratorRequest.Builder builder,
-            String sequenceNumber, InitialPositionInStreamExtended initialPosition) {
+                                                          String sequenceNumber,
+                                                          InitialPositionInStreamExtended initialPosition) {
+        return getShardIteratorRequest(builder, sequenceNumber, initialPosition, ShardIteratorType.AT_SEQUENCE_NUMBER);
+
+    }
+
+    public static GetShardIteratorRequest.Builder reconnectRequest(GetShardIteratorRequest.Builder builder,
+                                                                   String sequenceNumber,
+                                                                   InitialPositionInStreamExtended initialPosition) {
+        return getShardIteratorRequest(builder, sequenceNumber, initialPosition, ShardIteratorType.AFTER_SEQUENCE_NUMBER);
+    }
+
+    private static GetShardIteratorRequest.Builder getShardIteratorRequest(GetShardIteratorRequest.Builder builder,
+                                                                           String sequenceNumber,
+                                                                           InitialPositionInStreamExtended initialPosition,
+                                                                           ShardIteratorType shardIteratorType) {
         return apply(builder, GetShardIteratorRequest.Builder::shardIteratorType, GetShardIteratorRequest.Builder::timestamp,
                 GetShardIteratorRequest.Builder::startingSequenceNumber, initialPosition, sequenceNumber,
-                ShardIteratorType.AT_SEQUENCE_NUMBER);
+                shardIteratorType);
     }
 
     private final static Map<String, ShardIteratorType> SHARD_ITERATOR_MAPPING;

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/IteratorBuilder.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/IteratorBuilder.java
@@ -41,6 +41,14 @@ public class IteratorBuilder {
                 ShardIteratorType.AFTER_SEQUENCE_NUMBER);
     }
 
+    /**
+     * Creates a GetShardIteratorRequest builder that uses AT_SEQUENCE_NUMBER GetShardIterator.
+     *
+     * @param builder         An initial GetShardIteratorRequest builder to be updated.
+     * @param sequenceNumber  The sequence number to restart the request from.
+     * @param initialPosition One of LATEST, TRIM_HORIZON, or AT_TIMESTAMP.
+     * @return An updated GetShardIteratorRequest.Builder
+     */
     public static GetShardIteratorRequest.Builder request(GetShardIteratorRequest.Builder builder,
                                                           String sequenceNumber,
                                                           InitialPositionInStreamExtended initialPosition) {
@@ -48,6 +56,14 @@ public class IteratorBuilder {
 
     }
 
+    /**
+     * Creates a GetShardIteratorRequest builder that uses AFTER_SEQUENCE_NUMBER GetShardIterator.
+     *
+     * @param builder         An initial GetShardIteratorRequest builder to be updated.
+     * @param sequenceNumber  The sequence number to restart the request from.
+     * @param initialPosition One of LATEST, TRIM_HORIZON, or AT_TIMESTAMP.
+     * @return An updated GetShardIteratorRequest.Builder
+     */
     public static GetShardIteratorRequest.Builder reconnectRequest(GetShardIteratorRequest.Builder builder,
                                                                    String sequenceNumber,
                                                                    InitialPositionInStreamExtended initialPosition) {

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/polling/KinesisDataFetcher.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/polling/KinesisDataFetcher.java
@@ -237,9 +237,11 @@ public class KinesisDataFetcher implements DataFetcher {
 
         GetShardIteratorRequest.Builder builder = KinesisRequestsBuilder.getShardIteratorRequestBuilder()
                 .streamName(streamIdentifier.streamName()).shardId(shardId);
-        GetShardIteratorRequest request = IteratorBuilder.request(builder, sequenceNumber, initialPositionInStream).build();
+        GetShardIteratorRequest request;
         if (isIteratorRestart) {
             request = IteratorBuilder.reconnectRequest(builder, sequenceNumber, initialPositionInStream).build();
+        } else {
+            request = IteratorBuilder.request(builder, sequenceNumber, initialPositionInStream).build();
         }
 
         // TODO: Check if this metric is fine to be added
@@ -287,8 +289,8 @@ public class KinesisDataFetcher implements DataFetcher {
             throw new IllegalStateException(
                     "Make sure to initialize the KinesisDataFetcher before restarting the iterator.");
         }
-        log.debug("Getting a new next shard iterator for sequence number {} " +
-                "for streamAndShardId {}", lastKnownSequenceNumber, streamAndShardId);
+        log.debug("Restarting iterator for sequence number {} on shard id {}",
+                lastKnownSequenceNumber, streamAndShardId);
         advanceIteratorTo(lastKnownSequenceNumber, initialPositionInStream, true);
     }
 

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/polling/PrefetchRecordsPublisher.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/polling/PrefetchRecordsPublisher.java
@@ -502,6 +502,8 @@ public class PrefetchRecordsPublisher implements RecordsPublisher {
                             calculateHighestSequenceNumber(processRecordsInput), getRecordsResult.nextShardIterator(),
                             PrefetchRecordsRetrieved.generateBatchUniqueIdentifier());
                     publisherSession.highestSequenceNumber(recordsRetrieved.lastBatchSequenceNumber);
+                    log.debug("Last sequence number retrieved for streamAndShardId {} is {}", streamAndShardId,
+                            recordsRetrieved.lastBatchSequenceNumber);
                     addArrivedRecordsInput(recordsRetrieved);
                     drainQueueForRequests();
                 } catch (PositionResetException pse) {

--- a/amazon-kinesis-client/src/test/java/software/amazon/kinesis/retrieval/IteratorBuilderTest.java
+++ b/amazon-kinesis-client/src/test/java/software/amazon/kinesis/retrieval/IteratorBuilderTest.java
@@ -63,6 +63,12 @@ public class IteratorBuilderTest {
     }
 
     @Test
+    public void getShardIteratorReconnectTest() {
+        sequenceNumber(this::gsiBase, this::verifyGsiBase, IteratorBuilder::reconnectRequest, WrappedRequest::wrapped,
+                ShardIteratorType.AFTER_SEQUENCE_NUMBER);
+    }
+
+    @Test
     public void subscribeTimestampTest() {
         timeStampTest(this::stsBase, this::verifyStsBase, IteratorBuilder::request, WrappedRequest::wrapped);
     }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Updating the restartIterator logic in the KinesisDataFetcher class to use AFTER_SEQUENCE_NUMBER iterator call to prevent the last retrieved record from being retrieved again when the iterator expires. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
