### PR TITLE
Bump awssdk.version from 2.20.8 to 2.20.40

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
   </scm>
 
   <properties>
-    <awssdk.version>2.20.8</awssdk.version>
+    <awssdk.version>2.20.40</awssdk.version>
   </properties>
 
   <licenses>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Bump the version of aws java sdk v2
- Tested with `mvn clean install`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
