### PR TITLE
Fix checkstyle violations

### DIFF
--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/coordinator/PeriodicShardSyncManager.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/coordinator/PeriodicShardSyncManager.java
@@ -435,7 +435,8 @@ class PeriodicShardSyncManager {
                                 leaseRefresher.updateLeaseWithMetaInfo(lease, UpdateField.HASH_KEY_RANGE);
                             } catch (Exception e) {
                                 log.warn(
-                                        "Unable to update hash range key information for lease {} of stream {}. This may result in explicit lease sync.",
+                                        "Unable to update hash range key information for lease {} of stream {}."
+                                                + "This may result in explicit lease sync.",
                                         lease.leaseKey(),
                                         streamIdentifier);
                             }

--- a/checkstyle/checkstyle.xml
+++ b/checkstyle/checkstyle.xml
@@ -22,7 +22,6 @@
     </module>
 
     <module name="TreeWalker">
-        <module name="ArrayTrailingComma"/>
         <module name="AvoidStarImport"/>
         <module name="ConstantName"/>
         <module name="CovariantEquals"/>


### PR DESCRIPTION
Follow up to #1332:

- Manually split up a long string literal.
- Disable ArrayTrailingComma, which checkstyle complains about even in
  commented code. In any case it is redundant with PJF.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
