### PR TITLE
Fix a race condition between ShardConsumer shutdown and initialization

### DIFF
--- a/amazon-kinesis-client/pom.xml
+++ b/amazon-kinesis-client/pom.xml
@@ -123,13 +123,6 @@
 
     <!-- Test -->
     <dependency>
-      <groupId>org.awaitility</groupId>
-      <artifactId>awaitility</artifactId>
-      <version>3.0.0</version>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.13.2</version>

--- a/amazon-kinesis-client/pom.xml
+++ b/amazon-kinesis-client/pom.xml
@@ -123,6 +123,13 @@
 
     <!-- Test -->
     <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <version>3.0.0</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.13.2</version>

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/lifecycle/ShardConsumer.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/lifecycle/ShardConsumer.java
@@ -174,24 +174,20 @@ public class ShardConsumer {
             if (isShutdownRequested()) {
                 stateChangeFuture = shutdownComplete();
             } else if (needsInitialization) {
-                if (stateChangeFuture != null && stateChangeFuture.get()) {
-                    // Task rejection during the subscribe() call will not be propagated back as it not executed
-                    // in the context of the Scheduler thread. Hence we should not assume the subscription will
-                    // always be successful.
-                    // But if subscription was not successful, then it will recover
-                    // during healthCheck which will restart subscription.
-                    // From Shardconsumer point of view, initialization after the below subscribe call
-                    // is complete
-                    subscribe();
-                    needsInitialization = false;
-                    // Initialization is complete, we don't need to do initializeComplete anymore.
-                    // ShardConsumer is already in ProcessingState and any further activity
-                    // will be driven by publisher pushing data to subscriber which invokes handleInput
-                    // and that triggers ProcessTask. Scheduler is only meant to do health-checks
-                    // to ensure the consumer is not stuck for any reason and to do shutdown handling.
-                } else {
-                    stateChangeFuture = initializeComplete();
+                if (stateChangeFuture != null) {
+                    if (stateChangeFuture.get()) {
+                        // Task rejection during the subscribe() call will not be propagated back as it not executed
+                        // in the context of the Scheduler thread. Hence we should not assume the subscription will
+                        // always be successful.
+                        // But if subscription was not successful, then it will recover
+                        // during healthCheck which will restart subscription.
+                        // From Shardconsumer point of view, initialization after the below subscribe call
+                        // is complete
+                        subscribe();
+                        needsInitialization = false;
+                    }
                 }
+                stateChangeFuture = initializeComplete();
             }
         } catch (InterruptedException e) {
             //
@@ -284,6 +280,16 @@ public class ShardConsumer {
 
     @VisibleForTesting
     synchronized CompletableFuture<Boolean> initializeComplete() {
+        if (!needsInitialization) {
+            // initialization already complete, this must be a no-op.
+            // ShardConsumer must be in ProcessingState and
+            // any further activity will be driven by publisher pushing data to subscriber
+            // which invokes handleInput and that triggers ProcessTask.
+            // Scheduler is only meant to do health-checks to ensure the consumer
+            // is not stuck for any reason and to do shutdown handling.
+            return CompletableFuture.completedFuture(true);
+        }
+
         if (taskOutcome != null) {
             updateState(taskOutcome);
         }

--- a/amazon-kinesis-client/src/test/java/software/amazon/kinesis/lifecycle/ShardConsumerTest.java
+++ b/amazon-kinesis-client/src/test/java/software/amazon/kinesis/lifecycle/ShardConsumerTest.java
@@ -59,7 +59,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
 
-import org.awaitility.Awaitility;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Ignore;
@@ -858,15 +857,15 @@ public class ShardConsumerTest {
 
     @Test
     public void testEmptyShardProcessingRaceCondition() throws Exception {
-        RecordsPublisher mockPublisher = mock(RecordsPublisher.class);
-        ExecutorService mockExecutor = mock(ExecutorService.class);
-        ConsumerState mockState = mock(ConsumerState.class);
-        ShardConsumer consumer = new ShardConsumer(mockPublisher, mockExecutor, shardInfo, Optional.of(1L),
+        final RecordsPublisher mockPublisher = mock(RecordsPublisher.class);
+        final ExecutorService mockExecutor = mock(ExecutorService.class);
+        final ConsumerState mockState = mock(ConsumerState.class);
+        final ShardConsumer consumer = new ShardConsumer(mockPublisher, mockExecutor, shardInfo, Optional.of(1L),
             shardConsumerArgument, mockState, Function.identity(), 1, taskExecutionListener, 0);
 
         when(mockState.state()).thenReturn(ShardConsumerState.WAITING_ON_PARENT_SHARDS);
         when(mockState.taskType()).thenReturn(TaskType.BLOCK_ON_PARENT_SHARDS);
-        ConsumerTask mockTask = mock(ConsumerTask.class);
+        final ConsumerTask mockTask = mock(ConsumerTask.class);
         when(mockState.createTask(any(), any(), any())).thenReturn(mockTask);
         // Simulate successful BlockedOnParent task execution
         // and successful Initialize task execution
@@ -875,7 +874,7 @@ public class ShardConsumerTest {
         log.info("Scheduler Thread: Invoking ShardConsumer.executeLifecycle() to initiate async" +
             " processing of blocked on parent task");
         consumer.executeLifecycle();
-        ArgumentCaptor<Runnable> taskToExecute = ArgumentCaptor.forClass(Runnable.class);
+        final ArgumentCaptor<Runnable> taskToExecute = ArgumentCaptor.forClass(Runnable.class);
         verify(mockExecutor, timeout(100)).execute(taskToExecute.capture());
         taskToExecute.getValue().run();
         log.info("RecordProcessor Thread: Simulated successful execution of Blocked on parent task");
@@ -907,11 +906,11 @@ public class ShardConsumerTest {
         // In order to control the order in which execution occurs, lets first invoke
         // handleInput, although this will never happen, since there isn't a way
         // to control the precise timing of the thread execution, this is the best way
-        CountDownLatch processTaskLatch = new CountDownLatch(1);
+        final CountDownLatch processTaskLatch = new CountDownLatch(1);
         new Thread(() -> {
             reset(mockState);
             when(mockState.taskType()).thenReturn(TaskType.PROCESS);
-            ConsumerTask mockProcessTask = mock(ConsumerTask.class);
+            final ConsumerTask mockProcessTask = mock(ConsumerTask.class);
             when(mockState.createTask(any(), any(), any())).thenReturn(mockProcessTask);
             when(mockProcessTask.call()).then(input -> {
                 // first we want to wait for subscribe to be called,
@@ -927,7 +926,7 @@ public class ShardConsumerTest {
                 log.info("RecordProcessor Thread: Simulating execution of ProcessTask and returning shard-end result");
                 return new TaskResult(true);
             });
-            Subscription mockSubscription = mock(Subscription.class);
+            final Subscription mockSubscription = mock(Subscription.class);
             consumer.handleInput(ProcessRecordsInput.builder().isAtShardEnd(true).build(), mockSubscription);
         }).start();
 

--- a/amazon-kinesis-client/src/test/java/software/amazon/kinesis/lifecycle/ShardConsumerTest.java
+++ b/amazon-kinesis-client/src/test/java/software/amazon/kinesis/lifecycle/ShardConsumerTest.java
@@ -958,8 +958,8 @@ public class ShardConsumerTest {
         log.info("Scheduler Thread: Invoking ShardConsumer.executeLifecycle() to invoke subscribe and" +
             " complete initialization");
         consumer.executeLifecycle();
-        // initialization should be done by now, make sure shard consumer did not
-        // perform shutdown processing yet.
+        log.info("Scheduler Thread: Done initializing the ShardConsumer");
+
         log.info("Verifying scheduler did not perform shutdown transition during initialization");
         verify(mockState, times(0)).shutdownTransition(any());
     }


### PR DESCRIPTION
When Kinesis shards have no data, there can be a race condition where the shard-end record processing from RecordProcessorThread interleaves with Scheduler performing initialization. This leads to ShardConsumer making incorrect state transition during initialization (moves from PROCESSING -> SHUTTING_DOWN) state and during shutdown handling it moves from SHUTTING_DOWN -> SHUTDOWN_COMPLETE without running the ShutdownTask.

This can cause the ShardConsumer to not perform proper shutdown processing that is required for a child shard processing to be unblocked. So the child shard could be blocked forever unless the lease for the parent shard moves to a new worker and that worker does not run into the race condition.

This patch fixes the race condition as follows:

The intializationComplete invocation is not needed after needsInitialization has been set to false. Because initializationComplete is mean to perform initialization in an async manner, but once its done, the async task is a no-op in happy-path, but it can perform incorrect state transition during a race condition.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Issue: #837 
