### PR TITLE
Mutlilang streamArn Support

### DIFF
--- a/amazon-kinesis-client-multilang/src/main/java/software/amazon/kinesis/multilang/config/KinesisClientLibConfigurator.java
+++ b/amazon-kinesis-client-multilang/src/main/java/software/amazon/kinesis/multilang/config/KinesisClientLibConfigurator.java
@@ -74,15 +74,15 @@ public class KinesisClientLibConfigurator {
         });
 
         Validate.notBlank(configuration.getApplicationName(), "Application name is required");
+
         try {
+            Validate.notBlank(configuration.getStreamName(), "");
+        }catch (Exception e) {
+            Validate.notBlank(configuration.getStreamArn(), "Stream name or Stream Arn is required. (Stream Name takes precedence if both are passed in)");
             Arn streamArnObj = Arn.fromString(configuration.getStreamArn());
             String streamNameFromArn = streamArnObj.getResource().getResource();
-            Validate.notBlank(streamNameFromArn, "");
-
-            //Stream Arn takes precedence. Override existing configuration with the stream name found in the Arn
             configuration.setStreamName(streamNameFromArn);
-        }catch (Exception e) {
-            Validate.notBlank(configuration.getStreamName(), "Stream name or Stream Arn is required. (Stream Arn takes precedence if both are passed in)");
+
         }
         Validate.isTrue(configuration.getKinesisCredentialsProvider().isDirty(), "A basic set of AWS credentials must be provided");
         return configuration;

--- a/amazon-kinesis-client-multilang/src/main/java/software/amazon/kinesis/multilang/config/MultiLangDaemonConfiguration.java
+++ b/amazon-kinesis-client-multilang/src/main/java/software/amazon/kinesis/multilang/config/MultiLangDaemonConfiguration.java
@@ -28,7 +28,6 @@ import java.util.UUID;
 import java.util.function.Function;
 
 import org.apache.commons.beanutils.BeanUtilsBean;
-import org.apache.commons.beanutils.ConvertUtils;
 import org.apache.commons.beanutils.ConvertUtilsBean;
 import org.apache.commons.beanutils.Converter;
 import org.apache.commons.beanutils.converters.ArrayConverter;

--- a/amazon-kinesis-client-multilang/src/main/java/software/amazon/kinesis/multilang/config/MultiLangDaemonConfiguration.java
+++ b/amazon-kinesis-client-multilang/src/main/java/software/amazon/kinesis/multilang/config/MultiLangDaemonConfiguration.java
@@ -73,6 +73,8 @@ public class MultiLangDaemonConfiguration {
     private String applicationName;
 
     private String streamName;
+    private String streamArn;
+
 
     @ConfigurationSettable(configurationClass = ConfigsBuilder.class)
     private String tableName;

--- a/amazon-kinesis-client-multilang/src/test/java/software/amazon/kinesis/multilang/MultiLangDaemonConfigTest.java
+++ b/amazon-kinesis-client-multilang/src/test/java/software/amazon/kinesis/multilang/MultiLangDaemonConfigTest.java
@@ -40,7 +40,10 @@ public class MultiLangDaemonConfigTest {
     private static String TestStreamName = "fakeStream";
 
     private static String TestStreamNameInArn = "FAKE_STREAM_NAME";
-    private static String TestStreamArn = "arn:aws:kinesis:us-east-1:ACCOUNT_ID:stream/FAKE_STREAM_NAME";
+    private static String TestRegion = "us-east-1";
+
+    private static String TestRegionInArn = "us-east-2";
+    private static String TestStreamArn = "arn:aws:kinesis:us-east-2:ACCOUNT_ID:stream/FAKE_STREAM_NAME";
 
     @Mock
     ClassLoader classLoader;
@@ -57,9 +60,11 @@ public class MultiLangDaemonConfigTest {
         String PROPERTIES = String.format("executableName = %s \n"
                 + "applicationName = %s \n"
                 + "AWSCredentialsProvider = DefaultAWSCredentialsProviderChain\n"
-                + "processingLanguage = malbolge\n",
+                + "processingLanguage = malbolge\n"
+                + "regionName = %s \n",
                 TestExe,
-                TestApplicationName);
+                TestApplicationName,
+                TestRegion);
 
         if(streamName != null){
             PROPERTIES += String.format("streamName = %s \n", streamName);
@@ -112,7 +117,7 @@ public class MultiLangDaemonConfigTest {
 
         MultiLangDaemonConfig deamonConfig = new MultiLangDaemonConfig(FILENAME, classLoader, configurator);
 
-        AssertConfigurationsMatch(deamonConfig, TestExe, TestApplicationName, TestStreamName);
+        AssertConfigurationsMatch(deamonConfig, TestExe, TestApplicationName, TestStreamName, TestRegion);
     }
 
     @Test
@@ -121,7 +126,7 @@ public class MultiLangDaemonConfigTest {
 
         MultiLangDaemonConfig deamonConfig = new MultiLangDaemonConfig(FILENAME, classLoader, configurator);
 
-        AssertConfigurationsMatch(deamonConfig, TestExe, TestApplicationName, TestStreamName);
+        AssertConfigurationsMatch(deamonConfig, TestExe, TestApplicationName, TestStreamName, TestRegion);
     }
 
     @Test
@@ -130,7 +135,7 @@ public class MultiLangDaemonConfigTest {
 
         MultiLangDaemonConfig deamonConfig = new MultiLangDaemonConfig(FILENAME, classLoader, configurator);
 
-        AssertConfigurationsMatch(deamonConfig, TestExe, TestApplicationName, TestStreamNameInArn);
+        AssertConfigurationsMatch(deamonConfig, TestExe, TestApplicationName, TestStreamNameInArn, TestRegionInArn);
     }
 
     @Test
@@ -139,16 +144,16 @@ public class MultiLangDaemonConfigTest {
 
         MultiLangDaemonConfig deamonConfig = new MultiLangDaemonConfig(FILENAME, classLoader, configurator);
 
-        AssertConfigurationsMatch(deamonConfig, TestExe, TestApplicationName, TestStreamNameInArn);
+        AssertConfigurationsMatch(deamonConfig, TestExe, TestApplicationName, TestStreamNameInArn, TestRegionInArn);
     }
 
     @Test
-    public void testConstructorUsingStreamNameOverStreamArn() throws IOException {
+    public void testConstructorUsingStreamArnOverStreamName() throws IOException {
         setup(TestStreamName, TestStreamArn);
 
         MultiLangDaemonConfig deamonConfig = new MultiLangDaemonConfig(FILENAME, classLoader, configurator);
 
-        AssertConfigurationsMatch(deamonConfig, TestExe, TestApplicationName, TestStreamName);
+        AssertConfigurationsMatch(deamonConfig, TestExe, TestApplicationName, TestStreamNameInArn, TestRegionInArn);
     }
 
     /**
@@ -159,7 +164,8 @@ public class MultiLangDaemonConfigTest {
     private void AssertConfigurationsMatch(MultiLangDaemonConfig deamonConfig,
                                            String expectedExe,
                                            String expectedApplicationName,
-                                           String expectedStreamName){
+                                           String expectedStreamName,
+                                           String expectedRegionName){
         assertNotNull(deamonConfig.getExecutorService());
         assertNotNull(deamonConfig.getMultiLangDaemonConfiguration());
         assertNotNull(deamonConfig.getRecordProcessorFactory());
@@ -167,6 +173,9 @@ public class MultiLangDaemonConfigTest {
         assertEquals(expectedExe, deamonConfig.getRecordProcessorFactory().getCommandArray()[0]);
         assertEquals(expectedApplicationName, deamonConfig.getMultiLangDaemonConfiguration().getApplicationName());
         assertEquals(expectedStreamName, deamonConfig.getMultiLangDaemonConfiguration().getStreamName());
+        assertEquals(expectedRegionName, deamonConfig.getMultiLangDaemonConfiguration().getDynamoDbClient().get("region").toString());
+        assertEquals(expectedRegionName, deamonConfig.getMultiLangDaemonConfiguration().getCloudWatchClient().get("region").toString());
+        assertEquals(expectedRegionName, deamonConfig.getMultiLangDaemonConfiguration().getKinesisClient().get("region").toString());
     }
 
     @Test

--- a/amazon-kinesis-client-multilang/src/test/java/software/amazon/kinesis/multilang/MultiLangDaemonConfigTest.java
+++ b/amazon-kinesis-client-multilang/src/test/java/software/amazon/kinesis/multilang/MultiLangDaemonConfigTest.java
@@ -14,8 +14,9 @@
  */
 package software.amazon.kinesis.multilang;
 
-import static org.junit.Assert.*;
-import static org.mockito.Matchers.any;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.when;
 
 import java.io.ByteArrayInputStream;
@@ -37,7 +38,7 @@ public class MultiLangDaemonConfigTest {
     private static String FILENAME = "some.properties";
     private static String TestExe = "TestExe.exe";
     private static String TestApplicationName = "TestApp";
-    private static String TestStreamName =ßß "fakeStream";
+    private static String TestStreamName = "fakeStream";
     private static String TestStreamNameInArn = "FAKE_STREAM_NAME";
     private static String TestRegion = "us-east-1";
     private static String TestRegionInArn = "us-east-2";

--- a/amazon-kinesis-client-multilang/src/test/java/software/amazon/kinesis/multilang/MultiLangDaemonConfigTest.java
+++ b/amazon-kinesis-client-multilang/src/test/java/software/amazon/kinesis/multilang/MultiLangDaemonConfigTest.java
@@ -143,12 +143,12 @@ public class MultiLangDaemonConfigTest {
     }
 
     @Test
-    public void testConstructorUsingStreamArnOverStreamName() throws IOException {
+    public void testConstructorUsingStreamNameOverStreamArn() throws IOException {
         setup(TestStreamName, TestStreamArn);
 
         MultiLangDaemonConfig deamonConfig = new MultiLangDaemonConfig(FILENAME, classLoader, configurator);
 
-        AssertConfigurationsMatch(deamonConfig, TestExe, TestApplicationName, TestStreamNameInArn);
+        AssertConfigurationsMatch(deamonConfig, TestExe, TestApplicationName, TestStreamName);
     }
 
     /**

--- a/amazon-kinesis-client-multilang/src/test/java/software/amazon/kinesis/multilang/MultiLangDaemonConfigTest.java
+++ b/amazon-kinesis-client-multilang/src/test/java/software/amazon/kinesis/multilang/MultiLangDaemonConfigTest.java
@@ -37,14 +37,14 @@ public class MultiLangDaemonConfigTest {
     private static String FILENAME = "some.properties";
     private static String TestExe = "TestExe.exe";
     private static String TestApplicationName = "TestApp";
-    private static String TestStreamName = "fakeStream";
-
+    private static String TestStreamName =ßß "fakeStream";
     private static String TestStreamNameInArn = "FAKE_STREAM_NAME";
     private static String TestRegion = "us-east-1";
-
     private static String TestRegionInArn = "us-east-2";
-    private static String TestStreamArn = "arn:aws:kinesis:us-east-2:ACCOUNT_ID:stream/FAKE_STREAM_NAME";
 
+    private static String getTestStreamArn(){
+        return String.format("arn:aws:kinesis:%s:ACCOUNT_ID:stream/%s", TestRegionInArn, TestStreamNameInArn);
+    }
     @Mock
     ClassLoader classLoader;
 
@@ -131,7 +131,7 @@ public class MultiLangDaemonConfigTest {
 
     @Test
     public void testConstructorUsingStreamArn() throws IOException {
-        setup(null, TestStreamArn);
+        setup(null, getTestStreamArn());
 
         MultiLangDaemonConfig deamonConfig = new MultiLangDaemonConfig(FILENAME, classLoader, configurator);
 
@@ -140,7 +140,7 @@ public class MultiLangDaemonConfigTest {
 
     @Test
     public void testConstructorUsingStreamNameAsEmptyAndStreamArn() throws IOException {
-        setup("", TestStreamArn);
+        setup("", getTestStreamArn());
 
         MultiLangDaemonConfig deamonConfig = new MultiLangDaemonConfig(FILENAME, classLoader, configurator);
 
@@ -149,7 +149,7 @@ public class MultiLangDaemonConfigTest {
 
     @Test
     public void testConstructorUsingStreamArnOverStreamName() throws IOException {
-        setup(TestStreamName, TestStreamArn);
+        setup(TestStreamName, getTestStreamArn());
 
         MultiLangDaemonConfig deamonConfig = new MultiLangDaemonConfig(FILENAME, classLoader, configurator);
 

--- a/amazon-kinesis-client-multilang/src/test/java/software/amazon/kinesis/multilang/config/KinesisClientLibConfiguratorTest.java
+++ b/amazon-kinesis-client-multilang/src/test/java/software/amazon/kinesis/multilang/config/KinesisClientLibConfiguratorTest.java
@@ -308,7 +308,7 @@ public class KinesisClientLibConfiguratorTest {
     @Test
     public void testWithMissingStreamNameAndMissingStreamArn() {
         thrown.expect(NullPointerException.class);
-        thrown.expectMessage("Stream name or Stream Arn is required. (Stream Arn takes precedence if both are passed in)");
+        thrown.expectMessage("Stream name or Stream Arn is required. (Stream Name takes precedence if both are passed in)");
 
         String test = StringUtils.join(new String[] {
                 "applicationName = b",
@@ -323,7 +323,7 @@ public class KinesisClientLibConfiguratorTest {
     @Test
     public void testWithEmptyStreamNameAndMissingStreamArn() {
         thrown.expect(IllegalArgumentException.class);
-        thrown.expectMessage("Stream name or Stream Arn is required. (Stream Arn takes precedence if both are passed in)");
+        thrown.expectMessage("Stream name or Stream Arn is required. (Stream Name takes precedence if both are passed in)");
 
         String test = StringUtils.join(new String[] {
                         "applicationName = b",

--- a/amazon-kinesis-client-multilang/src/test/java/software/amazon/kinesis/multilang/config/KinesisClientLibConfiguratorTest.java
+++ b/amazon-kinesis-client-multilang/src/test/java/software/amazon/kinesis/multilang/config/KinesisClientLibConfiguratorTest.java
@@ -308,7 +308,7 @@ public class KinesisClientLibConfiguratorTest {
     @Test
     public void testWithMissingStreamNameAndMissingStreamArn() {
         thrown.expect(NullPointerException.class);
-        thrown.expectMessage("Stream name or Stream Arn is required. (Stream Name takes precedence if both are passed in)");
+        thrown.expectMessage("Stream name or Stream Arn is required. (Stream Arn takes precedence if both are passed in)");
 
         String test = StringUtils.join(new String[] {
                 "applicationName = b",
@@ -323,7 +323,7 @@ public class KinesisClientLibConfiguratorTest {
     @Test
     public void testWithEmptyStreamNameAndMissingStreamArn() {
         thrown.expect(IllegalArgumentException.class);
-        thrown.expectMessage("Stream name or Stream Arn is required. (Stream Name takes precedence if both are passed in)");
+        thrown.expectMessage("Stream name or Stream Arn is required. (Stream Arn takes precedence if both are passed in)");
 
         String test = StringUtils.join(new String[] {
                         "applicationName = b",

--- a/amazon-kinesis-client-multilang/src/test/java/software/amazon/kinesis/multilang/config/KinesisClientLibConfiguratorTest.java
+++ b/amazon-kinesis-client-multilang/src/test/java/software/amazon/kinesis/multilang/config/KinesisClientLibConfiguratorTest.java
@@ -306,12 +306,33 @@ public class KinesisClientLibConfiguratorTest {
     }
 
     @Test
-    public void testWithMissingStreamName() {
+    public void testWithMissingStreamNameAndMissingStreamArn() {
         thrown.expect(NullPointerException.class);
-        thrown.expectMessage("Stream name is required");
+        thrown.expectMessage("Stream name or Stream Arn is required. (Stream Arn takes precedence if both are passed in)");
 
-        String test = StringUtils.join(new String[] { "applicationName = b",
-                "AWSCredentialsProvider = " + credentialName1, "workerId = 123", "failoverTimeMillis = 100" }, '\n');
+        String test = StringUtils.join(new String[] {
+                "applicationName = b",
+                "AWSCredentialsProvider = " + credentialName1,
+                "workerId = 123",
+                "failoverTimeMillis = 100" },
+                '\n');
+        InputStream input = new ByteArrayInputStream(test.getBytes());
+
+        configurator.getConfiguration(input);
+    }
+    @Test
+    public void testWithEmptyStreamNameAndMissingStreamArn() {
+        thrown.expect(IllegalArgumentException.class);
+        thrown.expectMessage("Stream name or Stream Arn is required. (Stream Arn takes precedence if both are passed in)");
+
+        String test = StringUtils.join(new String[] {
+                        "applicationName = b",
+                        "AWSCredentialsProvider = " + credentialName1,
+                        "workerId = 123",
+                        "failoverTimeMillis = 100",
+                        "streamName = ",
+                        "streamArn = "},
+                '\n');
         InputStream input = new ByteArrayInputStream(test.getBytes());
 
         configurator.getConfiguration(input);

--- a/amazon-kinesis-client-multilang/src/test/java/software/amazon/kinesis/multilang/config/KinesisClientLibConfiguratorTest.java
+++ b/amazon-kinesis-client-multilang/src/test/java/software/amazon/kinesis/multilang/config/KinesisClientLibConfiguratorTest.java
@@ -308,7 +308,7 @@ public class KinesisClientLibConfiguratorTest {
     @Test
     public void testWithMissingStreamNameAndMissingStreamArn() {
         thrown.expect(NullPointerException.class);
-        thrown.expectMessage("Stream name or Stream Arn is required. (Stream Arn takes precedence if both are passed in)");
+        thrown.expectMessage("Stream name or Stream Arn is required. Stream Arn takes precedence if both are passed in.");
 
         String test = StringUtils.join(new String[] {
                 "applicationName = b",
@@ -323,7 +323,7 @@ public class KinesisClientLibConfiguratorTest {
     @Test
     public void testWithEmptyStreamNameAndMissingStreamArn() {
         thrown.expect(IllegalArgumentException.class);
-        thrown.expectMessage("Stream name or Stream Arn is required. (Stream Arn takes precedence if both are passed in)");
+        thrown.expectMessage("Stream name or Stream Arn is required. Stream Arn takes precedence if both are passed in.");
 
         String test = StringUtils.join(new String[] {
                         "applicationName = b",


### PR DESCRIPTION
*Description of changes:*
1. Updated multilang daemon to support 'streamArn' being passed in via Properties
2. streamName and regionName is parsed out if 'streamArn' is passed in.
   - Meaning streamArn takes precedence if it is passed in
3. Added unit test

===========================================================================================
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
