### PR TITLE
Modify backwards compatibility script to ignore synthetic access methods

### DIFF
--- a/.github/scripts/backwards_compatibility_check.sh
+++ b/.github/scripts/backwards_compatibility_check.sh
@@ -82,6 +82,9 @@ find_removed_methods() {
 
     local removed_methods=$(diff <(echo "$LATEST_METHODS") <(echo "$CURRENT_METHODS") | grep '^<')
 
+    # ignore synthetic access methods - these are not available to users and will not break backwards compatibility
+    removed_methods=$(echo "$removed_methods" | grep -v "access\$[1-4]00")
+
     if [[ "$removed_methods" != "" ]]
     then
       REMOVED_METHODS_FLAG=$TRUE

--- a/.github/scripts/backwards_compatibility_check.sh
+++ b/.github/scripts/backwards_compatibility_check.sh
@@ -83,7 +83,7 @@ find_removed_methods() {
     local removed_methods=$(diff <(echo "$LATEST_METHODS") <(echo "$CURRENT_METHODS") | grep '^<')
 
     # ignore synthetic access methods - these are not available to users and will not break backwards compatibility
-    removed_methods=$(echo "$removed_methods" | grep -v "access\$[1-4]00")
+    removed_methods=$(echo "$removed_methods" | grep -v "access\$[0-9]00")
 
     if [[ "$removed_methods" != "" ]]
     then


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Modify backwards compatibility script to ignore synthetic access methods. These access methods are not public and should not affect backwards compatibility. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
