### PR TITLE
Update PollingConfig maxRecords method to return PollingConfig

### DIFF
--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/polling/PollingConfig.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/polling/PollingConfig.java
@@ -146,12 +146,13 @@ public class PollingConfig implements RetrievalSpecificConfig {
         return this;
     }
 
-    public void maxRecords(int maxRecords) {
+    public PollingConfig maxRecords(int maxRecords) {
         if (maxRecords > DEFAULT_MAX_RECORDS) {
             throw new IllegalArgumentException(
                     "maxRecords must be less than or equal to " +  DEFAULT_MAX_RECORDS + " but current value is " + maxRecords());
         }
         this.maxRecords = maxRecords;
+        return this;
     }
 
     /**


### PR DESCRIPTION
*Issue #, if available:* https://github.com/awslabs/amazon-kinesis-client/issues/1274

*Description of changes:* Fixes backwards compatibility with the maxRecords function in PollingConfig


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
