### PR TITLE
Fix flaky restartAfterRequestTimerExpires tests

### DIFF
--- a/amazon-kinesis-client/src/test/java/software/amazon/kinesis/lifecycle/ShardConsumerSubscriberTest.java
+++ b/amazon-kinesis-client/src/test/java/software/amazon/kinesis/lifecycle/ShardConsumerSubscriberTest.java
@@ -79,7 +79,7 @@ public class ShardConsumerSubscriberTest {
 
     private static final String TERMINAL_MARKER = "Terminal";
 
-    private static final long DEFAULT_NOTIFIER_TIMEOUT = 5000;
+    private static final long DEFAULT_NOTIFIER_TIMEOUT = 5000L;
 
     private final RequestDetails lastSuccessfulRequestDetails = new RequestDetails();
 
@@ -763,7 +763,7 @@ public class ShardConsumerSubscriberTest {
     /**
      * Test to validate the non-timeout warning message from ShardConsumer is not suppressed with the default
      * configuration of 0
-     *
+     * 
      * @throws Exception
      */
     @Test
@@ -792,7 +792,7 @@ public class ShardConsumerSubscriberTest {
     /**
      * Test to validate the non-timeout warning message from ShardConsumer is not suppressed with 2 ReadTimeouts to
      * ignore
-     *
+     * 
      * @throws Exception
      */
     @Test

--- a/amazon-kinesis-client/src/test/java/software/amazon/kinesis/lifecycle/ShardConsumerSubscriberTest.java
+++ b/amazon-kinesis-client/src/test/java/software/amazon/kinesis/lifecycle/ShardConsumerSubscriberTest.java
@@ -400,6 +400,7 @@ public class ShardConsumerSubscriberTest {
         // First try to start subscriptions.
         synchronized (processedNotifier) {
             subscriber.startSubscriptions();
+            processedNotifier.wait(100);
         }
 
         // Verifying that there are no interactions with shardConsumer mock indicating no records were sent back and

--- a/amazon-kinesis-client/src/test/java/software/amazon/kinesis/lifecycle/ShardConsumerSubscriberTest.java
+++ b/amazon-kinesis-client/src/test/java/software/amazon/kinesis/lifecycle/ShardConsumerSubscriberTest.java
@@ -125,10 +125,7 @@ public class ShardConsumerSubscriberTest {
 
         setupNotifierAnswer(1);
 
-        synchronized (processedNotifier) {
-            subscriber.startSubscriptions();
-            processedNotifier.wait(5000);
-        }
+        startSubscriptionsAndWait(subscriber, 5000);
 
         verify(shardConsumer).handleInput(argThat(eqProcessRecordsInput(processRecordsInput)), any(Subscription.class));
     }
@@ -139,10 +136,7 @@ public class ShardConsumerSubscriberTest {
 
         setupNotifierAnswer(recordsPublisher.responses.size());
 
-        synchronized (processedNotifier) {
-            subscriber.startSubscriptions();
-            processedNotifier.wait(5000);
-        }
+        startSubscriptionsAndWait(subscriber, 5000);
 
         verify(shardConsumer, times(100)).handleInput(argThat(eqProcessRecordsInput(processRecordsInput)), any(Subscription.class));
     }
@@ -171,10 +165,7 @@ public class ShardConsumerSubscriberTest {
             }
         }).when(shardConsumer).handleInput(any(ProcessRecordsInput.class), any(Subscription.class));
 
-        synchronized (processedNotifier) {
-            subscriber.startSubscriptions();
-            processedNotifier.wait(5000);
-        }
+        startSubscriptionsAndWait(subscriber, 5000);
 
         assertThat(subscriber.getAndResetDispatchFailure(), equalTo(testException));
         assertThat(subscriber.getAndResetDispatchFailure(), nullValue());
@@ -192,10 +183,7 @@ public class ShardConsumerSubscriberTest {
 
         setupNotifierAnswer(10);
 
-        synchronized (processedNotifier) {
-            subscriber.startSubscriptions();
-            processedNotifier.wait(5000);
-        }
+        startSubscriptionsAndWait(subscriber, 5000);
 
         for (int attempts = 0; attempts < 10; attempts++) {
             if (subscriber.retrievalFailure() != null) {
@@ -220,10 +208,7 @@ public class ShardConsumerSubscriberTest {
 
         setupNotifierAnswer(10);
 
-        synchronized (processedNotifier) {
-            subscriber.startSubscriptions();
-            processedNotifier.wait(5000);
-        }
+        startSubscriptionsAndWait(subscriber, 5000);
 
         for (int attempts = 0; attempts < 10; attempts++) {
             if (subscriber.retrievalFailure() != null) {
@@ -267,10 +252,7 @@ public class ShardConsumerSubscriberTest {
             return null;
         }).when(shardConsumer).handleInput(any(ProcessRecordsInput.class), any(Subscription.class));
 
-        synchronized (processedNotifier) {
-            subscriber.startSubscriptions();
-            processedNotifier.wait(5000);
-        }
+        startSubscriptionsAndWait(subscriber, 5000);
 
         synchronized (processedNotifier) {
             executorService.execute(() -> {
@@ -337,10 +319,7 @@ public class ShardConsumerSubscriberTest {
         }).when(shardConsumer).handleInput(any(ProcessRecordsInput.class), any(Subscription.class));
 
         // First try to start subscriptions.
-        synchronized (processedNotifier) {
-            subscriber.startSubscriptions();
-            processedNotifier.wait(100);
-        }
+        startSubscriptionsAndWait(subscriber, 100);
 
         // Verifying that there are no interactions with shardConsumer mock indicating no records were sent back and
         // subscription has not started correctly.
@@ -398,10 +377,7 @@ public class ShardConsumerSubscriberTest {
         }).when(shardConsumer).handleInput(any(ProcessRecordsInput.class), any(Subscription.class));
 
         // First try to start subscriptions.
-        synchronized (processedNotifier) {
-            subscriber.startSubscriptions();
-            processedNotifier.wait(100);
-        }
+        startSubscriptionsAndWait(subscriber, 100);
 
         // Verifying that there are no interactions with shardConsumer mock indicating no records were sent back and
         // subscription has not started correctly.
@@ -478,6 +454,13 @@ public class ShardConsumerSubscriberTest {
                 return null;
             }
         }).when(shardConsumer).handleInput(any(ProcessRecordsInput.class), any(Subscription.class));
+    }
+
+    private void startSubscriptionsAndWait(ShardConsumerSubscriber subscriber, long timeout) throws InterruptedException {
+        synchronized (processedNotifier) {
+            subscriber.startSubscriptions();
+            processedNotifier.wait(timeout);
+        }
     }
 
     private class ResponseItem {

--- a/amazon-kinesis-client/src/test/java/software/amazon/kinesis/lifecycle/ShardConsumerSubscriberTest.java
+++ b/amazon-kinesis-client/src/test/java/software/amazon/kinesis/lifecycle/ShardConsumerSubscriberTest.java
@@ -339,7 +339,7 @@ public class ShardConsumerSubscriberTest {
         // First try to start subscriptions.
         synchronized (processedNotifier) {
             subscriber.startSubscriptions();
-            processedNotifier.wait(10);
+            processedNotifier.wait(100);
         }
 
         // Verifying that there are no interactions with shardConsumer mock indicating no records were sent back and

--- a/amazon-kinesis-client/src/test/java/software/amazon/kinesis/lifecycle/ShardConsumerSubscriberTest.java
+++ b/amazon-kinesis-client/src/test/java/software/amazon/kinesis/lifecycle/ShardConsumerSubscriberTest.java
@@ -339,6 +339,7 @@ public class ShardConsumerSubscriberTest {
         // First try to start subscriptions.
         synchronized (processedNotifier) {
             subscriber.startSubscriptions();
+            processedNotifier.wait(10);
         }
 
         // Verifying that there are no interactions with shardConsumer mock indicating no records were sent back and


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Add wait to allow subscriptions to start.
This eliminates flakiness of tests `restartAfterRequestTimerExpiresWhenNotGettingRecordsAfterInitialization` and `restartAfterRequestTimerExpiresWhenInitialTaskExecutionIsRejected`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
