### PR TITLE
Internally construct and use stream ARNs for all streams in multi-stream mode

### DIFF
--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/common/ArnUtil.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/common/ArnUtil.java
@@ -1,0 +1,32 @@
+package software.amazon.kinesis.common;
+
+import lombok.NonNull;
+import software.amazon.awssdk.arns.Arn;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.kinesis.annotations.KinesisClientInternalApi;
+
+import static software.amazon.awssdk.services.kinesis.KinesisAsyncClient.SERVICE_NAME;
+
+@KinesisClientInternalApi
+public final class ArnUtil {
+    private static final String STREAM_RESOURCE_PREFIX = "stream/";
+
+    /**
+     * Construct a Kinesis stream ARN.
+     *
+     * @param region The region the stream exists in.
+     * @param accountId The account the stream belongs to.
+     * @param streamName The name of the stream.
+     * @return The {@link Arn} of the Kinesis stream.
+     */
+    public static Arn constructStreamArn(
+            @NonNull final Region region, @NonNull final String accountId, @NonNull final String streamName) {
+        return Arn.builder()
+                .partition(region.metadata().partition().id())
+                .service(SERVICE_NAME)
+                .region(region.id())
+                .accountId(accountId)
+                .resource(STREAM_RESOURCE_PREFIX + streamName)
+                .build();
+    }
+}

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/common/StreamConfig.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/common/StreamConfig.java
@@ -15,10 +15,14 @@
 
 package software.amazon.kinesis.common;
 
+import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
 import lombok.experimental.Accessors;
 
+@AllArgsConstructor
+@RequiredArgsConstructor
 @Data
 @Accessors(fluent = true)
 public class StreamConfig {


### PR DESCRIPTION
*Issue #, if available:*
N/A.

*Description of changes:*
Construct stream ARNs (using the Kinesis client's configured region) for all stream configs upon writing to the `currentStreamConfigMap` in multi-stream mode. 
This should ensure that all Kinesis API requests from `KinesisDataFetcher` and `KinesisShardDetector` are provided with the stream ARN in multi-stream applications.

Note: An implication of stream ARNs being used for Kinesis API calls is that the `accountId` provided through the `StreamTracker` must be correct, whereas previously applications may have consumed the streams as long as the provided `streamName` existed in the account that the Kinesis client was configured for.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
