### PR TITLE
*Actually* skip tests while running backwards compatibility test.

### DIFF
--- a/.github/scripts/backwards_compatibility_check.sh
+++ b/.github/scripts/backwards_compatibility_check.sh
@@ -21,7 +21,7 @@ get_latest_jar() {
 
 # Get the JAR with the changes that need to be verified.
 get_current_jar() {
-  mvn -B install -DskipTests
+  mvn -B install -Dmaven.test.skip=true
   CURRENT_VERSION=$(mvn -q  -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec)
   CURRENT_JAR=$KCL_MAVEN_DIR/$CURRENT_VERSION/amazon-kinesis-client-$CURRENT_VERSION.jar
 }


### PR DESCRIPTION
*Issue #, if available:*

The Maven compiler plugin does not respect the `-Dskiptests` flag. As another benefit, this change skips recompiling the test sources too.

Of course ideally it would be nice to just get the classes from the previous build step but i have no idea how to do this.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
