### PR TITLE
Optimization: 9~15% improvement in `KinesisDataFetcher` wall-time after

### DIFF
--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/AWSExceptionManager.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/AWSExceptionManager.java
@@ -26,7 +26,9 @@ import lombok.experimental.Accessors;
 import software.amazon.kinesis.annotations.KinesisClientInternalApi;
 
 /**
- *
+ * Traverses a {@code Throwable} class inheritance in search of a mapping
+ * function which will convert that throwable into a {@code RuntimeException}.
+ * If no mapping function is found, the default function will be applied.
  */
 @KinesisClientInternalApi
 public class AWSExceptionManager {

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/polling/KinesisDataFetcher.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/polling/KinesisDataFetcher.java
@@ -28,14 +28,12 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import software.amazon.awssdk.core.exception.SdkException;
 import software.amazon.awssdk.services.kinesis.KinesisAsyncClient;
-import software.amazon.awssdk.services.kinesis.model.ChildShard;
 import software.amazon.awssdk.services.kinesis.model.GetRecordsRequest;
 import software.amazon.awssdk.services.kinesis.model.GetRecordsResponse;
 import software.amazon.awssdk.services.kinesis.model.GetShardIteratorRequest;
 import software.amazon.awssdk.services.kinesis.model.GetShardIteratorResponse;
 import software.amazon.awssdk.services.kinesis.model.KinesisException;
 import software.amazon.awssdk.services.kinesis.model.ResourceNotFoundException;
-import software.amazon.awssdk.utils.CollectionUtils;
 import software.amazon.kinesis.annotations.KinesisClientInternalApi;
 import software.amazon.kinesis.common.FutureUtils;
 import software.amazon.kinesis.common.InitialPositionInStreamExtended;
@@ -48,7 +46,6 @@ import software.amazon.kinesis.metrics.MetricsUtil;
 import software.amazon.kinesis.retrieval.AWSExceptionManager;
 import software.amazon.kinesis.retrieval.DataFetcherProviderConfig;
 import software.amazon.kinesis.retrieval.DataFetcherResult;
-import software.amazon.kinesis.retrieval.DataRetrievalUtil;
 import software.amazon.kinesis.retrieval.IteratorBuilder;
 import software.amazon.kinesis.retrieval.KinesisDataFetcherProviderConfig;
 import software.amazon.kinesis.retrieval.RetryableRetrievalException;
@@ -65,6 +62,14 @@ public class KinesisDataFetcher implements DataFetcher {
 
     private static final String METRICS_PREFIX = "KinesisDataFetcher";
     private static final String OPERATION = "ProcessTask";
+
+    /**
+     * Reusable {@link AWSExceptionManager}.
+     * <p>
+     * N.B. This instance is mutable, but thread-safe for <b>read-only</b> use.
+     * </p>
+     */
+    private static final AWSExceptionManager AWS_EXCEPTION_MANAGER = createExceptionManager();
 
     @NonNull
     private final KinesisAsyncClient kinesisClient;
@@ -91,8 +96,6 @@ public class KinesisDataFetcher implements DataFetcher {
 
     /**
      * Note: This method has package level access for testing purposes.
-     *
-     * @return nextIterator
      */
     @Getter(AccessLevel.PACKAGE)
     private String nextIterator;
@@ -233,8 +236,6 @@ public class KinesisDataFetcher implements DataFetcher {
             throw new IllegalArgumentException("SequenceNumber should not be null: shardId " + shardId);
         }
 
-        final AWSExceptionManager exceptionManager = createExceptionManager();
-
         GetShardIteratorRequest.Builder builder = KinesisRequestsBuilder.getShardIteratorRequestBuilder()
                 .streamName(streamIdentifier.streamName()).shardId(shardId);
         GetShardIteratorRequest request;
@@ -256,7 +257,7 @@ public class KinesisDataFetcher implements DataFetcher {
                 nextIterator = getNextIterator(request);
                 success = true;
             } catch (ExecutionException e) {
-                throw exceptionManager.apply(e.getCause());
+                throw AWS_EXCEPTION_MANAGER.apply(e.getCause());
             } catch (InterruptedException e) {
                 // TODO: Check behavior
                 throw new RuntimeException(e);
@@ -328,7 +329,6 @@ public class KinesisDataFetcher implements DataFetcher {
 
     @Override
     public GetRecordsResponse getRecords(@NonNull final String nextIterator) {
-        final AWSExceptionManager exceptionManager = createExceptionManager();
         GetRecordsRequest request = getGetRecordsRequest(nextIterator);
 
         final MetricsScope metricsScope = MetricsUtil.createMetricsWithOperation(metricsFactory, OPERATION);
@@ -341,7 +341,7 @@ public class KinesisDataFetcher implements DataFetcher {
             success = true;
             return response;
         } catch (ExecutionException e) {
-            throw exceptionManager.apply(e.getCause());
+            throw AWS_EXCEPTION_MANAGER.apply(e.getCause());
         } catch (InterruptedException e) {
             // TODO: Check behavior
             log.debug("{} : Interrupt called on method, shutdown initiated", streamAndShardId);
@@ -355,7 +355,7 @@ public class KinesisDataFetcher implements DataFetcher {
         }
     }
 
-    private AWSExceptionManager createExceptionManager() {
+    private static AWSExceptionManager createExceptionManager() {
         final AWSExceptionManager exceptionManager = new AWSExceptionManager();
         exceptionManager.add(ResourceNotFoundException.class, t -> t);
         exceptionManager.add(KinesisException.class, t -> t);


### PR DESCRIPTION
*Issue #, if available:*
n/a

*Description of changes:*
Optimization: 9~15% improvement in `KinesisDataFetcher` wall-time after converting `AWSExceptionManger` to a static variable.

Timed using multiple loops of 10k iterations/loop. Observed time decreased from `(p50=267ms, p100=398ms)` to `(p50=245ms, p100=307ms)`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
