### PR TITLE
Bumped aws-glue-schema-registry version

### DIFF
--- a/amazon-kinesis-client/pom.xml
+++ b/amazon-kinesis-client/pom.xml
@@ -51,7 +51,7 @@
     <sqlite4java.native>libsqlite4java</sqlite4java.native>
     <sqlite4java.libpath>${project.build.directory}/test-lib</sqlite4java.libpath>
     <slf4j.version>2.0.7</slf4j.version>
-    <gsr.version>1.1.14</gsr.version>
+    <gsr.version>1.1.16</gsr.version>
     <skipITs>true</skipITs>
   </properties>
 


### PR DESCRIPTION
Fixes CVE-2023-3635 in downstream dependencies


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
