### PR TITLE
fix: does not request shutdown for already shutdown consumer

### DIFF
--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/coordinator/Scheduler.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/coordinator/Scheduler.java
@@ -784,7 +784,7 @@ public class Scheduler implements Runnable {
                         lease, notificationCompleteLatch, shutdownCompleteLatch);
                 ShardInfo shardInfo = DynamoDBLeaseCoordinator.convertLeaseToAssignment(lease);
                 ShardConsumer consumer = shardInfoShardConsumerMap.get(shardInfo);
-                if (consumer != null) {
+                if (consumer != null && !consumer.isShutdown()) {
                     consumer.gracefulShutdown(shutdownNotification);
                 } else {
                     //


### PR DESCRIPTION
This patch fixes #1251 .


In graceful shutdown phase, two CountDownLatch variables that value is  the number of worker lease are used to wait all consumers are shutdown completed.

If the worker has a lease of completed shard, the worker requests shutdown for its consumer but the consumer is already shutdown and cannot decrement latches so two latches never becomes to 0 and always timeout.

This patch modifies worker not to request shutdown for already shutdown consumer and only decrement latch.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
