### PR TITLE
Adding clirr plugin to check for backwards compatibility

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -30,3 +30,5 @@ jobs:
           distribution: 'corretto'
       - name: Build with Maven
         run: mvn -B package --file pom.xml -DskipITs
+      - name: Check for backwards compatibility
+        run: mvn clirr:check

--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>clirr-maven-plugin</artifactId>
-        <version>2.8</version>
+        <version>2.2.1</version>
       </plugin>
     </plugins>
     <pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -93,6 +93,11 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>clirr-maven-plugin</artifactId>
+        <version>2.8</version>
+      </plugin>
     </plugins>
     <pluginManagement>
       <plugins>


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Adding clirr plugin to check for backwards compatibility

Tested by implementing a backwards incompatible change and running the Github action. If a backwards incompatible change is found, the GIthub check will fail. See [here](https://github.com/vincentvilo-aws/amazon-kinesis-client/actions/runs/8652321368/job/23724965726) for an example of a failure.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
