### PR TITLE
Add simple SingleStreamTracker constructor with position

### DIFF
--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/processor/SingleStreamTracker.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/processor/SingleStreamTracker.java
@@ -58,6 +58,12 @@ public class SingleStreamTracker implements StreamTracker {
         this(streamIdentifier, new StreamConfig(streamIdentifier, initialPosition));
     }
 
+    public SingleStreamTracker(
+            String streamName,
+            @NonNull InitialPositionInStreamExtended initialPosition) {
+        this(StreamIdentifier.singleStreamInstance(streamName), initialPosition);
+    }
+
     public SingleStreamTracker(@NonNull StreamIdentifier streamIdentifier, @NonNull StreamConfig streamConfig) {
         this.streamIdentifier = streamIdentifier;
         this.streamConfigs = Collections.singletonList(streamConfig);


### PR DESCRIPTION
The new `SingleStreamTracker` interface allows users to provide an initialPosition, but this constructor requires a user to pass in a `StreamIdentifier` rather than a simple String for the `streamName`. This adds a constructor with `streamName` and `initialPosition` parameters.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
