### PR TITLE
Reuse 'ShardSyncTaskManager' instance for existing stream to avoid duplicate enqueue of 'ShardSyncTask'

### DIFF
--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/coordinator/Scheduler.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/coordinator/Scheduler.java
@@ -141,7 +141,7 @@ public class Scheduler implements Runnable {
     private final DiagnosticEventHandler diagnosticEventHandler;
     private final LeaseCoordinator leaseCoordinator;
     private final Function<StreamConfig, ShardSyncTaskManager> shardSyncTaskManagerProvider;
-    private final Map<StreamConfig, ShardSyncTaskManager> streamToShardSyncTaskManagerMap = new HashMap<>();
+    private final Map<StreamConfig, ShardSyncTaskManager> streamToShardSyncTaskManagerMap = new ConcurrentHashMap<>();
     private final PeriodicShardSyncManager leaderElectedPeriodicShardSyncManager;
     private final ShardPrioritization shardPrioritization;
     private final boolean cleanupLeasesUponShardCompletion;
@@ -292,7 +292,7 @@ public class Scheduler implements Runnable {
         this.schedulerInitializationBackoffTimeMillis = this.coordinatorConfig.schedulerInitializationBackoffTimeMillis();
         this.leaderElectedPeriodicShardSyncManager = new PeriodicShardSyncManager(
                 leaseManagementConfig.workerIdentifier(), leaderDecider, leaseRefresher, currentStreamConfigMap,
-                shardSyncTaskManagerProvider, isMultiStreamMode, metricsFactory,
+                shardSyncTaskManagerProvider, streamToShardSyncTaskManagerMap, isMultiStreamMode, metricsFactory,
                 leaseManagementConfig.leasesRecoveryAuditorExecutionFrequencyMillis(),
                 leaseManagementConfig.leasesRecoveryAuditorInconsistencyConfidenceThreshold());
         this.leaseCleanupManager = this.leaseManagementConfig.leaseManagementFactory(leaseSerializer, isMultiStreamMode)

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/leases/ShardSyncTaskManager.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/leases/ShardSyncTaskManager.java
@@ -196,7 +196,7 @@ public class ShardSyncTaskManager {
         } else {
             if (log.isDebugEnabled()) {
                 log.debug("Previous {} task still pending.  Not submitting new task. "
-                          + "Enqueued a request that will be executed when the current request completes.", currentTask.taskType());
+                          + "Triggered a pending request but will not be executed until the current request completes.", currentTask.taskType());
             }
             shardSyncRequestPending.compareAndSet(false /*expected*/, true /*update*/);
         }
@@ -207,25 +207,6 @@ public class ShardSyncTaskManager {
         if (exception != null || taskResult.getException() != null) {
             log.error("Caught exception running {} task: {}", currentTask.taskType(),
                     exception != null ? exception : taskResult.getException());
-        }
-        // Acquire lock here. If shardSyncRequestPending is false in this completionStage and
-        // submitShardSyncTask is invoked, before completion stage exits (future completes)
-        // but right after the value of shardSyncRequestPending is checked, it will result in
-        // shardSyncRequestPending being set to true, but no pending futures to trigger the next
-        // ShardSyncTask. By executing this stage in a Reentrant lock, we ensure that if the
-        // previous task is in this completion stage, checkAndSubmitNextTask is not invoked
-        // until this completionStage exits.
-        try {
-            lock.lock();
-            if (shardSyncRequestPending.get()) {
-                shardSyncRequestPending.set(false);
-                // reset future to null, so next call creates a new one
-                // without trying to get results from the old future.
-                future = null;
-                checkAndSubmitNextTask();
-            }
-        } finally {
-            lock.unlock();
         }
     }
 

--- a/amazon-kinesis-client/src/test/java/software/amazon/kinesis/coordinator/PeriodicShardSyncManagerTest.java
+++ b/amazon-kinesis-client/src/test/java/software/amazon/kinesis/coordinator/PeriodicShardSyncManagerTest.java
@@ -70,12 +70,14 @@ public class PeriodicShardSyncManagerTest {
     Map<StreamIdentifier, StreamConfig> currentStreamConfigMap;
     @Mock
     Function<StreamConfig, ShardSyncTaskManager> shardSyncTaskManagerProvider;
+    @Mock
+    Map<StreamConfig, ShardSyncTaskManager> streamToShardSyncTaskManagerMap;
 
     @Before
     public void setup() {
         streamIdentifier = StreamIdentifier.multiStreamInstance("123456789012:stream:456");
         periodicShardSyncManager = new PeriodicShardSyncManager("worker", leaderDecider, leaseRefresher, currentStreamConfigMap,
-                shardSyncTaskManagerProvider, true, new NullMetricsFactory(), 2 * 60 * 1000, 3);
+                shardSyncTaskManagerProvider, streamToShardSyncTaskManagerMap, true, new NullMetricsFactory(), 2 * 60 * 1000, 3);
     }
 
     @Test


### PR DESCRIPTION
*Description of changes:*
- Make `streamToShardSyncTaskManagerMap` in Scheduler a `ConcurrentHashMap` and pass it into `PeriodicShardSyncManager` when a host is elected as leader
- Remove unnecessary retrigger mechanism in `ShardSyncTaskManager` to improve `ShardSyncTask` Performance
- Add Metric `NumSkippedShardSyncTask` to track how many **submissions of ShardSyncTask** were skipped because of previous ongoing task

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
