### PR TITLE
Skip cross account tests if no cross account credentials are provided

### DIFF
--- a/amazon-kinesis-client/src/test/java/software/amazon/kinesis/application/TestConsumer.java
+++ b/amazon-kinesis-client/src/test/java/software/amazon/kinesis/application/TestConsumer.java
@@ -44,6 +44,8 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
+import static org.junit.Assume.assumeTrue;
+
 @Slf4j
 public class TestConsumer {
     public final KCLAppConfig consumerConfig;
@@ -79,8 +81,9 @@ public class TestConsumer {
 
     public void run() throws Exception {
 
+        // Skip cross account tests if no cross account credentials are provided
         if (consumerConfig.isCrossAccount()) {
-            verifyCrossAccountCreds();
+            assumeTrue(consumerConfig.getCrossAccountCredentialsProvider() != null);
         }
 
         final StreamExistenceManager streamExistenceManager = new StreamExistenceManager(this.consumerConfig);
@@ -123,13 +126,6 @@ public class TestConsumer {
         } finally {
             // Clean up resources created
             deleteResources(streamExistenceManager, leaseTableManager);
-        }
-    }
-
-    private void verifyCrossAccountCreds() {
-        if (consumerConfig.getCrossAccountCredentialsProvider() == null) {
-            throw new RuntimeException("To run cross account integration tests, pass in an AWS profile with -D" +
-                    KCLAppConfig.CROSS_ACCOUNT_PROFILE_PROPERTY);
         }
     }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Previously, cross account tests would fail if no cross account credentials are provided. Now they will skip.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
