### PR TITLE
Fix issue in configuring metricsEnabledDimensions

### DIFF
--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/metrics/MetricsConfig.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/metrics/MetricsConfig.java
@@ -15,6 +15,7 @@
 
 package software.amazon.kinesis.metrics;
 
+import java.util.HashSet;
 import java.util.Set;
 
 import com.google.common.collect.ImmutableSet;
@@ -94,7 +95,7 @@ public class MetricsConfig {
      * Default value: {@link MetricsConfig#METRICS_DIMENSIONS_ALL}
      * </p>
      */
-    private Set<String> metricsEnabledDimensions = METRICS_DIMENSIONS_ALL;
+    private HashSet<String> metricsEnabledDimensions = new HashSet<String>(METRICS_DIMENSIONS_ALL);
 
     /**
      * Buffer size for MetricDatums before publishing.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Multilang users of KCL would run into the below error when attempting to configure the metricsEnabledDimensions of the KCL through the multilang properties files

```
Java.lang.NoSuchMethodException: software.amazon.kinesis.metrics.MetricsConfig.metricsEnabledDimensions(java.util.HashSet)
```

This commit fixes the type of the field so that multilang users can configure this field like this to omit emitting WorkerIdentifier dimension metrics to CloudWatch
```
# By default, KCL will emit metrics for Operation, ShardId, and WorkerIdentifier dimensions
# Specify the specific dimensions to emit metrics for
metricsEnabledDimensions = Operation,ShardId
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
