### PR TITLE
Update gsr.version to 1.1.17

### DIFF
--- a/amazon-kinesis-client/pom.xml
+++ b/amazon-kinesis-client/pom.xml
@@ -51,7 +51,7 @@
     <sqlite4java.native>libsqlite4java</sqlite4java.native>
     <sqlite4java.libpath>${project.build.directory}/test-lib</sqlite4java.libpath>
     <slf4j.version>2.0.7</slf4j.version>
-    <gsr.version>1.1.16</gsr.version>
+    <gsr.version>1.1.17</gsr.version>
     <skipITs>true</skipITs>
   </properties>
 


### PR DESCRIPTION
*Description of changes:* Updating to gsr 1.1.17 resolves a number of CVEs in transitive dependencies since kafka was updated from 2.8.2 to 3.6.0 in https://github.com/awslabs/aws-glue-schema-registry/pull/302

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.