### PR TITLE
Updated the dependency to fix vulnerability issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
 # Changelog
 ### Latest Release (1.14.10 - Feb 15, 2023)
-* [Issue #1026](https://github.com/awslabs/amazon-kinesis-client/issues/1026) Dependencies with vulnerabilities in 1.x
-* [PR #1042](https://github.com/awslabs/amazon-kinesis-client/pull/1042) updated the dependency to fix vulnerability issue
+* Updated aws-java-sdk from 1.12.130 to 1.12.406 
+* Updated com.google.protobuf from 3.19.4 to 3.19.6
+  * [Issue #1026](https://github.com/awslabs/amazon-kinesis-client/issues/1026)
+  * [PR #1042](https://github.com/awslabs/amazon-kinesis-client/pull/1042)
 
-### Latest Release (1.14.9 - Dec 14, 2022)
+### Release (1.14.9 - Dec 14, 2022)
 * [#995](https://github.com/awslabs/amazon-kinesis-client/commit/372f98b21a91487e36612d528c56765a44b0aa86) Every other change for DynamoDBStreamsKinesis Adapter Compatibility
 * [#970](https://github.com/awslabs/amazon-kinesis-client/commit/251b331a2e0fd912b50f8b5a12d088bf0b3263b9) PeriodicShardSyncManager Changes Needed for DynamoDBStreamsKinesisAdapter
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+### Latest Release (1.14.10 - Feb 15, 2023)
+* [Issue #1026](https://github.com/awslabs/amazon-kinesis-client/issues/1026) Dependencies with vulnerabilities in 1.x
+* [PR #1042](https://github.com/awslabs/amazon-kinesis-client/pull/1042) updated the dependency to fix vulnerability issue
 
 ### Latest Release (1.14.9 - Dec 14, 2022)
 * [#995](https://github.com/awslabs/amazon-kinesis-client/commit/372f98b21a91487e36612d528c56765a44b0aa86) Every other change for DynamoDBStreamsKinesis Adapter Compatibility

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <artifactId>amazon-kinesis-client</artifactId>
   <packaging>jar</packaging>
   <name>Amazon Kinesis Client Library for Java</name>
-  <version>1.14.9</version>
+  <version>1.14.10</version>
   <description>The Amazon Kinesis Client Library for Java enables Java developers to easily consume and process data
     from Amazon Kinesis.
   </description>
@@ -25,7 +25,7 @@
   </licenses>
 
   <properties>
-    <aws-java-sdk.version>1.12.130</aws-java-sdk.version>
+    <aws-java-sdk.version>1.12.406</aws-java-sdk.version>
     <sqlite4java.version>1.0.392</sqlite4java.version>
     <sqlite4java.native>libsqlite4java</sqlite4java.native>
     <sqlite4java.libpath>${project.build.directory}/test-lib</sqlite4java.libpath>
@@ -60,7 +60,7 @@
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
-      <version>3.19.4</version>
+      <version>3.19.6</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/KinesisClientLibConfiguration.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/KinesisClientLibConfiguration.java
@@ -147,7 +147,7 @@ public class KinesisClientLibConfiguration {
     /**
      * User agent set when Amazon Kinesis Client Library makes AWS requests.
      */
-    public static final String KINESIS_CLIENT_LIB_USER_AGENT = "amazon-kinesis-client-library-java-1.14.9";
+    public static final String KINESIS_CLIENT_LIB_USER_AGENT = "amazon-kinesis-client-library-java-1.14.10";
 
     /**
      * KCL will validate client provided sequence numbers with a call to Amazon Kinesis before checkpointing for calls


### PR DESCRIPTION
Updated the aws-java-sdk and google.protobuf version to fix vulnerability

*Issue #1026:*

*Description of changes:*
* update aws-java-sdk from [1.12.130](https://mvnrepository.com/artifact/com.amazonaws/aws-java-sdk-core/1.12.130) to [1.12.406](https://mvnrepository.com/artifact/com.amazonaws/aws-java-sdk-core/1.12.406)
* update com.google.protobuf from [3.19.4](https://mvnrepository.com/artifact/com.google.protobuf/protobuf-java/3.19.4) to [3.19.6](https://mvnrepository.com/artifact/com.google.protobuf/protobuf-java/3.19.6)



