### PR TITLE
Upgrade ch.qos.logback:logback-classic dependency from 1.3.12 to 1.5.…

### DIFF
--- a/amazon-kinesis-client-multilang/pom.xml
+++ b/amazon-kinesis-client-multilang/pom.xml
@@ -28,7 +28,7 @@
   <artifactId>amazon-kinesis-client-multilang</artifactId>
 
   <properties>
-    <aws-java-sdk.version>1.12.405</aws-java-sdk.version>
+    <aws-java-sdk.version>1.12.668</aws-java-sdk.version>
   </properties>
 
   <dependencies>
@@ -78,7 +78,7 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>1.3.12</version>
+      <version>1.5.1</version>
     </dependency>
     <dependency>
       <groupId>com.beust</groupId>

--- a/amazon-kinesis-client-multilang/pom.xml
+++ b/amazon-kinesis-client-multilang/pom.xml
@@ -78,7 +78,7 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>1.5.1</version>
+      <version>1.3.14</version>
     </dependency>
     <dependency>
       <groupId>com.beust</groupId>

--- a/amazon-kinesis-client/pom.xml
+++ b/amazon-kinesis-client/pom.xml
@@ -154,7 +154,7 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>1.5.1</version>
+      <version>1.3.14</version>
       <scope>test</scope>
     </dependency>
 

--- a/amazon-kinesis-client/pom.xml
+++ b/amazon-kinesis-client/pom.xml
@@ -1,4 +1,5 @@
 <!--
+
 /*
  * Copyright 2019 Amazon.com, Inc. or its affiliates.
  * Licensed under the Apache License, Version 2.0 (the
@@ -153,7 +154,7 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>1.3.12</version>
+      <version>1.5.1</version>
       <scope>test</scope>
     </dependency>
 

--- a/amazon-kinesis-client/pom.xml
+++ b/amazon-kinesis-client/pom.xml
@@ -52,7 +52,7 @@
     <sqlite4java.native>libsqlite4java</sqlite4java.native>
     <sqlite4java.libpath>${project.build.directory}/test-lib</sqlite4java.libpath>
     <slf4j.version>2.0.7</slf4j.version>
-    <gsr.version>1.1.17</gsr.version>
+    <gsr.version>1.1.19</gsr.version>
     <skipITs>true</skipITs>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
   </scm>
 
   <properties>
-    <awssdk.version>2.20.43</awssdk.version>
+    <awssdk.version>2.25.3</awssdk.version>
   </properties>
 
   <licenses>


### PR DESCRIPTION
…14 in /amazon-kinesis-client and /amazon-kinesis-client-multilang and aws-java-sdk.version from 1.12.405 to 1.12.668 in /amazon-kinesis-client-multilang

upgrade awssdk.version from 2.20.43 to 2.25.3

Upgrade gsr.version from 1.1.17 to 1.1.19

This is to resolve transitive dependency vulnerabilities that are currently in amazon-kinesis-client

#1231 

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
