### PR TITLE
Deprecate StreamIdentifier constructors that accept stream name or serialized identifier

### DIFF
--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/common/StreamIdentifier.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/common/StreamIdentifier.java
@@ -91,7 +91,10 @@ public class StreamIdentifier {
      *
      * @param streamIdentifierSer a String of {@code account:stream:creationEpoch}
      * @return StreamIdentifier with {@link #accountIdOptional} and {@link #streamCreationEpochOptional} present
+     *
+     * @deprecated This method is deprecated. Please use {@link #multiStreamInstance(Arn, long)} instead.
      */
+    @Deprecated
     public static StreamIdentifier multiStreamInstance(String streamIdentifierSer) {
         final Matcher matcher = STREAM_IDENTIFIER_PATTERN.matcher(streamIdentifierSer);
         if (matcher.matches()) {
@@ -142,7 +145,10 @@ public class StreamIdentifier {
      * Create a single stream instance for StreamIdentifier from stream name.
      *
      * @param streamName stream name of a Kinesis stream
+     *
+     * @deprecated This method is deprecated. Please use {@link #singleStreamInstance(Arn)} instead.
      */
+    @Deprecated
     public static StreamIdentifier singleStreamInstance(String streamName) {
         Validate.notEmpty(streamName, "StreamName should not be empty");
 


### PR DESCRIPTION
*Issue #, if available:*
N/A.

*Description of changes:*
Deprecate `StreamIdentifier#singleStreamInstance(String)` and `StreamIdentifier#multiStreamInstance(String)` methods.
A `StreamIdentifier` should be constructed using the [`ARN`](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference-arns.html) of the stream, rather than just the stream name or `accountId:streamName:creationEpoch` serialization.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
