### PR TITLE
Correcting the behavior of gracefulShutdown

### DIFF
--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/coordinator/GracefulShutdownContext.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/coordinator/GracefulShutdownContext.java
@@ -14,22 +14,22 @@
  */
 package software.amazon.kinesis.coordinator;
 
+import lombok.Builder;
 import lombok.Data;
 import lombok.experimental.Accessors;
 
 import java.util.concurrent.CountDownLatch;
 
 @Data
+@Builder
 @Accessors(fluent = true)
 class GracefulShutdownContext {
     private final CountDownLatch shutdownCompleteLatch;
     private final CountDownLatch notificationCompleteLatch;
+    private final CountDownLatch finalShutdownLatch;
     private final Scheduler scheduler;
 
-    static GracefulShutdownContext SHUTDOWN_ALREADY_COMPLETED = new GracefulShutdownContext(null, null, null);
-
-    boolean isShutdownAlreadyCompleted() {
+    boolean isRecordProcessorShutdownComplete() {
         return shutdownCompleteLatch == null && notificationCompleteLatch == null && scheduler == null;
     }
-
 }

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/coordinator/GracefulShutdownCoordinator.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/coordinator/GracefulShutdownCoordinator.java
@@ -155,7 +155,7 @@ class GracefulShutdownCoordinator {
             try {
                 context = startWorkerShutdown.call();
                 recordProcessorsShutdownSuccess = waitForRecordProcessors(context);
-                schedulerShutdownSuccess = context.scheduler().finalShutdownLatch().await(finalShutdownWaitTimeSeconds, TimeUnit.SECONDS);
+                schedulerShutdownSuccess = context.scheduler().waitForFinalShutdown();
             } catch (Exception ex) {
                 log.warn("Caught exception while requesting initial worker shutdown.", ex);
                 throw ex;

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/coordinator/GracefulShutdownCoordinator.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/coordinator/GracefulShutdownCoordinator.java
@@ -71,15 +71,8 @@ class GracefulShutdownCoordinator {
          * used to wait for the worker's final shutdown to complete before returning the future for graceful shutdown
          * @return true if the final shutdown is successful, false otherwise.
          */
-        private boolean waitForFinalShutdown(GracefulShutdownContext context) {
-            boolean finalShutdownResult;
-            try {
-                finalShutdownResult = context.finalShutdownLatch().await(FINAL_SHUTDOWN_WAIT_TIME_SECONDS, TimeUnit.SECONDS);
-            } catch (InterruptedException e) {
-                log.warn("Final shutdown was interrupted:", e);
-                return false;
-            }
-            return finalShutdownResult;
+        private boolean waitForFinalShutdown(GracefulShutdownContext context) throws InterruptedException {
+            return context.finalShutdownLatch().await(FINAL_SHUTDOWN_WAIT_TIME_SECONDS, TimeUnit.SECONDS);
         }
 
         private boolean waitForRecordProcessors(GracefulShutdownContext context) {

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/coordinator/GracefulShutdownCoordinator.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/coordinator/GracefulShutdownCoordinator.java
@@ -39,7 +39,6 @@ class GracefulShutdownCoordinator {
     @Slf4j
     static class GracefulShutdownCallable implements Callable<Boolean> {
         private final Callable<GracefulShutdownContext> startWorkerShutdown;
-        private final long finalShutdownWaitTimeSeconds = 60;
 
         GracefulShutdownCallable(Callable<GracefulShutdownContext> startWorkerShutdown) {
             this.startWorkerShutdown = startWorkerShutdown;

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/coordinator/Scheduler.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/coordinator/Scheduler.java
@@ -191,6 +191,13 @@ public class Scheduler implements Runnable {
      * Used to ensure that only one requestedShutdown is in progress at a time.
      */
     private CompletableFuture<Boolean> gracefulShutdownFuture;
+
+    /**
+     * CountDownLatch used by the GracefulShutdownCoordinator. Reaching zero means that
+     * the scheduler's finalShutdown() call has completed.
+     */
+    private final CountDownLatch finalShutdownLatch = new CountDownLatch(1);
+
     @VisibleForTesting
     protected boolean gracefuleShutdownStarted = false;
 
@@ -878,6 +885,7 @@ public class Scheduler implements Runnable {
             ((CloudWatchMetricsFactory) metricsFactory).shutdown();
         }
         shutdownComplete = true;
+        finalShutdownLatch.countDown();
     }
 
     private List<ShardInfo> getShardInfoForAssignments() {

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/coordinator/Scheduler.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/coordinator/Scheduler.java
@@ -113,6 +113,7 @@ public class Scheduler implements Runnable {
     private static final long MIN_WAIT_TIME_FOR_LEASE_TABLE_CHECK_MILLIS = 1000L;
     private static final long MAX_WAIT_TIME_FOR_LEASE_TABLE_CHECK_MILLIS = 30 * 1000L;
     private static final long NEW_STREAM_CHECK_INTERVAL_MILLIS = 60_000L;
+    private static final long FINAL_SHUTDOWN_WAIT_TIME_SECONDS = 60L;
     private static final boolean SHOULD_DO_LEASE_SYNC_FOR_OLD_STREAMS = false;
     private static final String MULTI_STREAM_TRACKER = "MultiStreamTracker";
     private static final String ACTIVE_STREAMS_COUNT = "ActiveStreams.Count";
@@ -196,6 +197,7 @@ public class Scheduler implements Runnable {
      * CountDownLatch used by the GracefulShutdownCoordinator. Reaching zero means that
      * the scheduler's finalShutdown() call has completed.
      */
+    @Getter(AccessLevel.NONE)
     private final CountDownLatch finalShutdownLatch = new CountDownLatch(1);
 
     @VisibleForTesting
@@ -886,6 +888,21 @@ public class Scheduler implements Runnable {
         }
         shutdownComplete = true;
         finalShutdownLatch.countDown();
+    }
+
+    /**
+     * called by {@link GracefulShutdownCoordinator} to wait for the worker's final shutdown to complete before returning
+     * @return true if the final shutdown is successful, false otherwise.
+     */
+    boolean waitForFinalShutdown() {
+        boolean finalShutdownResult;
+        try {
+            finalShutdownResult = finalShutdownLatch.await(FINAL_SHUTDOWN_WAIT_TIME_SECONDS, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            log.warn("Final shutdown interrupted due to exception:", e);
+            return false;
+        }
+        return finalShutdownResult;
     }
 
     private List<ShardInfo> getShardInfoForAssignments() {

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/lifecycle/ConsumerStates.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/lifecycle/ConsumerStates.java
@@ -478,6 +478,7 @@ class ConsumerStates {
                     argument.shardRecordProcessor(),
                     argument.recordProcessorCheckpointer(),
                     consumer.shutdownReason(),
+                    consumer.shutdownNotification(),
                     argument.initialPositionInStream(),
                     argument.cleanupLeasesOfCompletedShards(),
                     argument.ignoreUnexpectedChildShards(),
@@ -557,9 +558,6 @@ class ConsumerStates {
 
         @Override
         public ConsumerTask createTask(ShardConsumerArgument argument, ShardConsumer consumer, ProcessRecordsInput input) {
-            if (consumer.shutdownNotification() != null) {
-                consumer.shutdownNotification().shutdownComplete();
-            }
             return null;
         }
 

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/lifecycle/ShutdownTask.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/lifecycle/ShutdownTask.java
@@ -87,6 +87,7 @@ public class ShutdownTask implements ConsumerTask {
     private final ShardRecordProcessorCheckpointer recordProcessorCheckpointer;
     @NonNull
     private final ShutdownReason reason;
+    private final ShutdownNotification shutdownNotification;
     @NonNull
     private final InitialPositionInStreamExtended initialPositionInStream;
     private final boolean cleanupLeasesOfCompletedShards;
@@ -149,6 +150,12 @@ public class ShutdownTask implements ConsumerTask {
 
                 log.debug("Shutting down retrieval strategy for shard {}.", leaseKey);
                 recordsPublisher.shutdown();
+
+                // shutdownNotification is set when gracefulShutdown starts and is only used for gracefulShutdown
+                if (shutdownNotification != null) {
+                    shutdownNotification.shutdownComplete();
+                }
+
                 log.debug("Record processor completed shutdown() for shard {}", leaseKey);
 
                 return new TaskResult(null);

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/lifecycle/ShutdownTask.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/lifecycle/ShutdownTask.java
@@ -151,7 +151,7 @@ public class ShutdownTask implements ConsumerTask {
                 log.debug("Shutting down retrieval strategy for shard {}.", leaseKey);
                 recordsPublisher.shutdown();
 
-                // shutdownNotification is set when gracefulShutdown starts and is only used for gracefulShutdown
+                // shutdownNotification is only set and used when gracefulShutdown starts
                 if (shutdownNotification != null) {
                     shutdownNotification.shutdownComplete();
                 }

--- a/amazon-kinesis-client/src/test/java/software/amazon/kinesis/coordinator/GracefulShutdownCoordinatorTest.java
+++ b/amazon-kinesis-client/src/test/java/software/amazon/kinesis/coordinator/GracefulShutdownCoordinatorTest.java
@@ -46,8 +46,6 @@ public class GracefulShutdownCoordinatorTest {
     @Mock
     private CountDownLatch notificationCompleteLatch;
     @Mock
-    private CountDownLatch finalShutdownLatch;
-    @Mock
     private Scheduler scheduler;
     @Mock
     private Callable<GracefulShutdownContext> contextCallable;
@@ -56,7 +54,7 @@ public class GracefulShutdownCoordinatorTest {
 
     @Before
     public void before() throws InterruptedException {
-        mockFinalShutdownLatchSucceeds();
+        mockFinalShutdownSucceeds();
     }
 
     @Test
@@ -313,7 +311,7 @@ public class GracefulShutdownCoordinatorTest {
 
         when(notificationCompleteLatch.await(anyLong(), any(TimeUnit.class))).thenReturn(true);
         when(shutdownCompleteLatch.await(anyLong(), any(TimeUnit.class))).thenReturn(true);
-        when(scheduler.finalShutdownLatch().await(anyLong(), any(TimeUnit.class))).thenReturn(false);
+        when(scheduler.waitForFinalShutdown()).thenReturn(false);
 
         assertThat(requestedShutdownCallable.call(), equalTo(false));
     }
@@ -351,9 +349,8 @@ public class GracefulShutdownCoordinatorTest {
         when(shardInfoConsumerMap.isEmpty()).thenReturn(initialItemCount == 0, additionalEmptyStates);
     }
 
-    private void mockFinalShutdownLatchSucceeds() throws InterruptedException {
-        when(scheduler.finalShutdownLatch()).thenReturn(finalShutdownLatch);
-        when(finalShutdownLatch.await(anyLong(), any(TimeUnit.class))).thenReturn(true);
+    private void mockFinalShutdownSucceeds() {
+        when(scheduler.waitForFinalShutdown()).thenReturn(true);
     }
 
 }

--- a/amazon-kinesis-client/src/test/java/software/amazon/kinesis/coordinator/GracefulShutdownCoordinatorTest.java
+++ b/amazon-kinesis-client/src/test/java/software/amazon/kinesis/coordinator/GracefulShutdownCoordinatorTest.java
@@ -319,18 +319,6 @@ public class GracefulShutdownCoordinatorTest {
         verifyLatchAwait(finalShutdownLatch);
     }
 
-    @Test
-    public void testShutdownFailsDueToInterrupt() throws Exception {
-        Callable<Boolean> requestedShutdownCallable = buildRequestedShutdownCallable();
-
-        when(notificationCompleteLatch.await(anyLong(), any(TimeUnit.class))).thenReturn(true);
-        when(shutdownCompleteLatch.await(anyLong(), any(TimeUnit.class))).thenReturn(true);
-        when(finalShutdownLatch.await(anyLong(), any(TimeUnit.class))).thenThrow(new InterruptedException());
-
-        assertThat(requestedShutdownCallable.call(), equalTo(false));
-        verifyLatchAwait(finalShutdownLatch);
-    }
-
     /**
      * tests that shutdown still succeeds in the case where there are no leases returned by the lease coordinator
      */

--- a/amazon-kinesis-client/src/test/java/software/amazon/kinesis/lifecycle/ConsumerStatesTest.java
+++ b/amazon-kinesis-client/src/test/java/software/amazon/kinesis/lifecycle/ConsumerStatesTest.java
@@ -17,10 +17,7 @@ package software.amazon.kinesis.lifecycle;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static software.amazon.kinesis.lifecycle.ConsumerStates.ShardConsumerState;
 
@@ -355,28 +352,17 @@ public class ConsumerStatesTest {
         ConsumerState state = ShardConsumerState.SHUTDOWN_COMPLETE.consumerState();
 
         assertThat(state.createTask(argument, consumer, null), nullValue());
-        verify(consumer, times(2)).shutdownNotification();
-        verify(shutdownNotification).shutdownComplete();
 
         assertThat(state.successTransition(), equalTo(state));
         for (ShutdownReason reason : ShutdownReason.values()) {
             assertThat(state.shutdownTransition(reason), equalTo(state));
         }
 
+        assertThat(state.isTerminal(), equalTo(true));
         assertThat(state.state(), equalTo(ShardConsumerState.SHUTDOWN_COMPLETE));
         assertThat(state.taskType(), equalTo(TaskType.SHUTDOWN_COMPLETE));
     }
 
-    @Test
-    public void shutdownCompleteStateNullNotificationTest() {
-        ConsumerState state = ShardConsumerState.SHUTDOWN_COMPLETE.consumerState();
-
-        when(consumer.shutdownNotification()).thenReturn(null);
-        assertThat(state.createTask(argument, consumer, null), nullValue());
-
-        verify(consumer).shutdownNotification();
-        verify(shutdownNotification, never()).shutdownComplete();
-    }
 
     static <ValueType> ReflectionPropertyMatcher<ShutdownTask, ValueType> shutdownTask(Class<ValueType> valueTypeClass,
             String propertyName, Matcher<ValueType> matcher) {

--- a/amazon-kinesis-client/src/test/java/software/amazon/kinesis/lifecycle/ShutdownTaskTest.java
+++ b/amazon-kinesis-client/src/test/java/software/amazon/kinesis/lifecycle/ShutdownTaskTest.java
@@ -310,13 +310,24 @@ public class ShutdownTaskTest {
         verify(leaseRefresher, never()).createLeaseIfNotExists(any(Lease.class));
     }
 
+    /**
+     * shutdownNotification is only set when ShardConsumer.gracefulShutdown() is called and should be null otherwise.
+     * The task should still call recordsPublisher.shutdown() regardless of the notification
+     */
     @Test
     public void testCallWhenShutdownNotificationIsSet() {
         final TaskResult result = createShutdownTaskWithNotification(LEASE_LOST, Collections.emptyList()).call();
-
         assertNull(result.getException());
         verify(recordsPublisher).shutdown();
         verify(shutdownNotification).shutdownComplete();
+    }
+
+    @Test
+    public void testCallWhenShutdownNotificationIsNull() {
+        final TaskResult result = createShutdownTask(LEASE_LOST, Collections.emptyList()).call();
+        assertNull(result.getException());
+        verify(recordsPublisher).shutdown();
+        verify(shutdownNotification, never()).shutdownComplete();
     }
 
     /**


### PR DESCRIPTION
*Issue #, if available:* #616

*Description of changes:* This PR corrects the behavior of Scheduler's gracefulShutdown. 

Originally, calling `Scheduler.startGracefulShutdown()` would return false because the `CountDownLatch` used to track the shutdowns of the record processors was never decremented. To address this issue, the `CountDownLatch` is decremented within the `ConsumerTask` of the `ShuttingDownState` (see ShutdownTask.java). The `ShutdownCompleteState` is now used as a terminal state and contains no associated `ConsumerTask`. 

Also, another `CountDownLatch` was introduced to the Scheduler to ensure that its `finalShutdown()`method is returned before the `startGracefulShutdown()` returns. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
