### PR TITLE
Update Maven compiler plugin to 3.13.0

### DIFF
--- a/amazon-kinesis-client-multilang/pom.xml
+++ b/amazon-kinesis-client-multilang/pom.xml
@@ -130,10 +130,9 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.11.0</version>
+          <version>3.13.0</version>
           <configuration>
-            <source>1.8</source>
-            <target>1.8</target>
+            <release>8</release>
             <encoding>UTF-8</encoding>
           </configuration>
         </plugin>

--- a/amazon-kinesis-client/pom.xml
+++ b/amazon-kinesis-client/pom.xml
@@ -185,10 +185,9 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.11.0</version>
+          <version>3.13.0</version>
           <configuration>
-            <source>1.8</source>
-            <target>1.8</target>
+            <release>8</release>
             <encoding>UTF-8</encoding>
           </configuration>
         </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -99,10 +99,9 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.11.0</version>
+          <version>3.13.0</version>
           <configuration>
-            <source>1.8</source>
-            <target>1.8</target>
+            <release>8</release>
             <encoding>UTF-8</encoding>
           </configuration>
         </plugin>


### PR DESCRIPTION
This version of the compiler plugin supports the `--release` option as documented [here](https://maven.apache.org/plugins/maven-compiler-plugin/examples/set-compiler-release.html)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
