### PR TITLE
Add a backwards compatibility check for .proto files

### DIFF
--- a/amazon-kinesis-client/pom.xml
+++ b/amazon-kinesis-client/pom.xml
@@ -410,6 +410,18 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+         <groupId>com.salesforce.servicelibs</groupId>
+         <artifactId>proto-backwards-compatibility</artifactId>
+         <version>1.0.7</version>
+         <executions>
+             <execution>
+                 <goals>
+                     <goal>backwards-compatibility-check</goal>
+                 </goals>
+             </execution>
+         </executions>
+      </plugin>
     </plugins>
 
   </build>

--- a/amazon-kinesis-client/src/main/proto/proto.lock
+++ b/amazon-kinesis-client/src/main/proto/proto.lock
@@ -1,0 +1,78 @@
+{
+  "definitions": [
+    {
+      "protopath": "messages.proto",
+      "def": {
+        "messages": [
+          {
+            "name": "Tag",
+            "fields": [
+              {
+                "id": 1,
+                "name": "key",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "value",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "Record",
+            "fields": [
+              {
+                "id": 1,
+                "name": "partition_key_index",
+                "type": "uint64"
+              },
+              {
+                "id": 2,
+                "name": "explicit_hash_key_index",
+                "type": "uint64"
+              },
+              {
+                "id": 3,
+                "name": "data",
+                "type": "bytes"
+              },
+              {
+                "id": 4,
+                "name": "tags",
+                "type": "Tag",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "AggregatedRecord",
+            "fields": [
+              {
+                "id": 1,
+                "name": "partition_key_table",
+                "type": "string",
+                "is_repeated": true
+              },
+              {
+                "id": 2,
+                "name": "explicit_hash_key_table",
+                "type": "string",
+                "is_repeated": true
+              },
+              {
+                "id": 3,
+                "name": "records",
+                "type": "Record",
+                "is_repeated": true
+              }
+            ]
+          }
+        ],
+        "package": {
+          "name": "software.amazon.kinesis.retrieval.kpl"
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
In # 1361 we skip backwards compatibility tests for proto files because they were too brittle. By using [protolock](https://github.com/nilslice/protolock) through [this maven plugin](https://github.com/salesforce/proto-backwards-compat-maven-plugin) we can instead test the proto files directly instead of inspecting the generated Java code, which is better because:

1. It lets us ignore implementation specific details such as inheriting methods vs implementing them in the wrapper class directly
2. It lets us catch problems like reassigning field numbers or forgetting to reserve deleted field numbers, which would be missed by simply inspecting the generated code.

To verify that this works locally, I made a basic incompatible change and verified that the check failed:
```
$ perl -pi -e 's,key = 1,key = 8,g' amazon-kinesis-client/src/main/proto/messages.proto
$ mvn proto-backwards-compatibility:backwards-compatibility-check -pl amazon-kinesis-client
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
