### PR TITLE
Only deleting resource created by ITs

### DIFF
--- a/amazon-kinesis-client/src/test/java/software/amazon/kinesis/utils/AWSResourceManager.java
+++ b/amazon-kinesis-client/src/test/java/software/amazon/kinesis/utils/AWSResourceManager.java
@@ -65,7 +65,10 @@ public abstract class AWSResourceManager {
     public void deleteAllResource() throws Exception {
         final List<String> resourceNames = getAllResourceNames();
         for (String resourceName : resourceNames) {
-            deleteResource(resourceName);
+            // Delete all resources that have prefix "KCLRelease"
+            if (resourceName.startsWith("KCLRelease")) {
+                deleteResource(resourceName);
+            }
         }
     }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Updating deleteAllResource to only delete resources (streams and lease tables) that are created by automated ITs instead of all resources in the AWS account. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
