### PR TITLE
Update to Multilang Daemon to support StreamArn

### DIFF
--- a/amazon-kinesis-client-multilang/src/main/java/software/amazon/kinesis/multilang/config/KinesisClientLibConfigurator.java
+++ b/amazon-kinesis-client-multilang/src/main/java/software/amazon/kinesis/multilang/config/KinesisClientLibConfigurator.java
@@ -26,6 +26,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.Validate;
 import software.amazon.awssdk.arns.Arn;
 import software.amazon.awssdk.regions.Region;
+import software.amazon.kinesis.common.StreamIdentifier;
 
 /**
  * KinesisClientLibConfigurator constructs a KinesisClientLibConfiguration from java properties file. The following
@@ -73,17 +74,7 @@ public class KinesisClientLibConfigurator {
 
         if (configuration.getStreamArn() != null && !configuration.getStreamArn().trim().isEmpty()) {
             final Arn streamArnObj = Arn.fromString(configuration.getStreamArn());
-
-            final String resourceType = streamArnObj.resource().resourceType().get();
-            if (!"stream".equalsIgnoreCase(resourceType)) {
-                throw new IllegalArgumentException(String.format("StreamArn has unsupported resource type of '%s'. Expected: stream",
-                        resourceType));
-            }
-            final String arnService = streamArnObj.service();
-            if (!"kinesis".equalsIgnoreCase(arnService)) {
-                throw new IllegalArgumentException(String.format("StreamArn has unsupported service type of '%s'. Expected: kinesis",
-                        arnService));
-            }
+            StreamIdentifier.validateArn(streamArnObj);
             //Parse out the stream Name from the Arn (and/or override existing value for Stream Name)
             final String streamNameFromArn = streamArnObj.resource().resource();
             configuration.setStreamName(streamNameFromArn);

--- a/amazon-kinesis-client-multilang/src/main/java/software/amazon/kinesis/multilang/config/KinesisClientLibConfigurator.java
+++ b/amazon-kinesis-client-multilang/src/main/java/software/amazon/kinesis/multilang/config/KinesisClientLibConfigurator.java
@@ -84,11 +84,6 @@ public class KinesisClientLibConfigurator {
         }
         Validate.isTrue(configuration.getKinesisCredentialsProvider().isDirty(), "A basic set of AWS credentials must be provided");
 
-        //Verify Region is real
-        final String regionCode = String.valueOf(configuration.getKinesisClient().get("region"));
-        if (regionCode == null || Region.regions().stream().filter(x -> x.id().equalsIgnoreCase(regionCode)).count() == 0) {
-            throw new IllegalArgumentException(String.format("Unsupported region: %s", regionCode));
-        }
         return configuration;
     }
 

--- a/amazon-kinesis-client-multilang/src/main/java/software/amazon/kinesis/multilang/config/KinesisClientLibConfigurator.java
+++ b/amazon-kinesis-client-multilang/src/main/java/software/amazon/kinesis/multilang/config/KinesisClientLibConfigurator.java
@@ -79,9 +79,9 @@ public class KinesisClientLibConfigurator {
             final String streamNameFromArn = streamArnObj.resource().resource();
             configuration.setStreamName(streamNameFromArn);
 
-        } else {
-            Validate.notBlank(configuration.getStreamName(), "Stream name or Stream Arn is required. Stream Arn takes precedence if both are passed in.");
         }
+
+        Validate.notBlank(configuration.getStreamName(), "Stream name or Stream Arn is required. Stream Arn takes precedence if both are passed in.");
         Validate.isTrue(configuration.getKinesisCredentialsProvider().isDirty(), "A basic set of AWS credentials must be provided");
 
         return configuration;

--- a/amazon-kinesis-client-multilang/src/main/java/software/amazon/kinesis/multilang/config/KinesisClientLibConfigurator.java
+++ b/amazon-kinesis-client-multilang/src/main/java/software/amazon/kinesis/multilang/config/KinesisClientLibConfigurator.java
@@ -19,13 +19,12 @@ import java.io.InputStream;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Properties;
 
-import com.amazonaws.arn.Arn;
 import org.apache.commons.beanutils.BeanUtilsBean;
 import org.apache.commons.beanutils.ConvertUtilsBean;
 
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Validate;
+import software.amazon.awssdk.arns.Arn;
 import software.amazon.awssdk.regions.Region;
 
 /**
@@ -74,20 +73,20 @@ public class KinesisClientLibConfigurator {
 
         if (configuration.getStreamArn() != null && !configuration.getStreamArn().trim().isEmpty()) {
             Arn streamArnObj = Arn.fromString(configuration.getStreamArn());
-            if(!streamArnObj.getResource().getResourceType().equalsIgnoreCase("stream")){
+            if(!streamArnObj.resource().resourceType().get().equalsIgnoreCase("stream")){
                 throw new IllegalArgumentException(String.format("StreamArn has unsupported resource type of '%s'. Expected: stream",
-                        streamArnObj.getResource().getResourceType()));
+                        streamArnObj.resource().resourceType().get()));
             }
-            if(!streamArnObj.getService().equalsIgnoreCase("kinesis")){
+            if(!streamArnObj.service().equalsIgnoreCase("kinesis")){
                 throw new IllegalArgumentException(String.format("StreamArn has unsupported service type of '%s'. Expected: kinesis",
-                        streamArnObj.getResource().getResourceType()));
+                        streamArnObj.service()));
             }
             //Parse out the stream Name from the Arn (and/or override existing value for Stream Name)
-            String streamNameFromArn = streamArnObj.getResource().getResource();
+            String streamNameFromArn = streamArnObj.resource().resource();
             configuration.setStreamName(streamNameFromArn);
 
             //Parse out the region from the Arn and set (and/or override existing value for region)
-            Region regionObj = Region.of(streamArnObj.getRegion());
+            Region regionObj = Region.of(streamArnObj.region().get());
             if(Region.regions().stream().filter(x -> x.id().equalsIgnoreCase(regionObj.id())).count() == 0){
                 throw new IllegalArgumentException(String.format("%s is not a valid region", regionObj.id()));
             }

--- a/amazon-kinesis-client-multilang/src/main/java/software/amazon/kinesis/multilang/config/KinesisClientLibConfigurator.java
+++ b/amazon-kinesis-client-multilang/src/main/java/software/amazon/kinesis/multilang/config/KinesisClientLibConfigurator.java
@@ -94,11 +94,8 @@ public class KinesisClientLibConfigurator {
         Validate.isTrue(configuration.getKinesisCredentialsProvider().isDirty(), "A basic set of AWS credentials must be provided");
 
         //Verify Region is real
-        if(configuration.getKinesisClient().get("region") == null){
-            throw new NullPointerException("regionName must be passed in");
-        }
-        final String regionCode = configuration.getKinesisClient().get("region").toString();
-        if (Region.regions().stream().filter(x -> x.id().equalsIgnoreCase(regionCode)).count() == 0) {
+        final String regionCode = String.valueOf(configuration.getKinesisClient().get("region"));
+        if (regionCode == null || Region.regions().stream().filter(x -> x.id().equalsIgnoreCase(regionCode)).count() == 0) {
             throw new IllegalArgumentException(String.format("Unsupported region: %s", regionCode));
         }
         return configuration;

--- a/amazon-kinesis-client-multilang/src/main/java/software/amazon/kinesis/multilang/config/KinesisClientLibConfigurator.java
+++ b/amazon-kinesis-client-multilang/src/main/java/software/amazon/kinesis/multilang/config/KinesisClientLibConfigurator.java
@@ -19,12 +19,14 @@ import java.io.InputStream;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Properties;
 
+import com.amazonaws.arn.Arn;
 import org.apache.commons.beanutils.BeanUtilsBean;
 import org.apache.commons.beanutils.ConvertUtilsBean;
 
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Validate;
+import software.amazon.awssdk.regions.Region;
 
 /**
  * KinesisClientLibConfigurator constructs a KinesisClientLibConfiguration from java properties file. The following
@@ -55,7 +57,7 @@ public class KinesisClientLibConfigurator {
      * Program will fail immediately, if customer provide: 1) invalid variable value. Program will log it as warning and
      * continue, if customer provide: 1) variable with unsupported variable type. 2) a variable with name which does not
      * match any of the variables in KinesisClientLibConfigration.
-     * 
+     *
      * @param properties a Properties object containing the configuration information
      * @return KinesisClientLibConfiguration
      */
@@ -69,7 +71,30 @@ public class KinesisClientLibConfigurator {
         });
 
         Validate.notBlank(configuration.getApplicationName(), "Application name is required");
-        Validate.notBlank(configuration.getStreamName(), "Stream name is required");
+
+        if (configuration.getStreamArn() != null && !configuration.getStreamArn().trim().isEmpty()) {
+            Arn streamArnObj = Arn.fromString(configuration.getStreamArn());
+            if(!streamArnObj.getResource().getResourceType().equalsIgnoreCase("stream")){
+                throw new IllegalArgumentException(String.format("StreamArn has unsupported resource type of '%s'. Expected: stream",
+                        streamArnObj.getResource().getResourceType()));
+            }
+            if(!streamArnObj.getService().equalsIgnoreCase("kinesis")){
+                throw new IllegalArgumentException(String.format("StreamArn has unsupported service type of '%s'. Expected: kinesis",
+                        streamArnObj.getResource().getResourceType()));
+            }
+            //Parse out the stream Name from the Arn (and/or override existing value for Stream Name)
+            String streamNameFromArn = streamArnObj.getResource().getResource();
+            configuration.setStreamName(streamNameFromArn);
+
+            //Parse out the region from the Arn and set (and/or override existing value for region)
+            Region regionObj = Region.of(streamArnObj.getRegion());
+            if(Region.regions().stream().filter(x -> x.id().equalsIgnoreCase(regionObj.id())).count() == 0){
+                throw new IllegalArgumentException(String.format("%s is not a valid region", regionObj.id()));
+            }
+            configuration.setRegionName(regionObj);
+        } else {
+            Validate.notBlank(configuration.getStreamName(), "Stream name or Stream Arn is required. Stream Arn takes precedence if both are passed in.");
+        }
         Validate.isTrue(configuration.getKinesisCredentialsProvider().isDirty(), "A basic set of AWS credentials must be provided");
         return configuration;
     }

--- a/amazon-kinesis-client-multilang/src/main/java/software/amazon/kinesis/multilang/config/KinesisClientLibConfigurator.java
+++ b/amazon-kinesis-client-multilang/src/main/java/software/amazon/kinesis/multilang/config/KinesisClientLibConfigurator.java
@@ -88,7 +88,7 @@ public class KinesisClientLibConfigurator {
             //Parse out the region from the Arn and set (and/or override existing value for region)
             Region regionObj = Region.of(streamArnObj.region().get());
             if(Region.regions().stream().filter(x -> x.id().equalsIgnoreCase(regionObj.id())).count() == 0){
-                throw new IllegalArgumentException(String.format("%s is not a valid region", regionObj.id()));
+                throw new IllegalArgumentException(String.format("StreamArn has unsupported region of '%s'.", regionObj.id()));
             }
             configuration.setRegionName(regionObj);
         } else {

--- a/amazon-kinesis-client-multilang/src/main/java/software/amazon/kinesis/multilang/config/MultiLangDaemonConfiguration.java
+++ b/amazon-kinesis-client-multilang/src/main/java/software/amazon/kinesis/multilang/config/MultiLangDaemonConfiguration.java
@@ -28,7 +28,6 @@ import java.util.UUID;
 import java.util.function.Function;
 
 import org.apache.commons.beanutils.BeanUtilsBean;
-import org.apache.commons.beanutils.ConvertUtils;
 import org.apache.commons.beanutils.ConvertUtilsBean;
 import org.apache.commons.beanutils.Converter;
 import org.apache.commons.beanutils.converters.ArrayConverter;
@@ -73,6 +72,8 @@ public class MultiLangDaemonConfiguration {
     private String applicationName;
 
     private String streamName;
+    private String streamArn;
+
 
     @ConfigurationSettable(configurationClass = ConfigsBuilder.class)
     private String tableName;
@@ -300,7 +301,7 @@ public class MultiLangDaemonConfiguration {
     }
 
     private void updateCredentials(BuilderDynaBean toUpdate, AwsCredentialsProvider primary,
-            AwsCredentialsProvider secondary) {
+                                   AwsCredentialsProvider secondary) {
 
         if (toUpdate.hasValue("credentialsProvider")) {
             return;

--- a/amazon-kinesis-client-multilang/src/main/java/software/amazon/kinesis/multilang/config/MultiLangDaemonConfiguration.java
+++ b/amazon-kinesis-client-multilang/src/main/java/software/amazon/kinesis/multilang/config/MultiLangDaemonConfiguration.java
@@ -301,7 +301,7 @@ public class MultiLangDaemonConfiguration {
     }
 
     private void updateCredentials(BuilderDynaBean toUpdate, AwsCredentialsProvider primary,
-                                   AwsCredentialsProvider secondary) {
+            AwsCredentialsProvider secondary) {
 
         if (toUpdate.hasValue("credentialsProvider")) {
             return;

--- a/amazon-kinesis-client-multilang/src/test/java/software/amazon/kinesis/multilang/MessageReaderTest.java
+++ b/amazon-kinesis-client-multilang/src/test/java/software/amazon/kinesis/multilang/MessageReaderTest.java
@@ -28,7 +28,6 @@ import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
-import software.amazon.kinesis.multilang.MessageReader;
 import software.amazon.kinesis.multilang.messages.Message;
 import software.amazon.kinesis.multilang.messages.StatusMessage;
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/amazon-kinesis-client-multilang/src/test/java/software/amazon/kinesis/multilang/MessageWriterTest.java
+++ b/amazon-kinesis-client-multilang/src/test/java/software/amazon/kinesis/multilang/MessageWriterTest.java
@@ -32,15 +32,12 @@ import org.mockito.Mockito;
 
 import software.amazon.kinesis.lifecycle.events.LeaseLostInput;
 import software.amazon.kinesis.lifecycle.events.ShardEndedInput;
-import software.amazon.kinesis.multilang.MessageWriter;
-import software.amazon.kinesis.multilang.messages.LeaseLostMessage;
 import software.amazon.kinesis.multilang.messages.Message;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import software.amazon.kinesis.lifecycle.events.InitializationInput;
 import software.amazon.kinesis.lifecycle.events.ProcessRecordsInput;
-import software.amazon.kinesis.lifecycle.ShutdownReason;
 import software.amazon.kinesis.retrieval.KinesisClientRecord;
 
 import static org.mockito.Mockito.verify;

--- a/amazon-kinesis-client-multilang/src/test/java/software/amazon/kinesis/multilang/MultiLangDaemonConfigTest.java
+++ b/amazon-kinesis-client-multilang/src/test/java/software/amazon/kinesis/multilang/MultiLangDaemonConfigTest.java
@@ -42,7 +42,7 @@ public class MultiLangDaemonConfigTest {
     private static final String TEST_STREAM_NAME = "fakeStream";
     private static final String TEST_STREAM_NAME_IN_ARN = "FAKE_STREAM_NAME";
     private static final String TEST_REGION = "us-east-1";
-    private static final String TEST_STREAM_ARN = "arn:aws:kinesis:us-east-2:ACCOUNT_ID:stream/" + TEST_STREAM_NAME_IN_ARN;
+    private static final String TEST_STREAM_ARN = "arn:aws:kinesis:us-east-2:012345678987:stream/" + TEST_STREAM_NAME_IN_ARN;
 
     @Mock
     ClassLoader classLoader;
@@ -97,18 +97,13 @@ public class MultiLangDaemonConfigTest {
     }
 
     @Test(expected =  IllegalArgumentException.class)
-    public void testConstructorFailsBecauseStreamArnHasInvalidRegion() throws Exception {
-        setup("", "arn:aws:kinesis:us-east-1:ACCOUNT_ID:stream/streamName", "us-east-1000");
+    public void testConstructorFailsBecauseStreamArnIsInvalid2() throws Exception {
+        setup("", "arn:aws:kinesis:us-east-2:ACCOUNT_ID:BadFormatting:stream/" + TEST_STREAM_NAME_IN_ARN, TEST_REGION);
     }
 
     @Test(expected =  IllegalArgumentException.class)
-    public void testConstructorFailsBecauseStreamArnHasInvalidResourceType() throws Exception {
-        setup("", "arn:aws:kinesis:us-EAST-1:ACCOUNT_ID:dynamodb/streamName", TEST_REGION);
-    }
-
-    @Test(expected =  IllegalArgumentException.class)
-    public void testConstructorFailsBecauseStreamArnHasInvalidService() throws Exception {
-        setup("", "arn:aws:kinesisFakeService:us-east-1:ACCOUNT_ID:stream/streamName", TEST_REGION);
+    public void testConstructorFailsBecauseInvalidRegion() throws Exception {
+        setup("", TEST_STREAM_ARN, "us-east-1000");
     }
 
     @Test(expected =  IllegalArgumentException.class)

--- a/amazon-kinesis-client-multilang/src/test/java/software/amazon/kinesis/multilang/MultiLangDaemonConfigTest.java
+++ b/amazon-kinesis-client-multilang/src/test/java/software/amazon/kinesis/multilang/MultiLangDaemonConfigTest.java
@@ -98,7 +98,7 @@ public class MultiLangDaemonConfigTest {
     @Test
     public void testConstructorFailsBecauseStreamArnHasInvalidRegion() throws Exception {
         setup("", "arn:aws:kinesis:us-east-1000:ACCOUNT_ID:stream/streamName");
-        assertConstructorThrowsException(IllegalArgumentException.class, "us-east-1000 is not a valid region");
+        assertConstructorThrowsException(IllegalArgumentException.class, "StreamArn has unsupported region of 'us-east-1000'.");
     }
 
     @Test

--- a/amazon-kinesis-client-multilang/src/test/java/software/amazon/kinesis/multilang/MultiLangDaemonConfigTest.java
+++ b/amazon-kinesis-client-multilang/src/test/java/software/amazon/kinesis/multilang/MultiLangDaemonConfigTest.java
@@ -123,42 +123,42 @@ public class MultiLangDaemonConfigTest {
     public void testConstructorUsingStreamName() throws IOException {
         setup(TEST_STREAM_NAME, null, TEST_REGION);
 
-        assertConfigurationsMatch(deamonConfig, TEST_STREAM_NAME, null);
+        assertConfigurationsMatch(TEST_STREAM_NAME, null);
     }
 
     @Test
     public void testConstructorUsingStreamNameAndStreamArnIsEmpty() throws IOException {
         setup(TEST_STREAM_NAME, "", TEST_REGION);
 
-        assertConfigurationsMatch(deamonConfig, TEST_STREAM_NAME, "");
+        assertConfigurationsMatch(TEST_STREAM_NAME, "");
     }
 
     @Test
     public void testConstructorUsingStreamNameAndStreamArnIsWhitespace() throws IOException {
         setup(TEST_STREAM_NAME, "   ", TEST_REGION);
 
-        assertConfigurationsMatch(deamonConfig, TEST_STREAM_NAME, "");
+        assertConfigurationsMatch(TEST_STREAM_NAME, "");
     }
 
     @Test
     public void testConstructorUsingStreamArn() throws IOException {
         setup(null, TEST_STREAM_ARN, TEST_REGION);
 
-        assertConfigurationsMatch(deamonConfig, TEST_STREAM_NAME_IN_ARN, TEST_STREAM_ARN);
+        assertConfigurationsMatch(TEST_STREAM_NAME_IN_ARN, TEST_STREAM_ARN);
     }
 
     @Test
     public void testConstructorUsingStreamNameAsEmptyAndStreamArn() throws IOException {
         setup("", TEST_STREAM_ARN, TEST_REGION);
 
-        assertConfigurationsMatch(deamonConfig, TEST_STREAM_NAME_IN_ARN, TEST_STREAM_ARN);
+        assertConfigurationsMatch(TEST_STREAM_NAME_IN_ARN, TEST_STREAM_ARN);
     }
 
     @Test
     public void testConstructorUsingStreamArnOverStreamName() throws IOException {
         setup(TEST_STREAM_NAME, TEST_STREAM_ARN, TEST_REGION);
 
-        assertConfigurationsMatch(deamonConfig, TEST_STREAM_NAME_IN_ARN, TEST_STREAM_ARN);
+        assertConfigurationsMatch(TEST_STREAM_NAME_IN_ARN, TEST_STREAM_ARN);
     }
 
     /**
@@ -166,8 +166,7 @@ public class MultiLangDaemonConfigTest {
      * @param deamonConfig
      * @param expectedStreamName
      */
-    private void assertConfigurationsMatch(MultiLangDaemonConfig deamonConfig,
-                                           String expectedStreamName,
+    private void assertConfigurationsMatch(String expectedStreamName,
                                            String expectedStreamArn){
         assertNotNull(deamonConfig.getExecutorService());
         assertNotNull(deamonConfig.getMultiLangDaemonConfiguration());

--- a/amazon-kinesis-client-multilang/src/test/java/software/amazon/kinesis/multilang/MultiLangDaemonConfigTest.java
+++ b/amazon-kinesis-client-multilang/src/test/java/software/amazon/kinesis/multilang/MultiLangDaemonConfigTest.java
@@ -102,11 +102,6 @@ public class MultiLangDaemonConfigTest {
     }
 
     @Test(expected =  IllegalArgumentException.class)
-    public void testConstructorFailsBecauseInvalidRegion() throws Exception {
-        setup("", TEST_STREAM_ARN, "us-east-1000");
-    }
-
-    @Test(expected =  IllegalArgumentException.class)
     public void testConstructorFailsBecauseStreamNameAndArnAreEmpty() throws Exception {
         setup("", "", TEST_REGION);
     }

--- a/amazon-kinesis-client-multilang/src/test/java/software/amazon/kinesis/multilang/MultiLangDaemonConfigTest.java
+++ b/amazon-kinesis-client-multilang/src/test/java/software/amazon/kinesis/multilang/MultiLangDaemonConfigTest.java
@@ -59,7 +59,6 @@ public class MultiLangDaemonConfigTest {
      * Instantiate a MultiLangDaemonConfig object
      * @param streamName
      * @param streamArn
-     * @param region
      * @throws IOException
      */
     public void setup(String streamName, String streamArn) throws IOException {
@@ -71,7 +70,7 @@ public class MultiLangDaemonConfigTest {
                         + "regionName = %s\n",
                 EXE,
                 APPLICATION_NAME,
-                REGION.toString());
+                "us-east-1");
 
         if (streamName != null) {
             properties += String.format("streamName = %s\n", streamName);

--- a/amazon-kinesis-client-multilang/src/test/java/software/amazon/kinesis/multilang/MultiLangDaemonConfigTest.java
+++ b/amazon-kinesis-client-multilang/src/test/java/software/amazon/kinesis/multilang/MultiLangDaemonConfigTest.java
@@ -21,9 +21,7 @@ import static org.mockito.Mockito.when;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;

--- a/amazon-kinesis-client-multilang/src/test/java/software/amazon/kinesis/multilang/MultiLangDaemonTest.java
+++ b/amazon-kinesis-client-multilang/src/test/java/software/amazon/kinesis/multilang/MultiLangDaemonTest.java
@@ -17,7 +17,6 @@ package software.amazon.kinesis.multilang;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.isEmptyOrNullString;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Matchers.anyObject;

--- a/amazon-kinesis-client-multilang/src/test/java/software/amazon/kinesis/multilang/MultiLangProtocolTest.java
+++ b/amazon-kinesis-client-multilang/src/test/java/software/amazon/kinesis/multilang/MultiLangProtocolTest.java
@@ -31,7 +31,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
@@ -61,10 +60,8 @@ import software.amazon.kinesis.multilang.messages.ShardEndedMessage;
 import software.amazon.kinesis.multilang.messages.StatusMessage;
 import com.google.common.util.concurrent.SettableFuture;
 
-import software.amazon.kinesis.coordinator.KinesisClientLibConfiguration;
 import software.amazon.kinesis.lifecycle.events.InitializationInput;
 import software.amazon.kinesis.lifecycle.events.ProcessRecordsInput;
-import software.amazon.kinesis.lifecycle.ShutdownReason;
 import software.amazon.kinesis.processor.RecordProcessorCheckpointer;
 import software.amazon.kinesis.retrieval.KinesisClientRecord;
 

--- a/amazon-kinesis-client-multilang/src/test/java/software/amazon/kinesis/multilang/ReadSTDERRTaskTest.java
+++ b/amazon-kinesis-client-multilang/src/test/java/software/amazon/kinesis/multilang/ReadSTDERRTaskTest.java
@@ -27,8 +27,6 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
-import software.amazon.kinesis.multilang.DrainChildSTDERRTask;
-import software.amazon.kinesis.multilang.LineReaderTask;
 
 public class ReadSTDERRTaskTest {
 

--- a/amazon-kinesis-client-multilang/src/test/java/software/amazon/kinesis/multilang/StreamingShardRecordProcessorFactoryTest.java
+++ b/amazon-kinesis-client-multilang/src/test/java/software/amazon/kinesis/multilang/StreamingShardRecordProcessorFactoryTest.java
@@ -14,12 +14,9 @@
  */
 package software.amazon.kinesis.multilang;
 
-import software.amazon.kinesis.coordinator.KinesisClientLibConfiguration;
 import org.junit.Assert;
 import org.junit.Test;
 
-import software.amazon.kinesis.multilang.MultiLangRecordProcessorFactory;
-import software.amazon.kinesis.multilang.MultiLangShardRecordProcessor;
 import software.amazon.kinesis.multilang.config.MultiLangDaemonConfiguration;
 import software.amazon.kinesis.processor.ShardRecordProcessor;
 import org.junit.runner.RunWith;

--- a/amazon-kinesis-client-multilang/src/test/java/software/amazon/kinesis/multilang/config/AWSCredentialsProviderPropertyValueDecoderTest.java
+++ b/amazon-kinesis-client-multilang/src/test/java/software/amazon/kinesis/multilang/config/AWSCredentialsProviderPropertyValueDecoderTest.java
@@ -16,7 +16,6 @@ package software.amazon.kinesis.multilang.config;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
 import java.util.Arrays;
@@ -31,11 +30,6 @@ import org.junit.Test;
 import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.auth.AWSCredentialsProviderChain;
-
-import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
-import software.amazon.awssdk.auth.credentials.AwsCredentials;
-import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
-import software.amazon.awssdk.auth.credentials.AwsCredentialsProviderChain;
 
 public class AWSCredentialsProviderPropertyValueDecoderTest {
 

--- a/amazon-kinesis-client-multilang/src/test/java/software/amazon/kinesis/multilang/config/KinesisClientLibConfiguratorTest.java
+++ b/amazon-kinesis-client-multilang/src/test/java/software/amazon/kinesis/multilang/config/KinesisClientLibConfiguratorTest.java
@@ -278,10 +278,8 @@ public class KinesisClientLibConfiguratorTest {
         }
     }
 
-    @Test
+    @Test(expected = IllegalArgumentException.class)
     public void testWithMissingCredentialsProvider() {
-        thrown.expect(IllegalArgumentException.class);
-        thrown.expectMessage("A basic set of AWS credentials must be provided");
 
         String test = StringUtils.join(new String[] { "streamName = a", "applicationName = b", "workerId = 123",
                 "failoverTimeMillis = 100", "shardSyncIntervalMillis = 500" }, '\n');
@@ -305,10 +303,8 @@ public class KinesisClientLibConfiguratorTest {
         assertFalse(config.getWorkerIdentifier().isEmpty());
     }
 
-    @Test
+    @Test(expected = NullPointerException.class)
     public void testWithMissingStreamNameAndMissingStreamArn() {
-        thrown.expect(NullPointerException.class);
-
         String test = StringUtils.join(new String[] {
                         "applicationName = b",
                         "AWSCredentialsProvider = " + credentialName1,
@@ -320,9 +316,8 @@ public class KinesisClientLibConfiguratorTest {
         configurator.getConfiguration(input);
     }
 
-    @Test
+    @Test(expected = IllegalArgumentException.class)
     public void testWithEmptyStreamNameAndMissingStreamArn() {
-        thrown.expect(IllegalArgumentException.class);
 
         String test = StringUtils.join(new String[] {
                         "applicationName = b",
@@ -337,10 +332,8 @@ public class KinesisClientLibConfiguratorTest {
         configurator.getConfiguration(input);
     }
 
-    @Test
+    @Test(expected = NullPointerException.class)
     public void testWithMissingApplicationName() {
-        thrown.expect(NullPointerException.class);
-        thrown.expectMessage("Application name is required");
 
         String test = StringUtils.join(new String[] { "streamName = a", "AWSCredentialsProvider = " + credentialName1,
                 "workerId = 123", "failoverTimeMillis = 100" }, '\n');

--- a/amazon-kinesis-client-multilang/src/test/java/software/amazon/kinesis/multilang/config/KinesisClientLibConfiguratorTest.java
+++ b/amazon-kinesis-client-multilang/src/test/java/software/amazon/kinesis/multilang/config/KinesisClientLibConfiguratorTest.java
@@ -107,8 +107,8 @@ public class KinesisClientLibConfiguratorTest {
         // they must specify the time with initialPositionInStreamExtended.
         try {
             getConfiguration(StringUtils.join(new String[] { "applicationName = app",
-                    "streamName = 123", "AWSCredentialsProvider = " + credentialName1 + ", " + credentialName2,
-                    "initialPositionInStream = AT_TIMESTAMP"}, '\n'));
+            "streamName = 123", "AWSCredentialsProvider = " + credentialName1 + ", " + credentialName2,
+            "initialPositionInStream = AT_TIMESTAMP"}, '\n'));
             fail("Should have thrown when initialPositionInStream is set to AT_TIMESTAMP");
         } catch (Exception e) {
             Throwable rootCause = ExceptionUtils.getRootCause(e);
@@ -122,8 +122,8 @@ public class KinesisClientLibConfiguratorTest {
         // value is provided, the constructor should throw an IllegalArgumentException exception.
         try {
             getConfiguration(StringUtils.join(new String[] { "applicationName = app",
-                    "streamName = 123", "AWSCredentialsProvider = " + credentialName1 + ", " + credentialName2,
-                    "initialPositionInStreamExtended = null"}, '\n'));
+            "streamName = 123", "AWSCredentialsProvider = " + credentialName1 + ", " + credentialName2,
+            "initialPositionInStreamExtended = null"}, '\n'));
             fail("Should have thrown when initialPositionInStreamExtended is set to null");
         } catch (Exception e) {
             Throwable rootCause = ExceptionUtils.getRootCause(e);
@@ -163,9 +163,9 @@ public class KinesisClientLibConfiguratorTest {
     @Test
     public void testWithBooleanVariables() {
         MultiLangDaemonConfiguration config = getConfiguration(StringUtils.join(new String[] { "streamName = a",
-                        "applicationName = b", "AWSCredentialsProvider = ABCD, " + credentialName1, "workerId = 0",
-                        "cleanupLeasesUponShardCompletion = false", "validateSequenceNumberBeforeCheckpointing = true",
-                        "regionName = us-east-1"},
+                "applicationName = b", "AWSCredentialsProvider = ABCD, " + credentialName1, "workerId = 0",
+                "cleanupLeasesUponShardCompletion = false", "validateSequenceNumberBeforeCheckpointing = true",
+                "regionName = us-east-1"},
                 '\n'));
 
         assertEquals(config.getApplicationName(), "b");
@@ -309,7 +309,6 @@ public class KinesisClientLibConfiguratorTest {
     @Test
     public void testWithMissingStreamNameAndMissingStreamArn() {
         thrown.expect(NullPointerException.class);
-        thrown.expectMessage("Stream name or Stream Arn is required. Stream Arn takes precedence if both are passed in.");
 
         String test = StringUtils.join(new String[] {
                         "applicationName = b",
@@ -321,10 +320,10 @@ public class KinesisClientLibConfiguratorTest {
 
         configurator.getConfiguration(input);
     }
+
     @Test
     public void testWithEmptyStreamNameAndMissingStreamArn() {
         thrown.expect(IllegalArgumentException.class);
-        thrown.expectMessage("Stream name or Stream Arn is required. Stream Arn takes precedence if both are passed in.");
 
         String test = StringUtils.join(new String[] {
                         "applicationName = b",

--- a/amazon-kinesis-client-multilang/src/test/java/software/amazon/kinesis/multilang/config/KinesisClientLibConfiguratorTest.java
+++ b/amazon-kinesis-client-multilang/src/test/java/software/amazon/kinesis/multilang/config/KinesisClientLibConfiguratorTest.java
@@ -164,8 +164,7 @@ public class KinesisClientLibConfiguratorTest {
     public void testWithBooleanVariables() {
         MultiLangDaemonConfiguration config = getConfiguration(StringUtils.join(new String[] { "streamName = a",
                 "applicationName = b", "AWSCredentialsProvider = ABCD, " + credentialName1, "workerId = 0",
-                "cleanupLeasesUponShardCompletion = false", "validateSequenceNumberBeforeCheckpointing = true",
-                "regionName = us-east-1"},
+                "cleanupLeasesUponShardCompletion = false", "validateSequenceNumberBeforeCheckpointing = true" },
                 '\n'));
 
         assertEquals(config.getApplicationName(), "b");

--- a/amazon-kinesis-client-multilang/src/test/java/software/amazon/kinesis/multilang/config/KinesisClientLibConfiguratorTest.java
+++ b/amazon-kinesis-client-multilang/src/test/java/software/amazon/kinesis/multilang/config/KinesisClientLibConfiguratorTest.java
@@ -107,8 +107,8 @@ public class KinesisClientLibConfiguratorTest {
         // they must specify the time with initialPositionInStreamExtended.
         try {
             getConfiguration(StringUtils.join(new String[] { "applicationName = app",
-            "streamName = 123", "AWSCredentialsProvider = " + credentialName1 + ", " + credentialName2,
-            "initialPositionInStream = AT_TIMESTAMP"}, '\n'));
+                    "streamName = 123", "AWSCredentialsProvider = " + credentialName1 + ", " + credentialName2,
+                    "initialPositionInStream = AT_TIMESTAMP"}, '\n'));
             fail("Should have thrown when initialPositionInStream is set to AT_TIMESTAMP");
         } catch (Exception e) {
             Throwable rootCause = ExceptionUtils.getRootCause(e);
@@ -122,8 +122,8 @@ public class KinesisClientLibConfiguratorTest {
         // value is provided, the constructor should throw an IllegalArgumentException exception.
         try {
             getConfiguration(StringUtils.join(new String[] { "applicationName = app",
-            "streamName = 123", "AWSCredentialsProvider = " + credentialName1 + ", " + credentialName2,
-            "initialPositionInStreamExtended = null"}, '\n'));
+                    "streamName = 123", "AWSCredentialsProvider = " + credentialName1 + ", " + credentialName2,
+                    "initialPositionInStreamExtended = null"}, '\n'));
             fail("Should have thrown when initialPositionInStreamExtended is set to null");
         } catch (Exception e) {
             Throwable rootCause = ExceptionUtils.getRootCause(e);
@@ -163,8 +163,8 @@ public class KinesisClientLibConfiguratorTest {
     @Test
     public void testWithBooleanVariables() {
         MultiLangDaemonConfiguration config = getConfiguration(StringUtils.join(new String[] { "streamName = a",
-                "applicationName = b", "AWSCredentialsProvider = ABCD, " + credentialName1, "workerId = 0",
-                "cleanupLeasesUponShardCompletion = false", "validateSequenceNumberBeforeCheckpointing = true" },
+                        "applicationName = b", "AWSCredentialsProvider = ABCD, " + credentialName1, "workerId = 0",
+                        "cleanupLeasesUponShardCompletion = false", "validateSequenceNumberBeforeCheckpointing = true" },
                 '\n'));
 
         assertEquals(config.getApplicationName(), "b");
@@ -306,12 +306,33 @@ public class KinesisClientLibConfiguratorTest {
     }
 
     @Test
-    public void testWithMissingStreamName() {
+    public void testWithMissingStreamNameAndMissingStreamArn() {
         thrown.expect(NullPointerException.class);
-        thrown.expectMessage("Stream name is required");
+        thrown.expectMessage("Stream name or Stream Arn is required. Stream Arn takes precedence if both are passed in.");
 
-        String test = StringUtils.join(new String[] { "applicationName = b",
-                "AWSCredentialsProvider = " + credentialName1, "workerId = 123", "failoverTimeMillis = 100" }, '\n');
+        String test = StringUtils.join(new String[] {
+                        "applicationName = b",
+                        "AWSCredentialsProvider = " + credentialName1,
+                        "workerId = 123",
+                        "failoverTimeMillis = 100" },
+                '\n');
+        InputStream input = new ByteArrayInputStream(test.getBytes());
+
+        configurator.getConfiguration(input);
+    }
+    @Test
+    public void testWithEmptyStreamNameAndMissingStreamArn() {
+        thrown.expect(IllegalArgumentException.class);
+        thrown.expectMessage("Stream name or Stream Arn is required. Stream Arn takes precedence if both are passed in.");
+
+        String test = StringUtils.join(new String[] {
+                        "applicationName = b",
+                        "AWSCredentialsProvider = " + credentialName1,
+                        "workerId = 123",
+                        "failoverTimeMillis = 100",
+                        "streamName = ",
+                        "streamArn = "},
+                '\n');
         InputStream input = new ByteArrayInputStream(test.getBytes());
 
         configurator.getConfiguration(input);

--- a/amazon-kinesis-client-multilang/src/test/java/software/amazon/kinesis/multilang/config/KinesisClientLibConfiguratorTest.java
+++ b/amazon-kinesis-client-multilang/src/test/java/software/amazon/kinesis/multilang/config/KinesisClientLibConfiguratorTest.java
@@ -69,7 +69,7 @@ public class KinesisClientLibConfiguratorTest {
     @Test
     public void testWithBasicSetup() {
         MultiLangDaemonConfiguration config = getConfiguration(StringUtils.join(new String[] { "streamName = a",
-                "applicationName = b", "AWSCredentialsProvider = " + credentialName1, "workerId = 123", "regionName = us-east-1" }, '\n'));
+                "applicationName = b", "AWSCredentialsProvider = " + credentialName1, "workerId = 123" }, '\n'));
         assertEquals(config.getApplicationName(), "b");
         assertEquals(config.getStreamName(), "a");
         assertEquals(config.getWorkerIdentifier(), "123");
@@ -81,7 +81,7 @@ public class KinesisClientLibConfiguratorTest {
     public void testWithLongVariables() {
         MultiLangDaemonConfiguration config = getConfiguration(StringUtils.join(new String[] { "applicationName = app",
                 "streamName = 123", "AWSCredentialsProvider = " + credentialName1 + ", " + credentialName2,
-                "workerId = 123", "failoverTimeMillis = 100", "shardSyncIntervalMillis = 500", "regionName = us-east-1" }, '\n'));
+                "workerId = 123", "failoverTimeMillis = 100", "shardSyncIntervalMillis = 500" }, '\n'));
 
         assertEquals(config.getApplicationName(), "app");
         assertEquals(config.getStreamName(), "123");
@@ -95,7 +95,7 @@ public class KinesisClientLibConfiguratorTest {
         long epochTimeInSeconds = 1617406032;
         MultiLangDaemonConfiguration config = getConfiguration(StringUtils.join(new String[] { "applicationName = app",
                 "streamName = 123", "AWSCredentialsProvider = " + credentialName1 + ", " + credentialName2,
-                "initialPositionInStreamExtended = " + epochTimeInSeconds, "regionName = us-east-1"}, '\n'));
+                "initialPositionInStreamExtended = " + epochTimeInSeconds}, '\n'));
 
         assertEquals(config.getInitialPositionInStreamExtended().getTimestamp(), new Date(epochTimeInSeconds * 1000L));
         assertEquals(config.getInitialPositionInStream(), InitialPositionInStream.AT_TIMESTAMP);
@@ -135,7 +135,7 @@ public class KinesisClientLibConfiguratorTest {
     public void testWithUnsupportedClientConfigurationVariables() {
         MultiLangDaemonConfiguration config = getConfiguration(StringUtils.join(
                 new String[] { "AWSCredentialsProvider = " + credentialName1 + ", " + credentialName2, "workerId = id",
-                        "kinesisClientConfig = {}", "streamName = stream", "applicationName = b", "regionName = us-east-1" },
+                        "kinesisClientConfig = {}", "streamName = stream", "applicationName = b" },
                 '\n'));
 
         assertEquals(config.getApplicationName(), "b");
@@ -149,7 +149,7 @@ public class KinesisClientLibConfiguratorTest {
         MultiLangDaemonConfiguration config = getConfiguration(StringUtils.join(new String[] { "streamName = kinesis",
                 "AWSCredentialsProvider = " + credentialName2 + ", " + credentialName1, "workerId = w123",
                 "maxRecords = 10", "metricsMaxQueueSize = 20", "applicationName = kinesis",
-                "retryGetRecordsInSeconds = 2", "maxGetRecordsThreadPool = 1", "regionName = us-east-1" }, '\n'));
+                "retryGetRecordsInSeconds = 2", "maxGetRecordsThreadPool = 1" }, '\n'));
 
         assertEquals(config.getApplicationName(), "kinesis");
         assertEquals(config.getStreamName(), "kinesis");
@@ -179,7 +179,7 @@ public class KinesisClientLibConfiguratorTest {
     public void testWithStringVariables() {
         MultiLangDaemonConfiguration config = getConfiguration(StringUtils.join(new String[] { "streamName = a",
                 "applicationName = b", "AWSCredentialsProvider = ABCD," + credentialName1, "workerId = 1",
-                "kinesisEndpoint = https://kinesis", "metricsLevel = SUMMARY", "regionName = us-east-1" }, '\n'));
+                "kinesisEndpoint = https://kinesis", "metricsLevel = SUMMARY" }, '\n'));
 
         assertEquals(config.getWorkerIdentifier(), "1");
         assertEquals(config.getKinesisClient().get("endpointOverride"), URI.create("https://kinesis"));
@@ -190,7 +190,7 @@ public class KinesisClientLibConfiguratorTest {
     public void testWithSetVariables() {
         MultiLangDaemonConfiguration config = getConfiguration(StringUtils.join(new String[] { "streamName = a",
                 "applicationName = b", "AWSCredentialsProvider = ABCD," + credentialName1, "workerId = 1",
-                "metricsEnabledDimensions = ShardId, WorkerIdentifier", "regionName = us-east-1" }, '\n'));
+                "metricsEnabledDimensions = ShardId, WorkerIdentifier" }, '\n'));
 
         Set<String> expectedMetricsEnabledDimensions = ImmutableSet.<String> builder()
                 .add("ShardId", "WorkerIdentifier").build();
@@ -201,7 +201,7 @@ public class KinesisClientLibConfiguratorTest {
     public void testWithInitialPositionInStreamTrimHorizon() {
         MultiLangDaemonConfiguration config = getConfiguration(StringUtils.join(new String[] { "streamName = a",
                 "applicationName = b", "AWSCredentialsProvider = ABCD," + credentialName1, "workerId = 123",
-                "initialPositionInStream = TriM_Horizon", "regionName = us-east-1" }, '\n'));
+                "initialPositionInStream = TriM_Horizon" }, '\n'));
 
         assertEquals(config.getInitialPositionInStream(), InitialPositionInStream.TRIM_HORIZON);
     }
@@ -210,7 +210,7 @@ public class KinesisClientLibConfiguratorTest {
     public void testWithInitialPositionInStreamLatest() {
         MultiLangDaemonConfiguration config = getConfiguration(StringUtils.join(new String[] { "streamName = a",
                 "applicationName = b", "AWSCredentialsProvider = ABCD," + credentialName1, "workerId = 123",
-                "initialPositionInStream = LateSt", "regionName = us-east-1" }, '\n'));
+                "initialPositionInStream = LateSt" }, '\n'));
 
         assertEquals(config.getInitialPositionInStream(), InitialPositionInStream.LATEST);
     }
@@ -219,7 +219,7 @@ public class KinesisClientLibConfiguratorTest {
     public void testSkippingNonKCLVariables() {
         MultiLangDaemonConfiguration config = getConfiguration(StringUtils.join(new String[] { "streamName = a",
                 "applicationName = b", "AWSCredentialsProvider = ABCD," + credentialName1, "workerId = 123",
-                "initialPositionInStream = TriM_Horizon", "abc = 1", "regionName = us-east-1" }, '\n'));
+                "initialPositionInStream = TriM_Horizon", "abc = 1" }, '\n'));
 
         assertEquals(config.getApplicationName(), "b");
         assertEquals(config.getStreamName(), "a");
@@ -231,7 +231,7 @@ public class KinesisClientLibConfiguratorTest {
     public void testEmptyOptionalVariables() {
         MultiLangDaemonConfiguration config = getConfiguration(StringUtils.join(new String[] { "streamName = a",
                 "applicationName = b", "AWSCredentialsProvider = ABCD," + credentialName1, "workerId = 123",
-                "initialPositionInStream = TriM_Horizon", "maxGetRecordsThreadPool = 1", "regionName = us-east-1" }, '\n'));
+                "initialPositionInStream = TriM_Horizon", "maxGetRecordsThreadPool = 1" }, '\n'));
         assertThat(config.getMaxGetRecordsThreadPool(), equalTo(1));
         assertThat(config.getRetryGetRecordsInSeconds(), nullValue());
     }
@@ -241,7 +241,7 @@ public class KinesisClientLibConfiguratorTest {
         String test = StringUtils.join(new String[] { "streamName = a", "applicationName = b",
                 "AWSCredentialsProvider = ABCD," + credentialName1, "workerId = 123",
                 "initialPositionInStream = TriM_Horizon", "maxGetRecordsThreadPool = 0",
-                "retryGetRecordsInSeconds = 0", "regionName = us-east-1" }, '\n');
+                "retryGetRecordsInSeconds = 0" }, '\n');
         InputStream input = new ByteArrayInputStream(test.getBytes());
 
         try {
@@ -255,7 +255,7 @@ public class KinesisClientLibConfiguratorTest {
     @Test
     public void testWithInvalidIntValue() {
         String test = StringUtils.join(new String[] { "streamName = a", "applicationName = b",
-                "AWSCredentialsProvider = " + credentialName1, "workerId = 123", "failoverTimeMillis = 100nf", "regionName = us-east-1" }, '\n');
+                "AWSCredentialsProvider = " + credentialName1, "workerId = 123", "failoverTimeMillis = 100nf" }, '\n');
         InputStream input = new ByteArrayInputStream(test.getBytes());
 
         try {
@@ -268,7 +268,7 @@ public class KinesisClientLibConfiguratorTest {
     @Test
     public void testWithNegativeIntValue() {
         String test = StringUtils.join(new String[] { "streamName = a", "applicationName = b",
-                "AWSCredentialsProvider = " + credentialName1, "workerId = 123", "failoverTimeMillis = -12", "regionName = us-east-1" }, '\n');
+                "AWSCredentialsProvider = " + credentialName1, "workerId = 123", "failoverTimeMillis = -12" }, '\n');
         InputStream input = new ByteArrayInputStream(test.getBytes());
 
         // separate input stream with getConfiguration to explicitly catch exception from the getConfiguration statement
@@ -296,7 +296,7 @@ public class KinesisClientLibConfiguratorTest {
     public void testWithMissingWorkerId() {
         String test = StringUtils.join(
                 new String[] { "streamName = a", "applicationName = b", "AWSCredentialsProvider = " + credentialName1,
-                        "failoverTimeMillis = 100", "shardSyncIntervalMillis = 500", "regionName = us-east-1" },
+                        "failoverTimeMillis = 100", "shardSyncIntervalMillis = 500" },
                 '\n');
         InputStream input = new ByteArrayInputStream(test.getBytes());
         MultiLangDaemonConfiguration config = configurator.getConfiguration(input);
@@ -375,7 +375,7 @@ public class KinesisClientLibConfiguratorTest {
                 "AWSCredentialsProvider = " + credentialNameKinesis,
                 "AWSCredentialsProviderDynamoDB = " + credentialNameDynamoDB,
                 "AWSCredentialsProviderCloudWatch = " + credentialNameCloudWatch, "failoverTimeMillis = 100",
-                "shardSyncIntervalMillis = 500", "regionName = us-east-1" }, '\n');
+                "shardSyncIntervalMillis = 500" }, '\n');
         InputStream input = new ByteArrayInputStream(test.getBytes());
 
         // separate input stream with getConfiguration to explicitly catch exception from the getConfiguration statement
@@ -404,7 +404,7 @@ public class KinesisClientLibConfiguratorTest {
                 "AWSCredentialsProvider = " + credentialNameKinesis,
                 "AWSCredentialsProviderDynamoDB = " + credentialName2,
                 "AWSCredentialsProviderCloudWatch = " + credentialName2, "failoverTimeMillis = 100",
-                "shardSyncIntervalMillis = 500", "regionName = us-east-1" }, '\n');
+                "shardSyncIntervalMillis = 500" }, '\n');
         InputStream input = new ByteArrayInputStream(test.getBytes());
 
         // separate input stream with getConfiguration to explicitly catch exception from the getConfiguration statement

--- a/amazon-kinesis-client-multilang/src/test/java/software/amazon/kinesis/multilang/config/KinesisClientLibConfiguratorTest.java
+++ b/amazon-kinesis-client-multilang/src/test/java/software/amazon/kinesis/multilang/config/KinesisClientLibConfiguratorTest.java
@@ -69,7 +69,7 @@ public class KinesisClientLibConfiguratorTest {
     @Test
     public void testWithBasicSetup() {
         MultiLangDaemonConfiguration config = getConfiguration(StringUtils.join(new String[] { "streamName = a",
-                "applicationName = b", "AWSCredentialsProvider = " + credentialName1, "workerId = 123" }, '\n'));
+                "applicationName = b", "AWSCredentialsProvider = " + credentialName1, "workerId = 123", "regionName = us-east-1" }, '\n'));
         assertEquals(config.getApplicationName(), "b");
         assertEquals(config.getStreamName(), "a");
         assertEquals(config.getWorkerIdentifier(), "123");
@@ -81,7 +81,7 @@ public class KinesisClientLibConfiguratorTest {
     public void testWithLongVariables() {
         MultiLangDaemonConfiguration config = getConfiguration(StringUtils.join(new String[] { "applicationName = app",
                 "streamName = 123", "AWSCredentialsProvider = " + credentialName1 + ", " + credentialName2,
-                "workerId = 123", "failoverTimeMillis = 100", "shardSyncIntervalMillis = 500" }, '\n'));
+                "workerId = 123", "failoverTimeMillis = 100", "shardSyncIntervalMillis = 500", "regionName = us-east-1" }, '\n'));
 
         assertEquals(config.getApplicationName(), "app");
         assertEquals(config.getStreamName(), "123");
@@ -95,7 +95,7 @@ public class KinesisClientLibConfiguratorTest {
         long epochTimeInSeconds = 1617406032;
         MultiLangDaemonConfiguration config = getConfiguration(StringUtils.join(new String[] { "applicationName = app",
                 "streamName = 123", "AWSCredentialsProvider = " + credentialName1 + ", " + credentialName2,
-                "initialPositionInStreamExtended = " + epochTimeInSeconds}, '\n'));
+                "initialPositionInStreamExtended = " + epochTimeInSeconds, "regionName = us-east-1"}, '\n'));
 
         assertEquals(config.getInitialPositionInStreamExtended().getTimestamp(), new Date(epochTimeInSeconds * 1000L));
         assertEquals(config.getInitialPositionInStream(), InitialPositionInStream.AT_TIMESTAMP);
@@ -135,7 +135,7 @@ public class KinesisClientLibConfiguratorTest {
     public void testWithUnsupportedClientConfigurationVariables() {
         MultiLangDaemonConfiguration config = getConfiguration(StringUtils.join(
                 new String[] { "AWSCredentialsProvider = " + credentialName1 + ", " + credentialName2, "workerId = id",
-                        "kinesisClientConfig = {}", "streamName = stream", "applicationName = b" },
+                        "kinesisClientConfig = {}", "streamName = stream", "applicationName = b", "regionName = us-east-1" },
                 '\n'));
 
         assertEquals(config.getApplicationName(), "b");
@@ -149,7 +149,7 @@ public class KinesisClientLibConfiguratorTest {
         MultiLangDaemonConfiguration config = getConfiguration(StringUtils.join(new String[] { "streamName = kinesis",
                 "AWSCredentialsProvider = " + credentialName2 + ", " + credentialName1, "workerId = w123",
                 "maxRecords = 10", "metricsMaxQueueSize = 20", "applicationName = kinesis",
-                "retryGetRecordsInSeconds = 2", "maxGetRecordsThreadPool = 1" }, '\n'));
+                "retryGetRecordsInSeconds = 2", "maxGetRecordsThreadPool = 1", "regionName = us-east-1" }, '\n'));
 
         assertEquals(config.getApplicationName(), "kinesis");
         assertEquals(config.getStreamName(), "kinesis");
@@ -164,7 +164,8 @@ public class KinesisClientLibConfiguratorTest {
     public void testWithBooleanVariables() {
         MultiLangDaemonConfiguration config = getConfiguration(StringUtils.join(new String[] { "streamName = a",
                         "applicationName = b", "AWSCredentialsProvider = ABCD, " + credentialName1, "workerId = 0",
-                        "cleanupLeasesUponShardCompletion = false", "validateSequenceNumberBeforeCheckpointing = true" },
+                        "cleanupLeasesUponShardCompletion = false", "validateSequenceNumberBeforeCheckpointing = true",
+                        "regionName = us-east-1"},
                 '\n'));
 
         assertEquals(config.getApplicationName(), "b");
@@ -178,7 +179,7 @@ public class KinesisClientLibConfiguratorTest {
     public void testWithStringVariables() {
         MultiLangDaemonConfiguration config = getConfiguration(StringUtils.join(new String[] { "streamName = a",
                 "applicationName = b", "AWSCredentialsProvider = ABCD," + credentialName1, "workerId = 1",
-                "kinesisEndpoint = https://kinesis", "metricsLevel = SUMMARY" }, '\n'));
+                "kinesisEndpoint = https://kinesis", "metricsLevel = SUMMARY", "regionName = us-east-1" }, '\n'));
 
         assertEquals(config.getWorkerIdentifier(), "1");
         assertEquals(config.getKinesisClient().get("endpointOverride"), URI.create("https://kinesis"));
@@ -189,7 +190,7 @@ public class KinesisClientLibConfiguratorTest {
     public void testWithSetVariables() {
         MultiLangDaemonConfiguration config = getConfiguration(StringUtils.join(new String[] { "streamName = a",
                 "applicationName = b", "AWSCredentialsProvider = ABCD," + credentialName1, "workerId = 1",
-                "metricsEnabledDimensions = ShardId, WorkerIdentifier" }, '\n'));
+                "metricsEnabledDimensions = ShardId, WorkerIdentifier", "regionName = us-east-1" }, '\n'));
 
         Set<String> expectedMetricsEnabledDimensions = ImmutableSet.<String> builder()
                 .add("ShardId", "WorkerIdentifier").build();
@@ -200,7 +201,7 @@ public class KinesisClientLibConfiguratorTest {
     public void testWithInitialPositionInStreamTrimHorizon() {
         MultiLangDaemonConfiguration config = getConfiguration(StringUtils.join(new String[] { "streamName = a",
                 "applicationName = b", "AWSCredentialsProvider = ABCD," + credentialName1, "workerId = 123",
-                "initialPositionInStream = TriM_Horizon" }, '\n'));
+                "initialPositionInStream = TriM_Horizon", "regionName = us-east-1" }, '\n'));
 
         assertEquals(config.getInitialPositionInStream(), InitialPositionInStream.TRIM_HORIZON);
     }
@@ -209,7 +210,7 @@ public class KinesisClientLibConfiguratorTest {
     public void testWithInitialPositionInStreamLatest() {
         MultiLangDaemonConfiguration config = getConfiguration(StringUtils.join(new String[] { "streamName = a",
                 "applicationName = b", "AWSCredentialsProvider = ABCD," + credentialName1, "workerId = 123",
-                "initialPositionInStream = LateSt" }, '\n'));
+                "initialPositionInStream = LateSt", "regionName = us-east-1" }, '\n'));
 
         assertEquals(config.getInitialPositionInStream(), InitialPositionInStream.LATEST);
     }
@@ -218,7 +219,7 @@ public class KinesisClientLibConfiguratorTest {
     public void testSkippingNonKCLVariables() {
         MultiLangDaemonConfiguration config = getConfiguration(StringUtils.join(new String[] { "streamName = a",
                 "applicationName = b", "AWSCredentialsProvider = ABCD," + credentialName1, "workerId = 123",
-                "initialPositionInStream = TriM_Horizon", "abc = 1" }, '\n'));
+                "initialPositionInStream = TriM_Horizon", "abc = 1", "regionName = us-east-1" }, '\n'));
 
         assertEquals(config.getApplicationName(), "b");
         assertEquals(config.getStreamName(), "a");
@@ -230,7 +231,7 @@ public class KinesisClientLibConfiguratorTest {
     public void testEmptyOptionalVariables() {
         MultiLangDaemonConfiguration config = getConfiguration(StringUtils.join(new String[] { "streamName = a",
                 "applicationName = b", "AWSCredentialsProvider = ABCD," + credentialName1, "workerId = 123",
-                "initialPositionInStream = TriM_Horizon", "maxGetRecordsThreadPool = 1" }, '\n'));
+                "initialPositionInStream = TriM_Horizon", "maxGetRecordsThreadPool = 1", "regionName = us-east-1" }, '\n'));
         assertThat(config.getMaxGetRecordsThreadPool(), equalTo(1));
         assertThat(config.getRetryGetRecordsInSeconds(), nullValue());
     }
@@ -240,7 +241,7 @@ public class KinesisClientLibConfiguratorTest {
         String test = StringUtils.join(new String[] { "streamName = a", "applicationName = b",
                 "AWSCredentialsProvider = ABCD," + credentialName1, "workerId = 123",
                 "initialPositionInStream = TriM_Horizon", "maxGetRecordsThreadPool = 0",
-                "retryGetRecordsInSeconds = 0" }, '\n');
+                "retryGetRecordsInSeconds = 0", "regionName = us-east-1" }, '\n');
         InputStream input = new ByteArrayInputStream(test.getBytes());
 
         try {
@@ -254,7 +255,7 @@ public class KinesisClientLibConfiguratorTest {
     @Test
     public void testWithInvalidIntValue() {
         String test = StringUtils.join(new String[] { "streamName = a", "applicationName = b",
-                "AWSCredentialsProvider = " + credentialName1, "workerId = 123", "failoverTimeMillis = 100nf" }, '\n');
+                "AWSCredentialsProvider = " + credentialName1, "workerId = 123", "failoverTimeMillis = 100nf", "regionName = us-east-1" }, '\n');
         InputStream input = new ByteArrayInputStream(test.getBytes());
 
         try {
@@ -267,7 +268,7 @@ public class KinesisClientLibConfiguratorTest {
     @Test
     public void testWithNegativeIntValue() {
         String test = StringUtils.join(new String[] { "streamName = a", "applicationName = b",
-                "AWSCredentialsProvider = " + credentialName1, "workerId = 123", "failoverTimeMillis = -12" }, '\n');
+                "AWSCredentialsProvider = " + credentialName1, "workerId = 123", "failoverTimeMillis = -12", "regionName = us-east-1" }, '\n');
         InputStream input = new ByteArrayInputStream(test.getBytes());
 
         // separate input stream with getConfiguration to explicitly catch exception from the getConfiguration statement
@@ -295,7 +296,7 @@ public class KinesisClientLibConfiguratorTest {
     public void testWithMissingWorkerId() {
         String test = StringUtils.join(
                 new String[] { "streamName = a", "applicationName = b", "AWSCredentialsProvider = " + credentialName1,
-                        "failoverTimeMillis = 100", "shardSyncIntervalMillis = 500" },
+                        "failoverTimeMillis = 100", "shardSyncIntervalMillis = 500", "regionName = us-east-1" },
                 '\n');
         InputStream input = new ByteArrayInputStream(test.getBytes());
         MultiLangDaemonConfiguration config = configurator.getConfiguration(input);
@@ -374,7 +375,7 @@ public class KinesisClientLibConfiguratorTest {
                 "AWSCredentialsProvider = " + credentialNameKinesis,
                 "AWSCredentialsProviderDynamoDB = " + credentialNameDynamoDB,
                 "AWSCredentialsProviderCloudWatch = " + credentialNameCloudWatch, "failoverTimeMillis = 100",
-                "shardSyncIntervalMillis = 500" }, '\n');
+                "shardSyncIntervalMillis = 500", "regionName = us-east-1" }, '\n');
         InputStream input = new ByteArrayInputStream(test.getBytes());
 
         // separate input stream with getConfiguration to explicitly catch exception from the getConfiguration statement
@@ -403,7 +404,7 @@ public class KinesisClientLibConfiguratorTest {
                 "AWSCredentialsProvider = " + credentialNameKinesis,
                 "AWSCredentialsProviderDynamoDB = " + credentialName2,
                 "AWSCredentialsProviderCloudWatch = " + credentialName2, "failoverTimeMillis = 100",
-                "shardSyncIntervalMillis = 500" }, '\n');
+                "shardSyncIntervalMillis = 500", "regionName = us-east-1" }, '\n');
         InputStream input = new ByteArrayInputStream(test.getBytes());
 
         // separate input stream with getConfiguration to explicitly catch exception from the getConfiguration statement

--- a/amazon-kinesis-client-multilang/src/test/java/software/amazon/kinesis/multilang/messages/MessageTest.java
+++ b/amazon-kinesis-client-multilang/src/test/java/software/amazon/kinesis/multilang/messages/MessageTest.java
@@ -26,13 +26,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import software.amazon.kinesis.lifecycle.events.InitializationInput;
 import software.amazon.kinesis.lifecycle.events.ProcessRecordsInput;
 import software.amazon.kinesis.lifecycle.ShutdownReason;
-import software.amazon.kinesis.multilang.messages.CheckpointMessage;
-import software.amazon.kinesis.multilang.messages.InitializeMessage;
-import software.amazon.kinesis.multilang.messages.Message;
-import software.amazon.kinesis.multilang.messages.ProcessRecordsMessage;
-import software.amazon.kinesis.multilang.messages.ShutdownMessage;
-import software.amazon.kinesis.multilang.messages.ShutdownRequestedMessage;
-import software.amazon.kinesis.multilang.messages.StatusMessage;
 import software.amazon.kinesis.retrieval.KinesisClientRecord;
 
 public class MessageTest {

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/common/StreamIdentifier.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/common/StreamIdentifier.java
@@ -167,12 +167,22 @@ public class StreamIdentifier {
                 .build();
     }
 
-    private static void validateArn(Arn streamArn) {
+    /**
+     * Verify the streamArn follows the appropriate formatting.
+     * Throw an exception if it does not.
+     * @param streamArn
+     */
+    public static void validateArn(Arn streamArn) {
         if (!STREAM_ARN_PATTERN.matcher(streamArn.toString()).matches() || !streamArn.region().isPresent()) {
-            throw new IllegalArgumentException("Unable to create a StreamIdentifier from " + streamArn);
+            throw new IllegalArgumentException("Invalid streamArn " + streamArn);
         }
     }
 
+    /**
+     * Verify creationEpoch is greater than 0.
+     * Throw an exception if it is not.
+     * @param creationEpoch
+     */
     private static void validateCreationEpoch(long creationEpoch) {
         if (creationEpoch <= 0) {
             throw new IllegalArgumentException(


### PR DESCRIPTION
*[Extension of PR 1141](https://github.com/awslabs/amazon-kinesis-client/pull/1141) - Moved from branch to fork


*Description of changes:*
1. Updated multilang daemon to support 'streamArn' being passed in via Properties
   - Validation to ensure Arn is properly structured.
2. streamName is parsed out if 'streamArn' is passed in.
   - Meaning streamArn takes precedence if it is passed in
3. Added unit test to verify stream Arn is working as expected
4. Removed unused imports

==========================================================================================
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
