### PR TITLE
Add Deletion protection config

### DIFF
--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/leases/LeaseManagementConfig.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/leases/LeaseManagementConfig.java
@@ -195,6 +195,13 @@ public class LeaseManagementConfig {
     private BillingMode billingMode = BillingMode.PAY_PER_REQUEST;
 
     /**
+     * Whether to enabled deletion protection on the DyanmoDB lease table created by KCL.
+     *
+     * <p>Default value: false
+     */
+    private boolean deletionProtectionEnabled = false;
+
+    /**
      * The list of tags to be applied to the DynamoDB table created for lease management.
      *
      * <p>Default value: {@link DefaultSdkAutoConstructList}
@@ -382,6 +389,7 @@ public class LeaseManagementConfig {
                     tableCreatorCallback(),
                     dynamoDbRequestTimeout(),
                     billingMode(),
+                    deletionProtectionEnabled(),
                     tags(),
                     leaseSerializer,
                     customShardDetectorProvider(),

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/leases/LeaseManagementConfig.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/leases/LeaseManagementConfig.java
@@ -195,11 +195,11 @@ public class LeaseManagementConfig {
     private BillingMode billingMode = BillingMode.PAY_PER_REQUEST;
 
     /**
-     * Whether to enabled deletion protection on the DyanmoDB lease table created by KCL.
+     * Whether to enabled deletion protection on the DynamoDB lease table created by KCL.
      *
      * <p>Default value: false
      */
-    private boolean deletionProtectionEnabled = false;
+    private boolean leaseTableDeletionProtectionEnabled = false;
 
     /**
      * The list of tags to be applied to the DynamoDB table created for lease management.
@@ -389,7 +389,7 @@ public class LeaseManagementConfig {
                     tableCreatorCallback(),
                     dynamoDbRequestTimeout(),
                     billingMode(),
-                    deletionProtectionEnabled(),
+                    leaseTableDeletionProtectionEnabled(),
                     tags(),
                     leaseSerializer,
                     customShardDetectorProvider(),

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/leases/dynamodb/DynamoDBLeaseManagementFactory.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/leases/dynamodb/DynamoDBLeaseManagementFactory.java
@@ -89,7 +89,7 @@ public class DynamoDBLeaseManagementFactory implements LeaseManagementFactory {
     private final TableCreatorCallback tableCreatorCallback;
     private final Duration dynamoDbRequestTimeout;
     private final BillingMode billingMode;
-    private final boolean deletionProtectionEnabled;
+    private final boolean leaseTableDeletionProtectionEnabled;
     private final Collection<Tag> tags;
     private final boolean isMultiStreamMode;
     private final LeaseCleanupConfig leaseCleanupConfig;
@@ -484,7 +484,7 @@ public class DynamoDBLeaseManagementFactory implements LeaseManagementFactory {
      * @param tableCreatorCallback
      * @param dynamoDbRequestTimeout
      * @param billingMode
-     * @param deletionProtectionEnabled
+     * @param leaseTableDeletionProtectionEnabled
      * @param tags
      */
     private DynamoDBLeaseManagementFactory(final KinesisAsyncClient kinesisClient, final StreamConfig streamConfig,
@@ -497,7 +497,7 @@ public class DynamoDBLeaseManagementFactory implements LeaseManagementFactory {
             final long listShardsCacheAllowedAgeInSeconds, final int cacheMissWarningModulus,
             final long initialLeaseTableReadCapacity, final long initialLeaseTableWriteCapacity,
             final HierarchicalShardSyncer deprecatedHierarchicalShardSyncer, final TableCreatorCallback tableCreatorCallback,
-            Duration dynamoDbRequestTimeout, BillingMode billingMode, final boolean deletionProtectionEnabled,
+            Duration dynamoDbRequestTimeout, BillingMode billingMode, final boolean leaseTableDeletionProtectionEnabled,
             Collection<Tag> tags, LeaseSerializer leaseSerializer) {
         this(kinesisClient, dynamoDBClient, tableName,
                 workerIdentifier, executorService, failoverTimeMillis, epsilonMillis, maxLeasesForWorker,
@@ -506,7 +506,7 @@ public class DynamoDBLeaseManagementFactory implements LeaseManagementFactory {
                 maxListShardsRetryAttempts, maxCacheMissesBeforeReload, listShardsCacheAllowedAgeInSeconds,
                 cacheMissWarningModulus, initialLeaseTableReadCapacity, initialLeaseTableWriteCapacity,
                 deprecatedHierarchicalShardSyncer, tableCreatorCallback, dynamoDbRequestTimeout, billingMode,
-                deletionProtectionEnabled, tags, leaseSerializer, null, false,
+                leaseTableDeletionProtectionEnabled, tags, leaseSerializer, null, false,
                 LeaseManagementConfig.DEFAULT_LEASE_CLEANUP_CONFIG);
         this.streamConfig = streamConfig;
     }
@@ -538,7 +538,7 @@ public class DynamoDBLeaseManagementFactory implements LeaseManagementFactory {
      * @param tableCreatorCallback
      * @param dynamoDbRequestTimeout
      * @param billingMode
-     * @param deletionProtectionEnabled
+     * @param leaseTableDeletionProtectionEnabled
      * @param leaseSerializer
      * @param customShardDetectorProvider
      * @param isMultiStreamMode
@@ -554,7 +554,7 @@ public class DynamoDBLeaseManagementFactory implements LeaseManagementFactory {
             final long listShardsCacheAllowedAgeInSeconds, final int cacheMissWarningModulus,
             final long initialLeaseTableReadCapacity, final long initialLeaseTableWriteCapacity,
             final HierarchicalShardSyncer deprecatedHierarchicalShardSyncer, final TableCreatorCallback tableCreatorCallback,
-            Duration dynamoDbRequestTimeout, BillingMode billingMode, final boolean deletionProtectionEnabled,
+            Duration dynamoDbRequestTimeout, BillingMode billingMode, final boolean leaseTableDeletionProtectionEnabled,
             Collection<Tag> tags, LeaseSerializer leaseSerializer,
             Function<StreamConfig, ShardDetector> customShardDetectorProvider, boolean isMultiStreamMode,
             LeaseCleanupConfig leaseCleanupConfig) {
@@ -583,7 +583,7 @@ public class DynamoDBLeaseManagementFactory implements LeaseManagementFactory {
         this.tableCreatorCallback = tableCreatorCallback;
         this.dynamoDbRequestTimeout = dynamoDbRequestTimeout;
         this.billingMode = billingMode;
-        this.deletionProtectionEnabled = deletionProtectionEnabled;
+        this.leaseTableDeletionProtectionEnabled = leaseTableDeletionProtectionEnabled;
         this.leaseSerializer = leaseSerializer;
         this.customShardDetectorProvider = customShardDetectorProvider;
         this.isMultiStreamMode = isMultiStreamMode;
@@ -655,7 +655,7 @@ public class DynamoDBLeaseManagementFactory implements LeaseManagementFactory {
     @Override
     public DynamoDBLeaseRefresher createLeaseRefresher() {
         return new DynamoDBLeaseRefresher(tableName, dynamoDBClient, leaseSerializer, consistentReads,
-                tableCreatorCallback, dynamoDbRequestTimeout, billingMode, deletionProtectionEnabled, tags);
+                tableCreatorCallback, dynamoDbRequestTimeout, billingMode, leaseTableDeletionProtectionEnabled, tags);
     }
 
     @Override

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/leases/dynamodb/DynamoDBLeaseRefresher.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/leases/dynamodb/DynamoDBLeaseRefresher.java
@@ -80,7 +80,7 @@ public class DynamoDBLeaseRefresher implements LeaseRefresher {
 
     private final Duration dynamoDbRequestTimeout;
     private final BillingMode billingMode;
-    private final boolean deletionProtectionEnabled;
+    private final boolean leaseTableDeletionProtectionEnabled;
     private final Collection<Tag> tags;
 
     private boolean newTableCreated = false;
@@ -147,15 +147,15 @@ public class DynamoDBLeaseRefresher implements LeaseRefresher {
      * @param tableCreatorCallback
      * @param dynamoDbRequestTimeout
      * @param billingMode
-     * @param deletionProtectionEnabled
+     * @param leaseTableDeletionProtectionEnabled
      */
     @Deprecated
     public DynamoDBLeaseRefresher(final String table, final DynamoDbAsyncClient dynamoDBClient,
                                   final LeaseSerializer serializer, final boolean consistentReads,
                                   @NonNull final TableCreatorCallback tableCreatorCallback, Duration dynamoDbRequestTimeout,
-                                  final BillingMode billingMode, final boolean deletionProtectionEnabled) {
+                                  final BillingMode billingMode, final boolean leaseTableDeletionProtectionEnabled) {
         this(table, dynamoDBClient, serializer, consistentReads, tableCreatorCallback, dynamoDbRequestTimeout,
-                billingMode, deletionProtectionEnabled, DefaultSdkAutoConstructList.getInstance());
+                billingMode, leaseTableDeletionProtectionEnabled, DefaultSdkAutoConstructList.getInstance());
     }
 
     /**
@@ -167,13 +167,13 @@ public class DynamoDBLeaseRefresher implements LeaseRefresher {
      * @param tableCreatorCallback
      * @param dynamoDbRequestTimeout
      * @param billingMode
-     * @param deletionProtectionEnabled
+     * @param leaseTableDeletionProtectionEnabled
      * @param tags
      */
     public DynamoDBLeaseRefresher(final String table, final DynamoDbAsyncClient dynamoDBClient,
                                   final LeaseSerializer serializer, final boolean consistentReads,
                                   @NonNull final TableCreatorCallback tableCreatorCallback, Duration dynamoDbRequestTimeout,
-                                  final BillingMode billingMode, final boolean deletionProtectionEnabled,
+                                  final BillingMode billingMode, final boolean leaseTableDeletionProtectionEnabled,
                                   final Collection<Tag> tags) {
         this.table = table;
         this.dynamoDBClient = dynamoDBClient;
@@ -182,7 +182,7 @@ public class DynamoDBLeaseRefresher implements LeaseRefresher {
         this.tableCreatorCallback = tableCreatorCallback;
         this.dynamoDbRequestTimeout = dynamoDbRequestTimeout;
         this.billingMode = billingMode;
-        this.deletionProtectionEnabled = deletionProtectionEnabled;
+        this.leaseTableDeletionProtectionEnabled = leaseTableDeletionProtectionEnabled;
         this.tags = tags;
     }
 
@@ -811,7 +811,7 @@ public class DynamoDBLeaseRefresher implements LeaseRefresher {
     private CreateTableRequest.Builder createTableRequestBuilder() {
         final CreateTableRequest.Builder builder = CreateTableRequest.builder().tableName(table).keySchema(serializer.getKeySchema())
                         .attributeDefinitions(serializer.getAttributeDefinitions())
-                        .deletionProtectionEnabled(deletionProtectionEnabled)
+                        .deletionProtectionEnabled(leaseTableDeletionProtectionEnabled)
                         .tags(tags);
         if (BillingMode.PAY_PER_REQUEST.equals(billingMode)) {
             builder.billingMode(billingMode);

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/leases/dynamodb/DynamoDBLeaseRefresher.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/leases/dynamodb/DynamoDBLeaseRefresher.java
@@ -80,6 +80,7 @@ public class DynamoDBLeaseRefresher implements LeaseRefresher {
 
     private final Duration dynamoDbRequestTimeout;
     private final BillingMode billingMode;
+    private final boolean deletionProtectionEnabled;
     private final Collection<Tag> tags;
 
     private boolean newTableCreated = false;
@@ -134,7 +135,7 @@ public class DynamoDBLeaseRefresher implements LeaseRefresher {
     public DynamoDBLeaseRefresher(final String table, final DynamoDbAsyncClient dynamoDBClient,
                                   final LeaseSerializer serializer, final boolean consistentReads,
                                   @NonNull final TableCreatorCallback tableCreatorCallback, Duration dynamoDbRequestTimeout) {
-        this(table, dynamoDBClient, serializer, consistentReads, tableCreatorCallback, dynamoDbRequestTimeout, BillingMode.PAY_PER_REQUEST);
+        this(table, dynamoDBClient, serializer, consistentReads, tableCreatorCallback, dynamoDbRequestTimeout, BillingMode.PAY_PER_REQUEST, false);
     }
 
     /**
@@ -146,14 +147,15 @@ public class DynamoDBLeaseRefresher implements LeaseRefresher {
      * @param tableCreatorCallback
      * @param dynamoDbRequestTimeout
      * @param billingMode
+     * @param deletionProtectionEnabled
      */
     @Deprecated
     public DynamoDBLeaseRefresher(final String table, final DynamoDbAsyncClient dynamoDBClient,
                                   final LeaseSerializer serializer, final boolean consistentReads,
                                   @NonNull final TableCreatorCallback tableCreatorCallback, Duration dynamoDbRequestTimeout,
-                                  final BillingMode billingMode) {
+                                  final BillingMode billingMode, final boolean deletionProtectionEnabled) {
         this(table, dynamoDBClient, serializer, consistentReads, tableCreatorCallback, dynamoDbRequestTimeout,
-                billingMode, DefaultSdkAutoConstructList.getInstance());
+                billingMode, deletionProtectionEnabled, DefaultSdkAutoConstructList.getInstance());
     }
 
     /**
@@ -165,12 +167,14 @@ public class DynamoDBLeaseRefresher implements LeaseRefresher {
      * @param tableCreatorCallback
      * @param dynamoDbRequestTimeout
      * @param billingMode
+     * @param deletionProtectionEnabled
      * @param tags
      */
     public DynamoDBLeaseRefresher(final String table, final DynamoDbAsyncClient dynamoDBClient,
                                   final LeaseSerializer serializer, final boolean consistentReads,
                                   @NonNull final TableCreatorCallback tableCreatorCallback, Duration dynamoDbRequestTimeout,
-                                  final BillingMode billingMode, final Collection<Tag> tags) {
+                                  final BillingMode billingMode, final boolean deletionProtectionEnabled,
+                                  final Collection<Tag> tags) {
         this.table = table;
         this.dynamoDBClient = dynamoDBClient;
         this.serializer = serializer;
@@ -178,6 +182,7 @@ public class DynamoDBLeaseRefresher implements LeaseRefresher {
         this.tableCreatorCallback = tableCreatorCallback;
         this.dynamoDbRequestTimeout = dynamoDbRequestTimeout;
         this.billingMode = billingMode;
+        this.deletionProtectionEnabled = deletionProtectionEnabled;
         this.tags = tags;
     }
 
@@ -806,6 +811,7 @@ public class DynamoDBLeaseRefresher implements LeaseRefresher {
     private CreateTableRequest.Builder createTableRequestBuilder() {
         final CreateTableRequest.Builder builder = CreateTableRequest.builder().tableName(table).keySchema(serializer.getKeySchema())
                         .attributeDefinitions(serializer.getAttributeDefinitions())
+                        .deletionProtectionEnabled(deletionProtectionEnabled)
                         .tags(tags);
         if (BillingMode.PAY_PER_REQUEST.equals(billingMode)) {
             builder.billingMode(billingMode);

--- a/amazon-kinesis-client/src/test/java/software/amazon/kinesis/leases/LeaseIntegrationBillingModePayPerRequestTest.java
+++ b/amazon-kinesis-client/src/test/java/software/amazon/kinesis/leases/LeaseIntegrationBillingModePayPerRequestTest.java
@@ -23,6 +23,6 @@ public class LeaseIntegrationBillingModePayPerRequestTest extends LeaseIntegrati
     @Override
     protected DynamoDBLeaseRefresher getLeaseRefresher() {
         return new DynamoDBLeaseRefresher(tableName+"Per-Request", ddbClient, leaseSerializer, true,
-                tableCreatorCallback, LeaseManagementConfig.DEFAULT_REQUEST_TIMEOUT, BillingMode.PAY_PER_REQUEST);
+                tableCreatorCallback, LeaseManagementConfig.DEFAULT_REQUEST_TIMEOUT, BillingMode.PAY_PER_REQUEST, false);
     }
 }

--- a/amazon-kinesis-client/src/test/java/software/amazon/kinesis/leases/LeaseIntegrationTest.java
+++ b/amazon-kinesis-client/src/test/java/software/amazon/kinesis/leases/LeaseIntegrationTest.java
@@ -74,7 +74,7 @@ public class LeaseIntegrationTest {
 
     protected DynamoDBLeaseRefresher getLeaseRefresher() {
         return new DynamoDBLeaseRefresher(tableName, ddbClient, leaseSerializer, true,
-                tableCreatorCallback, LeaseManagementConfig.DEFAULT_REQUEST_TIMEOUT, BillingMode.PAY_PER_REQUEST);
+                tableCreatorCallback, LeaseManagementConfig.DEFAULT_REQUEST_TIMEOUT, BillingMode.PAY_PER_REQUEST, false);
     }
 
 }

--- a/amazon-kinesis-client/src/test/java/software/amazon/kinesis/leases/dynamodb/DynamoDBLeaseRefresherTest.java
+++ b/amazon-kinesis-client/src/test/java/software/amazon/kinesis/leases/dynamodb/DynamoDBLeaseRefresherTest.java
@@ -81,6 +81,7 @@ public class DynamoDBLeaseRefresherTest {
 
     private static final String TABLE_NAME = "test";
     private static final boolean CONSISTENT_READS = true;
+    private static final boolean DELETION_PROTECTION_ENABLED = false;
 
     @Mock
     private DynamoDbAsyncClient dynamoDbClient;
@@ -127,6 +128,7 @@ public class DynamoDBLeaseRefresherTest {
                 .keySchema(leaseSerializer.getKeySchema())
                 .attributeDefinitions(leaseSerializer.getAttributeDefinitions())
                 .billingMode(BillingMode.PAY_PER_REQUEST)
+                .deletionProtectionEnabled(DELETION_PROTECTION_ENABLED)
                 .build();
     }
 
@@ -286,7 +288,7 @@ public class DynamoDBLeaseRefresherTest {
     @Test
     public void testCreateLeaseTableProvisionedBillingModeIfNotExists() throws Exception {
         leaseRefresher = new DynamoDBLeaseRefresher(TABLE_NAME, dynamoDbClient, leaseSerializer, CONSISTENT_READS,
-                tableCreatorCallback, LeaseManagementConfig.DEFAULT_REQUEST_TIMEOUT, BillingMode.PROVISIONED);
+                tableCreatorCallback, LeaseManagementConfig.DEFAULT_REQUEST_TIMEOUT, BillingMode.PROVISIONED, DELETION_PROTECTION_ENABLED);
 
         when(dynamoDbClient.describeTable(describeTableRequest)).thenReturn(mockDescribeTableFuture);
         when(mockDescribeTableFuture.get(eq(LeaseManagementConfig.DEFAULT_REQUEST_TIMEOUT.toMillis()), eq(TimeUnit.MILLISECONDS)))
@@ -299,6 +301,7 @@ public class DynamoDBLeaseRefresherTest {
                 .keySchema(leaseSerializer.getKeySchema())
                 .attributeDefinitions(leaseSerializer.getAttributeDefinitions())
                 .provisionedThroughput(throughput)
+                .deletionProtectionEnabled(DELETION_PROTECTION_ENABLED)
                 .build();
         when(dynamoDbClient.createTable(createTableRequest)).thenReturn(mockCreateTableFuture);
         when(mockCreateTableFuture.get(eq(LeaseManagementConfig.DEFAULT_REQUEST_TIMEOUT.toMillis()), eq(TimeUnit.MILLISECONDS)))
@@ -319,7 +322,7 @@ public class DynamoDBLeaseRefresherTest {
     public void testCreateLeaseTableWithTagsIfNotExists() throws Exception {
         tags = Collections.singletonList(Tag.builder().key("foo").value("bar").build());
         leaseRefresher = new DynamoDBLeaseRefresher(TABLE_NAME, dynamoDbClient, leaseSerializer, CONSISTENT_READS,
-                tableCreatorCallback, LeaseManagementConfig.DEFAULT_REQUEST_TIMEOUT, BillingMode.PROVISIONED, tags);
+                tableCreatorCallback, LeaseManagementConfig.DEFAULT_REQUEST_TIMEOUT, BillingMode.PROVISIONED, DELETION_PROTECTION_ENABLED, tags);
 
         when(dynamoDbClient.describeTable(describeTableRequest)).thenReturn(mockDescribeTableFuture);
         when(mockDescribeTableFuture.get(LeaseManagementConfig.DEFAULT_REQUEST_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS))
@@ -332,6 +335,7 @@ public class DynamoDBLeaseRefresherTest {
                 .keySchema(leaseSerializer.getKeySchema())
                 .attributeDefinitions(leaseSerializer.getAttributeDefinitions())
                 .provisionedThroughput(throughput)
+                .deletionProtectionEnabled(DELETION_PROTECTION_ENABLED)
                 .tags(tags)
                 .build();
         when(dynamoDbClient.createTable(createTableRequest)).thenReturn(mockCreateTableFuture);
@@ -462,7 +466,7 @@ public class DynamoDBLeaseRefresherTest {
     @Test
     public void testCreateLeaseTableProvisionedBillingModeTimesOut() throws Exception {
         leaseRefresher = new DynamoDBLeaseRefresher(TABLE_NAME, dynamoDbClient, leaseSerializer, CONSISTENT_READS,
-                tableCreatorCallback, LeaseManagementConfig.DEFAULT_REQUEST_TIMEOUT, BillingMode.PROVISIONED);
+                tableCreatorCallback, LeaseManagementConfig.DEFAULT_REQUEST_TIMEOUT, BillingMode.PROVISIONED, false);
         TimeoutException te = setRuleForDependencyTimeout();
 
         when(dynamoDbClient.describeTable(any(DescribeTableRequest.class))).thenReturn(mockDescribeTableFuture);


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The KCL lease table does not have an option to be created with deletion protection enabled. This commit adds the option to be configured via the LeaseManagementConfig

Sample usage
```
leaseManagementConfig = configsBuilder.leaseManagementConfig()
                    .initialPositionInStream(InitialPositionInStreamExtended.newInitialPosition(config.getKclInitialPosition()))
                    .initialLeaseTableReadCapacity(50).initialLeaseTableWriteCapacity(50).deletionProtectionEnabled(true)
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
