### PR TITLE
CVE-2023-2976: revbump Guava `32.0.0-jre` -> `32.1.1-jre`

### DIFF
--- a/amazon-kinesis-client/pom.xml
+++ b/amazon-kinesis-client/pom.xml
@@ -88,7 +88,7 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>32.0.0-jre</version>
+      <version>32.1.1-jre</version>
     </dependency>
     <dependency>
       <groupId>com.google.protobuf</groupId>


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/amazon-kinesis-client/security/dependabot/6

*Description of changes:*
CVE-2023-2976: revbump Guava `32.0.0-jre` -> `32.1.1-jre`

https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-2976

`mvn clean verify` yields:
```
[INFO] Reactor Summary for Amazon Kinesis Client Library 2.5.2-SNAPSHOT:
[INFO] 
[INFO] Amazon Kinesis Client Library ...................... SUCCESS [  0.934 s]
[INFO] Amazon Kinesis Client Library for Java ............. SUCCESS [14:26 min]
[INFO] amazon-kinesis-client-multilang .................... SUCCESS [  6.268 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  14:34 min
[INFO] Finished at: 2023-07-17T15:48:40-04:00
[INFO] ------------------------------------------------------------------------
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
