### PR TITLE
Exposed convenience method of `ExtendedSequenceNumber#isSentinelCheck…

### DIFF
--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/leases/ShardSyncTaskManager.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/leases/ShardSyncTaskManager.java
@@ -205,7 +205,8 @@ public class ShardSyncTaskManager {
 
     private void handlePendingShardSyncs(Throwable exception, TaskResult taskResult) {
         if (exception != null || taskResult.getException() != null) {
-            log.error("Caught exception running {} task: ", currentTask.taskType(), exception != null ? exception : taskResult.getException());
+            log.error("Caught exception running {} task: {}", currentTask.taskType(),
+                    exception != null ? exception : taskResult.getException());
         }
         // Acquire lock here. If shardSyncRequestPending is false in this completionStage and
         // submitShardSyncTask is invoked, before completion stage exits (future completes)

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/leases/exceptions/ShardSyncer.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/leases/exceptions/ShardSyncer.java
@@ -12,14 +12,13 @@ import software.amazon.kinesis.metrics.MetricsScope;
  * Helper class to sync leases with shards of the Kinesis stream.
  * It will create new leases/activities when it discovers new Kinesis shards (bootstrap/resharding).
  * It deletes leases for shards that have been trimmed from Kinesis, or if we've completed processing it
- * and begun processing it's child shards.
+ * and begun processing its child shards.
  *
  * <p>NOTE: This class is deprecated and will be removed in a future release.</p>
  */
 @Deprecated
 public class ShardSyncer {
     private static final HierarchicalShardSyncer HIERARCHICAL_SHARD_SYNCER = new HierarchicalShardSyncer();
-    private static final boolean garbageCollectLeases = true;
 
     /**
      * <p>NOTE: This method is deprecated and will be removed in a future release.</p>

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/lifecycle/ProcessTask.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/lifecycle/ProcessTask.java
@@ -113,7 +113,7 @@ public class ProcessTask implements ConsumerTask {
      */
     @Override
     public TaskResult call() {
-        /**
+        /*
          * NOTE: the difference between appScope and shardScope is, appScope doesn't have shardId as a dimension,
          * therefore all data added to appScope, although from different shard consumer, will be sent to the same metric,
          * which is the app-level MillsBehindLatest metric.
@@ -179,8 +179,6 @@ public class ProcessTask implements ConsumerTask {
             MetricsUtil.endScope(appScope);
         }
     }
-
-
 
     private List<KinesisClientRecord> deaggregateAnyKplRecords(List<KinesisClientRecord> records) {
         if (shard == null) {

--- a/amazon-kinesis-client/src/test/java/software/amazon/kinesis/retrieval/kpl/ExtendedSequenceNumberTest.java
+++ b/amazon-kinesis-client/src/test/java/software/amazon/kinesis/retrieval/kpl/ExtendedSequenceNumberTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2023 Amazon.com, Inc. or its affiliates.
+ * Licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package software.amazon.kinesis.retrieval.kpl;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+import software.amazon.kinesis.checkpoint.SentinelCheckpoint;
+
+public class ExtendedSequenceNumberTest {
+
+    @Test
+    public void testSentinelCheckpoints() {
+        for (final SentinelCheckpoint sentinel : SentinelCheckpoint.values()) {
+            final ExtendedSequenceNumber esn = new ExtendedSequenceNumber(sentinel.name());
+            assertTrue(sentinel.name(), esn.isSentinelCheckpoint());
+
+            // For backwards-compatibility, sentinels should ignore subsequences
+            final ExtendedSequenceNumber esnWithSubsequence = new ExtendedSequenceNumber(sentinel.name(), 42L);
+            assertTrue(sentinel.name(), esnWithSubsequence.isSentinelCheckpoint());
+        }
+    }
+
+}


### PR DESCRIPTION
*Issue #, if available:*
n/a

*Description of changes:*
Exposed convenience method of `ExtendedSequenceNumber#isSentinelCheckpoint()`

+ fixed unrelated parameterized log message in `ShardSyncTaskManager`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
