### PR TITLE
Prevent improper error logging during worker shutdown

### DIFF
--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/polling/PrefetchRecordsPublisher.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/polling/PrefetchRecordsPublisher.java
@@ -289,7 +289,6 @@ public class PrefetchRecordsPublisher implements RecordsPublisher {
     }
 
     private PrefetchRecordsRetrieved peekNextResult() {
-        throwOnIllegalState();
         return publisherSession.peekNextRecord();
     }
 
@@ -389,6 +388,7 @@ public class PrefetchRecordsPublisher implements RecordsPublisher {
         // If there is an event available to drain and if there is at least one demand,
         // then schedule it for delivery
         if (publisherSession.hasDemandToPublish() && canDispatchRecord(recordsToDeliver)) {
+            throwOnIllegalState();
             subscriber.onNext(recordsToDeliver.prepareForPublish());
             recordsToDeliver.dispatched();
             lastEventDeliveryTime = Instant.now();

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/polling/PrefetchRecordsPublisher.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/polling/PrefetchRecordsPublisher.java
@@ -335,6 +335,7 @@ public class PrefetchRecordsPublisher implements RecordsPublisher {
 
     @Override
     public void subscribe(Subscriber<? super RecordsRetrieved> s) {
+        throwOnIllegalState();
         subscriber = s;
         subscriber.onSubscribe(new Subscription() {
             @Override

--- a/amazon-kinesis-client/src/test/java/software/amazon/kinesis/retrieval/polling/PrefetchRecordsPublisherTest.java
+++ b/amazon-kinesis-client/src/test/java/software/amazon/kinesis/retrieval/polling/PrefetchRecordsPublisherTest.java
@@ -378,14 +378,14 @@ public class PrefetchRecordsPublisherTest {
     }
 
     @Test(expected = IllegalStateException.class)
-    public void testGetNextRecordsWithoutStarting() {
+    public void testSubscribeWithoutStarting() {
         verify(executorService, never()).execute(any());
         Subscriber<RecordsRetrieved> mockSubscriber = mock(Subscriber.class);
         getRecordsCache.subscribe(mockSubscriber);
     }
 
     @Test(expected = IllegalStateException.class)
-    public void testCallAfterShutdown() {
+    public void testRequestRecordsOnSubscriptionAfterShutdown() {
         GetRecordsResponse response = GetRecordsResponse.builder().records(
                         Record.builder().data(SdkBytes.fromByteArray(new byte[] { 1, 2, 3 })).sequenceNumber("123").build())
                 .nextShardIterator(NEXT_SHARD_ITERATOR).build();

--- a/amazon-kinesis-client/src/test/java/software/amazon/kinesis/retrieval/polling/PrefetchRecordsPublisherTest.java
+++ b/amazon-kinesis-client/src/test/java/software/amazon/kinesis/retrieval/polling/PrefetchRecordsPublisherTest.java
@@ -31,8 +31,10 @@ import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -64,6 +66,7 @@ import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.runners.MockitoJUnitRunner;
@@ -377,13 +380,27 @@ public class PrefetchRecordsPublisherTest {
     @Test(expected = IllegalStateException.class)
     public void testGetNextRecordsWithoutStarting() {
         verify(executorService, never()).execute(any());
-        getRecordsCache.drainQueueForRequests();
+        Subscriber<RecordsRetrieved> mockSubscriber = mock(Subscriber.class);
+        getRecordsCache.subscribe(mockSubscriber);
     }
 
     @Test(expected = IllegalStateException.class)
     public void testCallAfterShutdown() {
+        GetRecordsResponse response = GetRecordsResponse.builder().records(
+                        Record.builder().data(SdkBytes.fromByteArray(new byte[] { 1, 2, 3 })).sequenceNumber("123").build())
+                .nextShardIterator(NEXT_SHARD_ITERATOR).build();
+        when(getRecordsRetrievalStrategy.getRecords(anyInt())).thenReturn(response);
+
+        getRecordsCache.start(sequenceNumber, initialPosition);
+
+        verify(getRecordsRetrievalStrategy, timeout(100).atLeastOnce()).getRecords(anyInt());
+
         when(executorService.isShutdown()).thenReturn(true);
-        getRecordsCache.drainQueueForRequests();
+        Subscriber<RecordsRetrieved> mockSubscriber = mock(Subscriber.class);
+        getRecordsCache.subscribe(mockSubscriber);
+        ArgumentCaptor<Subscription> subscriptionCaptor = ArgumentCaptor.forClass(Subscription.class);
+        verify(mockSubscriber).onSubscribe(subscriptionCaptor.capture());
+        subscriptionCaptor.getValue().request(1);
     }
 
     @Test


### PR DESCRIPTION
This fix deals with a customer issue where the KCL logs an IllegalStateException during even a graceful worker shutdown. See https://github.com/awslabs/amazon-kinesis-client/issues/914

