### PR TITLE
Refactored `MultiStreamTracker` to provide and enhance OOP for both

### DIFF
--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/common/DeprecationUtils.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/common/DeprecationUtils.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2023 Amazon.com, Inc. or its affiliates.
+ * Licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package software.amazon.kinesis.common;
+
+import java.util.function.Function;
+
+import software.amazon.awssdk.utils.Either;
+import software.amazon.kinesis.processor.MultiStreamTracker;
+import software.amazon.kinesis.processor.SingleStreamTracker;
+import software.amazon.kinesis.processor.StreamTracker;
+
+/**
+ * Utility methods to facilitate deprecated code until that deprecated code
+ * can be safely removed.
+ */
+public final class DeprecationUtils {
+
+    private DeprecationUtils() {
+        throw new UnsupportedOperationException("utility class");
+    }
+
+    /**
+     * Converts a {@link StreamTracker} into the deprecated {@code Either<L, R>} convention.
+     *
+     * @param streamTracker tracker to convert
+     */
+    @Deprecated
+    public static <R> Either<MultiStreamTracker, R> convert(
+            StreamTracker streamTracker,
+            Function<SingleStreamTracker, R> converter) {
+        if (streamTracker instanceof MultiStreamTracker) {
+            return Either.left((MultiStreamTracker) streamTracker);
+        } else if (streamTracker instanceof SingleStreamTracker) {
+            return Either.right(converter.apply((SingleStreamTracker) streamTracker));
+        } else {
+            throw new IllegalArgumentException("Unhandled StreamTracker: " + streamTracker);
+        }
+    }
+
+}

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/processor/MultiStreamTracker.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/processor/MultiStreamTracker.java
@@ -15,43 +15,14 @@
 
 package software.amazon.kinesis.processor;
 
-import software.amazon.kinesis.common.InitialPositionInStream;
-import software.amazon.kinesis.common.InitialPositionInStreamExtended;
-import software.amazon.kinesis.common.StreamConfig;
-
-import java.util.List;
-
 /**
- * Interface for stream trackers. This is useful for KCL Workers that need
- * to consume data from multiple streams.
- * KCL will periodically probe this interface to learn about the new and old streams.
+ * Tracker for consuming multiple Kinesis streams.
  */
-public interface MultiStreamTracker {
+public interface MultiStreamTracker extends StreamTracker {
 
-    /**
-     * Returns the list of stream config, to be processed by the current application.
-     * <b>Note that the streams list CAN be changed during the application runtime.</b>
-     * This method will be called periodically by the KCL to learn about the change in streams to process.
-     *
-     * @return List of StreamConfig
-     */
-    List<StreamConfig> streamConfigList();
-
-    /**
-     * Strategy to delete leases of old streams in the lease table.
-     * <b>Note that the strategy CANNOT be changed during the application runtime.</b>
-     *
-     * @return StreamsLeasesDeletionStrategy
-     */
-    FormerStreamsLeasesDeletionStrategy formerStreamsLeasesDeletionStrategy();
-
-    /**
-     * The position for getting records from an "orphaned" stream that is in the lease table but not tracked
-     * Default assumes that the stream no longer need to be tracked, so use LATEST for faster shard end.
-     *
-     * <p>Default value: {@link InitialPositionInStream#LATEST}</p>
-     */
-    default InitialPositionInStreamExtended orphanedStreamInitialPositionInStream() {
-        return InitialPositionInStreamExtended.newInitialPosition(InitialPositionInStream.LATEST);
+    @Override
+    default boolean isMultiStream() {
+        return true;
     }
+
 }

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/processor/SingleStreamTracker.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/processor/SingleStreamTracker.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2023 Amazon.com, Inc. or its affiliates.
+ * Licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package software.amazon.kinesis.processor;
+
+import java.util.Collections;
+import java.util.List;
+
+import lombok.EqualsAndHashCode;
+import lombok.NonNull;
+import lombok.ToString;
+import software.amazon.kinesis.common.InitialPositionInStreamExtended;
+import software.amazon.kinesis.common.StreamConfig;
+import software.amazon.kinesis.common.StreamIdentifier;
+
+/**
+ * Tracker for consuming a single Kinesis stream.
+ */
+@EqualsAndHashCode
+@ToString
+public class SingleStreamTracker implements StreamTracker {
+
+    /**
+     * By default, single-stream applications should expect the target stream
+     * to exist for the duration of the application. Therefore, there is no
+     * expectation for the leases to be deleted mid-execution.
+     */
+    private static final FormerStreamsLeasesDeletionStrategy NO_LEASE_DELETION =
+            new FormerStreamsLeasesDeletionStrategy.NoLeaseDeletionStrategy();
+
+    private final StreamIdentifier streamIdentifier;
+
+    private final List<StreamConfig> streamConfigs;
+
+    public SingleStreamTracker(String streamName) {
+        this(StreamIdentifier.singleStreamInstance(streamName));
+    }
+
+    public SingleStreamTracker(StreamIdentifier streamIdentifier) {
+        this(streamIdentifier, DEFAULT_POSITION_IN_STREAM);
+    }
+
+    public SingleStreamTracker(
+            StreamIdentifier streamIdentifier,
+            @NonNull InitialPositionInStreamExtended initialPosition) {
+        this(streamIdentifier, new StreamConfig(streamIdentifier, initialPosition));
+    }
+
+    public SingleStreamTracker(@NonNull StreamIdentifier streamIdentifier, @NonNull StreamConfig streamConfig) {
+        this.streamIdentifier = streamIdentifier;
+        this.streamConfigs = Collections.singletonList(streamConfig);
+    }
+
+    @Override
+    public List<StreamConfig> streamConfigList() {
+        return streamConfigs;
+    }
+
+    @Override
+    public FormerStreamsLeasesDeletionStrategy formerStreamsLeasesDeletionStrategy() {
+        return NO_LEASE_DELETION;
+    }
+
+    @Override
+    public boolean isMultiStream() {
+        return false;
+    }
+
+}

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/processor/StreamTracker.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/processor/StreamTracker.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates.
+ * Licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package software.amazon.kinesis.processor;
+
+import software.amazon.kinesis.common.InitialPositionInStream;
+import software.amazon.kinesis.common.InitialPositionInStreamExtended;
+import software.amazon.kinesis.common.StreamConfig;
+import software.amazon.kinesis.common.StreamIdentifier;
+
+import java.util.List;
+
+/**
+ * Interface for stream trackers.
+ * KCL will periodically probe this interface to learn about the new and old streams.
+ */
+public interface StreamTracker {
+
+    /**
+     * Default position to begin consuming records from a Kinesis stream.
+     *
+     * @see #orphanedStreamInitialPositionInStream()
+     */
+    InitialPositionInStreamExtended DEFAULT_POSITION_IN_STREAM =
+            InitialPositionInStreamExtended.newInitialPosition(InitialPositionInStream.LATEST);
+
+    /**
+     * Returns the list of stream config, to be processed by the current application.
+     * <b>Note that the streams list CAN be changed during the application runtime.</b>
+     * This method will be called periodically by the KCL to learn about the change in streams to process.
+     *
+     * @return List of StreamConfig
+     */
+    List<StreamConfig> streamConfigList();
+
+    /**
+     * Strategy to delete leases of old streams in the lease table.
+     * <b>Note that the strategy CANNOT be changed during the application runtime.</b>
+     *
+     * @return StreamsLeasesDeletionStrategy
+     */
+    FormerStreamsLeasesDeletionStrategy formerStreamsLeasesDeletionStrategy();
+
+    /**
+     * The position for getting records from an "orphaned" stream that is in the lease table but not tracked
+     * Default assumes that the stream no longer need to be tracked, so use LATEST for faster shard end.
+     *
+     * <p>Default value: {@link InitialPositionInStream#LATEST}</p>
+     */
+    default InitialPositionInStreamExtended orphanedStreamInitialPositionInStream() {
+        return DEFAULT_POSITION_IN_STREAM;
+    }
+
+    /**
+     * Returns a new {@link StreamConfig} for the provided stream identifier.
+     *
+     * @param streamIdentifier stream for which to create a new config
+     */
+    default StreamConfig createStreamConfig(StreamIdentifier streamIdentifier) {
+        return new StreamConfig(streamIdentifier, orphanedStreamInitialPositionInStream());
+    }
+
+    /**
+     * Returns true if this application should accommodate the consumption of
+     * more than one Kinesis stream.
+     * <p>
+     * <b>This method must be consistent.</b> Varying the returned value will
+     * have indeterminate, and likely problematic, effects on stream processing.
+     * </p>
+     */
+    boolean isMultiStream();
+
+}

--- a/amazon-kinesis-client/src/test/java/software/amazon/kinesis/common/ConfigsBuilderTest.java
+++ b/amazon-kinesis-client/src/test/java/software/amazon/kinesis/common/ConfigsBuilderTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2023 Amazon.com, Inc. or its affiliates.
+ * Licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package software.amazon.kinesis.common;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.mockito.Mockito.mock;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import software.amazon.awssdk.services.cloudwatch.CloudWatchAsyncClient;
+import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient;
+import software.amazon.awssdk.services.kinesis.KinesisAsyncClient;
+import software.amazon.kinesis.processor.MultiStreamTracker;
+import software.amazon.kinesis.processor.ShardRecordProcessorFactory;
+import software.amazon.kinesis.processor.SingleStreamTracker;
+import software.amazon.kinesis.processor.StreamTracker;
+
+public class ConfigsBuilderTest {
+
+    @Mock
+    private KinesisAsyncClient mockKinesisClient;
+
+    @Mock
+    private DynamoDbAsyncClient mockDynamoClient;
+
+    @Mock
+    private CloudWatchAsyncClient mockCloudWatchClient;
+
+    @Mock
+    private ShardRecordProcessorFactory mockShardProcessorFactory;
+
+    private static final String APPLICATION_NAME = ConfigsBuilderTest.class.getSimpleName();
+    private static final String WORKER_IDENTIFIER = "worker-id";
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    public void testTrackerConstruction() {
+        final String streamName = "single-stream";
+        final ConfigsBuilder configByName = createConfig(streamName);
+        final ConfigsBuilder configBySingleTracker = createConfig(new SingleStreamTracker(streamName));
+
+        for (final ConfigsBuilder cb : Arrays.asList(configByName, configBySingleTracker)) {
+            assertEquals(Optional.empty(), cb.appStreamTracker().left());
+            assertEquals(streamName, cb.appStreamTracker().right().get());
+            assertEquals(streamName, cb.streamTracker().streamConfigList().get(0).streamIdentifier().streamName());
+            assertFalse(cb.streamTracker().isMultiStream());
+        }
+
+        final StreamTracker mockMultiStreamTracker = mock(MultiStreamTracker.class);
+        final ConfigsBuilder configByMultiTracker = createConfig(mockMultiStreamTracker);
+        assertEquals(Optional.empty(), configByMultiTracker.appStreamTracker().right());
+        assertEquals(mockMultiStreamTracker, configByMultiTracker.appStreamTracker().left().get());
+        assertEquals(mockMultiStreamTracker, configByMultiTracker.streamTracker());
+    }
+
+    private ConfigsBuilder createConfig(String streamName) {
+        return new ConfigsBuilder(streamName, APPLICATION_NAME, mockKinesisClient, mockDynamoClient,
+                mockCloudWatchClient, WORKER_IDENTIFIER, mockShardProcessorFactory);
+    }
+
+    private ConfigsBuilder createConfig(StreamTracker streamTracker) {
+        return new ConfigsBuilder(streamTracker, APPLICATION_NAME, mockKinesisClient, mockDynamoClient,
+                mockCloudWatchClient, WORKER_IDENTIFIER, mockShardProcessorFactory);
+    }
+
+}

--- a/amazon-kinesis-client/src/test/java/software/amazon/kinesis/common/DeprecationUtilsTest.java
+++ b/amazon-kinesis-client/src/test/java/software/amazon/kinesis/common/DeprecationUtilsTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2023 Amazon.com, Inc. or its affiliates.
+ * Licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package software.amazon.kinesis.common;
+
+import java.util.function.Function;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+
+import org.junit.Test;
+import software.amazon.awssdk.utils.Either;
+import software.amazon.kinesis.processor.MultiStreamTracker;
+import software.amazon.kinesis.processor.SingleStreamTracker;
+import software.amazon.kinesis.processor.StreamTracker;
+
+public class DeprecationUtilsTest {
+
+    @Test
+    public void testTrackerConversion() {
+        final StreamTracker mockMultiTracker = mock(MultiStreamTracker.class);
+        assertEquals(Either.left(mockMultiTracker), DeprecationUtils.convert(mockMultiTracker, Function.identity()));
+
+        final StreamTracker mockSingleTracker = mock(SingleStreamTracker.class);
+        assertEquals(Either.right(mockSingleTracker), DeprecationUtils.convert(mockSingleTracker, Function.identity()));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testUnsupportedStreamTrackerConversion() {
+        DeprecationUtils.convert(mock(StreamTracker.class), Function.identity());
+    }
+
+}

--- a/amazon-kinesis-client/src/test/java/software/amazon/kinesis/processor/SingleStreamTrackerTest.java
+++ b/amazon-kinesis-client/src/test/java/software/amazon/kinesis/processor/SingleStreamTrackerTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2023 Amazon.com, Inc. or its affiliates.
+ * Licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package software.amazon.kinesis.processor;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertThat;
+
+import org.hamcrest.Matchers;
+import org.junit.Test;
+import software.amazon.kinesis.common.InitialPositionInStream;
+import software.amazon.kinesis.common.InitialPositionInStreamExtended;
+import software.amazon.kinesis.common.StreamConfig;
+import software.amazon.kinesis.common.StreamIdentifier;
+
+public class SingleStreamTrackerTest {
+
+    private static final String STREAM_NAME = SingleStreamTrackerTest.class.getSimpleName();
+
+    @Test
+    public void testDefaults() {
+        validate(new SingleStreamTracker(STREAM_NAME));
+        validate(new SingleStreamTracker(StreamIdentifier.singleStreamInstance(STREAM_NAME)));
+    }
+
+    @Test
+    public void testInitialPositionConstructor() {
+        final InitialPositionInStreamExtended expectedPosition =
+                InitialPositionInStreamExtended.newInitialPosition(InitialPositionInStream.TRIM_HORIZON);
+        assertNotEquals(expectedPosition, StreamTracker.DEFAULT_POSITION_IN_STREAM);
+
+        final StreamTracker tracker = new SingleStreamTracker(
+                StreamIdentifier.singleStreamInstance(STREAM_NAME), expectedPosition);
+        validate(tracker, expectedPosition);
+    }
+
+    private static void validate(StreamTracker tracker) {
+        validate(tracker, StreamTracker.DEFAULT_POSITION_IN_STREAM);
+    }
+
+    private static void validate(StreamTracker tracker, InitialPositionInStreamExtended expectedPosition) {
+        assertEquals(1, tracker.streamConfigList().size());
+        assertFalse(tracker.isMultiStream());
+        assertThat(tracker.formerStreamsLeasesDeletionStrategy(),
+                Matchers.instanceOf(FormerStreamsLeasesDeletionStrategy.NoLeaseDeletionStrategy.class));
+
+        final StreamConfig config = tracker.streamConfigList().get(0);
+        assertEquals(STREAM_NAME, config.streamIdentifier().streamName());
+        assertEquals(expectedPosition, config.initialPositionInStreamExtended());
+    }
+
+}

--- a/amazon-kinesis-client/src/test/java/software/amazon/kinesis/retrieval/RetrievalConfigTest.java
+++ b/amazon-kinesis-client/src/test/java/software/amazon/kinesis/retrieval/RetrievalConfigTest.java
@@ -1,0 +1,85 @@
+package software.amazon.kinesis.retrieval;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.mockito.Mockito.mock;
+import static software.amazon.kinesis.common.InitialPositionInStream.LATEST;
+import static software.amazon.kinesis.common.InitialPositionInStream.TRIM_HORIZON;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import software.amazon.awssdk.services.kinesis.KinesisAsyncClient;
+import software.amazon.kinesis.common.InitialPositionInStreamExtended;
+import software.amazon.kinesis.common.StreamConfig;
+import software.amazon.kinesis.processor.MultiStreamTracker;
+import software.amazon.kinesis.processor.SingleStreamTracker;
+import software.amazon.kinesis.processor.StreamTracker;
+
+public class RetrievalConfigTest {
+
+    private static final String APPLICATION_NAME = RetrievalConfigTest.class.getSimpleName();
+
+    @Mock
+    private KinesisAsyncClient mockKinesisClient;
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    public void testTrackerConstruction() {
+        final String streamName = "single-stream";
+        final RetrievalConfig configByName = createConfig(streamName);
+        final SingleStreamTracker singleTracker = new SingleStreamTracker(streamName);
+        final RetrievalConfig configBySingleTracker = createConfig(singleTracker);
+
+        for (final RetrievalConfig rc : Arrays.asList(configByName, configBySingleTracker)) {
+            assertEquals(Optional.empty(), rc.appStreamTracker().left());
+            assertEquals(singleTracker, rc.streamTracker());
+            assertEquals(1, rc.streamTracker().streamConfigList().size());
+            assertFalse(rc.streamTracker().isMultiStream());
+        }
+
+        final StreamTracker mockMultiStreamTracker = mock(MultiStreamTracker.class);
+        final RetrievalConfig configByMultiTracker = createConfig(mockMultiStreamTracker);
+        assertEquals(Optional.empty(), configByMultiTracker.appStreamTracker().right());
+        assertEquals(mockMultiStreamTracker, configByMultiTracker.appStreamTracker().left().get());
+        assertEquals(mockMultiStreamTracker, configByMultiTracker.streamTracker());
+    }
+
+    @Test
+    public void testUpdateInitialPositionInSingleStream() {
+        final RetrievalConfig config = createConfig(new SingleStreamTracker("foo"));
+
+        for (final StreamConfig sc : config.streamTracker().streamConfigList()) {
+            assertEquals(LATEST, sc.initialPositionInStreamExtended().getInitialPositionInStream());
+        }
+        config.initialPositionInStreamExtended(
+                InitialPositionInStreamExtended.newInitialPosition(TRIM_HORIZON));
+        for (final StreamConfig sc : config.streamTracker().streamConfigList()) {
+            assertEquals(TRIM_HORIZON, sc.initialPositionInStreamExtended().getInitialPositionInStream());
+        }
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testUpdateInitialPositionInMultiStream() {
+        final RetrievalConfig config = createConfig(mock(MultiStreamTracker.class));
+        config.initialPositionInStreamExtended(
+                InitialPositionInStreamExtended.newInitialPosition(TRIM_HORIZON));
+    }
+
+    private RetrievalConfig createConfig(String streamName) {
+        return new RetrievalConfig(mockKinesisClient, streamName, APPLICATION_NAME);
+    }
+
+    private RetrievalConfig createConfig(StreamTracker streamTracker) {
+        return new RetrievalConfig(mockKinesisClient, streamTracker, APPLICATION_NAME);
+    }
+
+}


### PR DESCRIPTION
*Issue #, if available:*
n/a

*Description of changes:*
Refactored `MultiStreamTracker` to provide and enhance OOP for both single- and multi-stream trackers.

+ converted `Scheduler#currentStreamConfigMap` to `ConcurrentHashMap`
+ eliminated a responsibility from Scheduler (i.e., orphan config generation)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.