### PR TITLE
Modified `dependabot.yml` to set the correct `v[1|2].x` label.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,12 +2,18 @@ version: 2
 updates:
 - package-ecosystem: "maven"
   directory: "/"
+  labels:
+    - "dependencies"
+    - "v2.x"
   schedule: 
     interval: "weekly"
 
 # branch - v1.x
 - package-ecosystem: "maven"
   directory: "/"
+  labels:
+    - "dependencies"
+    - "v1.x"
   target-branch: "v1.x"
   schedule:
     interval: "weekly"


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*

Modified `dependabot.yml` to add the correct `v[1|2].x` label.

Configuration details @ https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#labels

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
