### PR TITLE
Add config to enable PITR

### DIFF
--- a/amazon-kinesis-client-multilang/src/main/java/software/amazon/kinesis/coordinator/KinesisClientLibConfiguration.java
+++ b/amazon-kinesis-client-multilang/src/main/java/software/amazon/kinesis/coordinator/KinesisClientLibConfiguration.java
@@ -218,6 +218,8 @@ public class KinesisClientLibConfiguration {
     private AwsCredentialsProvider cloudWatchCredentialsProvider;
     private long failoverTimeMillis;
     private boolean enablePriorityLeaseAssignment;
+    private boolean leaseTableDeletionProtectionEnabled;
+    private boolean leaseTablePitrEnabled;
     private String workerIdentifier;
     private long shardSyncIntervalMillis;
     private int maxRecords;

--- a/amazon-kinesis-client-multilang/src/main/java/software/amazon/kinesis/multilang/config/MultiLangDaemonConfiguration.java
+++ b/amazon-kinesis-client-multilang/src/main/java/software/amazon/kinesis/multilang/config/MultiLangDaemonConfiguration.java
@@ -89,6 +89,12 @@ public class MultiLangDaemonConfiguration {
     private Boolean enablePriorityLeaseAssignment;
 
     @ConfigurationSettable(configurationClass = LeaseManagementConfig.class)
+    private Boolean leaseTableDeletionProtectionEnabled;
+
+    @ConfigurationSettable(configurationClass = LeaseManagementConfig.class)
+    private Boolean leaseTablePitrEnabled;
+
+    @ConfigurationSettable(configurationClass = LeaseManagementConfig.class)
     private long shardSyncIntervalMillis;
 
     @ConfigurationSettable(configurationClass = LeaseManagementConfig.class)

--- a/amazon-kinesis-client-multilang/src/test/java/software/amazon/kinesis/multilang/config/MultiLangDaemonConfigurationTest.java
+++ b/amazon-kinesis-client-multilang/src/test/java/software/amazon/kinesis/multilang/config/MultiLangDaemonConfigurationTest.java
@@ -100,6 +100,28 @@ public class MultiLangDaemonConfigurationTest {
     }
 
     @Test
+    public void testSetLeaseTableDeletionProtectionEnabled() {
+        MultiLangDaemonConfiguration configuration = baseConfiguration();
+        configuration.setLeaseTableDeletionProtectionEnabled(true);
+
+        MultiLangDaemonConfiguration.ResolvedConfiguration resolvedConfiguration =
+                configuration.resolvedConfiguration(shardRecordProcessorFactory);
+
+        assertThat(resolvedConfiguration.leaseManagementConfig.leaseTableDeletionProtectionEnabled(), equalTo(true));
+    }
+
+    @Test
+    public void testSetLeaseTablePitrEnabled() {
+        MultiLangDaemonConfiguration configuration = baseConfiguration();
+        configuration.setLeaseTablePitrEnabled(true);
+
+        MultiLangDaemonConfiguration.ResolvedConfiguration resolvedConfiguration =
+                configuration.resolvedConfiguration(shardRecordProcessorFactory);
+
+        assertThat(resolvedConfiguration.leaseManagementConfig.leaseTablePitrEnabled(), equalTo(true));
+    }
+
+    @Test
     public void testDefaultRetrievalConfig() {
         MultiLangDaemonConfiguration configuration = baseConfiguration();
 

--- a/amazon-kinesis-client-multilang/src/test/java/software/amazon/kinesis/multilang/config/MultiLangDaemonConfigurationTest.java
+++ b/amazon-kinesis-client-multilang/src/test/java/software/amazon/kinesis/multilang/config/MultiLangDaemonConfigurationTest.java
@@ -33,6 +33,7 @@ import software.amazon.kinesis.retrieval.polling.PollingConfig;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
@@ -100,25 +101,47 @@ public class MultiLangDaemonConfigurationTest {
     }
 
     @Test
-    public void testSetLeaseTableDeletionProtectionEnabled() {
+    public void testSetLeaseTableDeletionProtectionEnabledToTrue() {
         MultiLangDaemonConfiguration configuration = baseConfiguration();
         configuration.setLeaseTableDeletionProtectionEnabled(true);
 
         MultiLangDaemonConfiguration.ResolvedConfiguration resolvedConfiguration =
                 configuration.resolvedConfiguration(shardRecordProcessorFactory);
 
-        assertThat(resolvedConfiguration.leaseManagementConfig.leaseTableDeletionProtectionEnabled(), equalTo(true));
+        assertTrue(resolvedConfiguration.leaseManagementConfig.leaseTableDeletionProtectionEnabled());
     }
 
     @Test
-    public void testSetLeaseTablePitrEnabled() {
+    public void testSetLeaseTablePitrEnabledToTrue() {
         MultiLangDaemonConfiguration configuration = baseConfiguration();
         configuration.setLeaseTablePitrEnabled(true);
 
         MultiLangDaemonConfiguration.ResolvedConfiguration resolvedConfiguration =
                 configuration.resolvedConfiguration(shardRecordProcessorFactory);
 
-        assertThat(resolvedConfiguration.leaseManagementConfig.leaseTablePitrEnabled(), equalTo(true));
+        assertTrue(resolvedConfiguration.leaseManagementConfig.leaseTablePitrEnabled());
+    }
+
+    @Test
+    public void testSetLeaseTableDeletionProtectionEnabledToFalse() {
+        MultiLangDaemonConfiguration configuration = baseConfiguration();
+        configuration.setLeaseTableDeletionProtectionEnabled(false);
+
+        MultiLangDaemonConfiguration.ResolvedConfiguration resolvedConfiguration =
+                configuration.resolvedConfiguration(shardRecordProcessorFactory);
+
+        assertFalse(resolvedConfiguration.leaseManagementConfig.leaseTableDeletionProtectionEnabled());
+    }
+
+    @Test
+    public void testSetLeaseTablePitrEnabledToFalse() {
+        MultiLangDaemonConfiguration configuration = baseConfiguration();
+        configuration.setLeaseTablePitrEnabled(false);
+
+        MultiLangDaemonConfiguration.ResolvedConfiguration resolvedConfiguration =
+                configuration.resolvedConfiguration(shardRecordProcessorFactory);
+
+        assertFalse(resolvedConfiguration.leaseManagementConfig.leaseTablePitrEnabled());
     }
 
     @Test

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/leases/LeaseManagementConfig.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/leases/LeaseManagementConfig.java
@@ -59,6 +59,8 @@ public class LeaseManagementConfig {
     public static final long DEFAULT_GARBAGE_LEASE_CLEANUP_INTERVAL_MILLIS =
             Duration.ofMinutes(30).toMillis();
     public static final long DEFAULT_PERIODIC_SHARD_SYNC_INTERVAL_MILLIS = 2 * 60 * 1000L;
+    public static final boolean DEFAULT_LEASE_TABLE_DELETION_PROTECTION_ENABLED = false;
+    public static final boolean DEFAULT_LEASE_TABLE_PITR_ENABLED = false;
     public static final boolean DEFAULT_ENABLE_PRIORITY_LEASE_ASSIGNMENT = true;
     public static final int DEFAULT_CONSECUTIVE_HOLES_FOR_TRIGGERING_LEASE_RECOVERY = 3;
 
@@ -208,11 +210,20 @@ public class LeaseManagementConfig {
     private BillingMode billingMode = BillingMode.PAY_PER_REQUEST;
 
     /**
-     * Whether to enabled deletion protection on the DynamoDB lease table created by KCL.
+     * Whether to enable deletion protection on the DynamoDB lease table created by KCL. This does not update
+     * already existing tables.
      *
      * <p>Default value: false
      */
-    private boolean leaseTableDeletionProtectionEnabled = false;
+    private boolean leaseTableDeletionProtectionEnabled = DEFAULT_LEASE_TABLE_DELETION_PROTECTION_ENABLED;
+
+    /**
+     * Whether to enable PITR (point in time recovery) on the DynamoDB lease table created by KCL. If true, this can
+     * update existing table's PITR.
+     *
+     * <p>Default value: false
+     */
+    private boolean leaseTablePitrEnabled = DEFAULT_LEASE_TABLE_PITR_ENABLED;
 
     /**
      * The list of tags to be applied to the DynamoDB table created for lease management.
@@ -424,6 +435,7 @@ public class LeaseManagementConfig {
                     dynamoDbRequestTimeout(),
                     billingMode(),
                     leaseTableDeletionProtectionEnabled(),
+                    leaseTablePitrEnabled(),
                     tags(),
                     leaseSerializer,
                     customShardDetectorProvider(),

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/leases/dynamodb/DynamoDBLeaseManagementFactory.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/leases/dynamodb/DynamoDBLeaseManagementFactory.java
@@ -99,6 +99,7 @@ public class DynamoDBLeaseManagementFactory implements LeaseManagementFactory {
     private final Duration dynamoDbRequestTimeout;
     private final BillingMode billingMode;
     private final boolean leaseTableDeletionProtectionEnabled;
+    private final boolean leaseTablePitrEnabled;
     private final Collection<Tag> tags;
     private final boolean isMultiStreamMode;
     private final LeaseCleanupConfig leaseCleanupConfig;
@@ -707,7 +708,7 @@ public class DynamoDBLeaseManagementFactory implements LeaseManagementFactory {
                 tableCreatorCallback,
                 dynamoDbRequestTimeout,
                 billingMode,
-                false,
+                LeaseManagementConfig.DEFAULT_LEASE_TABLE_DELETION_PROTECTION_ENABLED,
                 DefaultSdkAutoConstructList.getInstance(),
                 leaseSerializer);
     }
@@ -945,6 +946,7 @@ public class DynamoDBLeaseManagementFactory implements LeaseManagementFactory {
      * @param isMultiStreamMode
      * @param leaseCleanupConfig
      */
+    @Deprecated
     public DynamoDBLeaseManagementFactory(
             final KinesisAsyncClient kinesisClient,
             final DynamoDbAsyncClient dynamoDBClient,
@@ -978,6 +980,76 @@ public class DynamoDBLeaseManagementFactory implements LeaseManagementFactory {
             Function<StreamConfig, ShardDetector> customShardDetectorProvider,
             boolean isMultiStreamMode,
             LeaseCleanupConfig leaseCleanupConfig) {
+        this(
+                kinesisClient,
+                dynamoDBClient,
+                tableName,
+                workerIdentifier,
+                executorService,
+                failoverTimeMillis,
+                enablePriorityLeaseAssignment,
+                epsilonMillis,
+                maxLeasesForWorker,
+                maxLeasesToStealAtOneTime,
+                maxLeaseRenewalThreads,
+                cleanupLeasesUponShardCompletion,
+                ignoreUnexpectedChildShards,
+                shardSyncIntervalMillis,
+                consistentReads,
+                listShardsBackoffTimeMillis,
+                maxListShardsRetryAttempts,
+                maxCacheMissesBeforeReload,
+                listShardsCacheAllowedAgeInSeconds,
+                cacheMissWarningModulus,
+                initialLeaseTableReadCapacity,
+                initialLeaseTableWriteCapacity,
+                deprecatedHierarchicalShardSyncer,
+                tableCreatorCallback,
+                dynamoDbRequestTimeout,
+                billingMode,
+                leaseTableDeletionProtectionEnabled,
+                LeaseManagementConfig.DEFAULT_LEASE_TABLE_PITR_ENABLED,
+                tags,
+                leaseSerializer,
+                customShardDetectorProvider,
+                isMultiStreamMode,
+                leaseCleanupConfig);
+    }
+
+    public DynamoDBLeaseManagementFactory(
+            final KinesisAsyncClient kinesisClient,
+            final DynamoDbAsyncClient dynamoDBClient,
+            final String tableName,
+            final String workerIdentifier,
+            final ExecutorService executorService,
+            final long failoverTimeMillis,
+            final boolean enablePriorityLeaseAssignment,
+            final long epsilonMillis,
+            final int maxLeasesForWorker,
+            final int maxLeasesToStealAtOneTime,
+            final int maxLeaseRenewalThreads,
+            final boolean cleanupLeasesUponShardCompletion,
+            final boolean ignoreUnexpectedChildShards,
+            final long shardSyncIntervalMillis,
+            final boolean consistentReads,
+            final long listShardsBackoffTimeMillis,
+            final int maxListShardsRetryAttempts,
+            final int maxCacheMissesBeforeReload,
+            final long listShardsCacheAllowedAgeInSeconds,
+            final int cacheMissWarningModulus,
+            final long initialLeaseTableReadCapacity,
+            final long initialLeaseTableWriteCapacity,
+            final HierarchicalShardSyncer deprecatedHierarchicalShardSyncer,
+            final TableCreatorCallback tableCreatorCallback,
+            Duration dynamoDbRequestTimeout,
+            BillingMode billingMode,
+            final boolean leaseTableDeletionProtectionEnabled,
+            final boolean leaseTablePitrEnabled,
+            Collection<Tag> tags,
+            LeaseSerializer leaseSerializer,
+            Function<StreamConfig, ShardDetector> customShardDetectorProvider,
+            boolean isMultiStreamMode,
+            LeaseCleanupConfig leaseCleanupConfig) {
         this.kinesisClient = kinesisClient;
         this.dynamoDBClient = dynamoDBClient;
         this.tableName = tableName;
@@ -1005,6 +1077,7 @@ public class DynamoDBLeaseManagementFactory implements LeaseManagementFactory {
         this.dynamoDbRequestTimeout = dynamoDbRequestTimeout;
         this.billingMode = billingMode;
         this.leaseTableDeletionProtectionEnabled = leaseTableDeletionProtectionEnabled;
+        this.leaseTablePitrEnabled = leaseTablePitrEnabled;
         this.leaseSerializer = leaseSerializer;
         this.customShardDetectorProvider = customShardDetectorProvider;
         this.isMultiStreamMode = isMultiStreamMode;
@@ -1091,6 +1164,7 @@ public class DynamoDBLeaseManagementFactory implements LeaseManagementFactory {
                 dynamoDbRequestTimeout,
                 billingMode,
                 leaseTableDeletionProtectionEnabled,
+                leaseTablePitrEnabled,
                 tags);
     }
 

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/leases/dynamodb/DynamoDBLeaseRefresher.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/leases/dynamodb/DynamoDBLeaseRefresher.java
@@ -40,7 +40,6 @@ import software.amazon.awssdk.services.dynamodb.model.DynamoDbException;
 import software.amazon.awssdk.services.dynamodb.model.GetItemRequest;
 import software.amazon.awssdk.services.dynamodb.model.GetItemResponse;
 import software.amazon.awssdk.services.dynamodb.model.LimitExceededException;
-import software.amazon.awssdk.services.dynamodb.model.PointInTimeRecoverySpecification;
 import software.amazon.awssdk.services.dynamodb.model.ProvisionedThroughput;
 import software.amazon.awssdk.services.dynamodb.model.ProvisionedThroughputExceededException;
 import software.amazon.awssdk.services.dynamodb.model.PutItemRequest;
@@ -305,9 +304,7 @@ public class DynamoDBLeaseRefresher implements LeaseRefresher {
     private void enablePitr() throws DependencyException {
         final UpdateContinuousBackupsRequest request = UpdateContinuousBackupsRequest.builder()
                 .tableName(table)
-                .pointInTimeRecoverySpecification(PointInTimeRecoverySpecification.builder()
-                        .pointInTimeRecoveryEnabled(true)
-                        .build())
+                .pointInTimeRecoverySpecification(builder -> builder.pointInTimeRecoveryEnabled(true))
                 .build();
 
         final AWSExceptionManager exceptionManager = createExceptionManager();

--- a/amazon-kinesis-client/src/test/java/software/amazon/kinesis/leases/dynamodb/DynamoDBLeaseRefresherTest.java
+++ b/amazon-kinesis-client/src/test/java/software/amazon/kinesis/leases/dynamodb/DynamoDBLeaseRefresherTest.java
@@ -31,6 +31,7 @@ import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
+import software.amazon.awssdk.core.util.DefaultSdkAutoConstructList;
 import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 import software.amazon.awssdk.services.dynamodb.model.BillingMode;
@@ -44,6 +45,7 @@ import software.amazon.awssdk.services.dynamodb.model.DynamoDbException;
 import software.amazon.awssdk.services.dynamodb.model.GetItemRequest;
 import software.amazon.awssdk.services.dynamodb.model.GetItemResponse;
 import software.amazon.awssdk.services.dynamodb.model.LimitExceededException;
+import software.amazon.awssdk.services.dynamodb.model.PointInTimeRecoverySpecification;
 import software.amazon.awssdk.services.dynamodb.model.ProvisionedThroughput;
 import software.amazon.awssdk.services.dynamodb.model.PutItemRequest;
 import software.amazon.awssdk.services.dynamodb.model.PutItemResponse;
@@ -54,6 +56,8 @@ import software.amazon.awssdk.services.dynamodb.model.ScanResponse;
 import software.amazon.awssdk.services.dynamodb.model.TableDescription;
 import software.amazon.awssdk.services.dynamodb.model.TableStatus;
 import software.amazon.awssdk.services.dynamodb.model.Tag;
+import software.amazon.awssdk.services.dynamodb.model.UpdateContinuousBackupsRequest;
+import software.amazon.awssdk.services.dynamodb.model.UpdateContinuousBackupsResponse;
 import software.amazon.awssdk.services.dynamodb.model.UpdateItemRequest;
 import software.amazon.awssdk.services.dynamodb.model.UpdateItemResponse;
 import software.amazon.kinesis.leases.Lease;
@@ -80,6 +84,10 @@ public class DynamoDBLeaseRefresherTest {
     private static final String TABLE_NAME = "test";
     private static final boolean CONSISTENT_READS = true;
     private static final boolean DELETION_PROTECTION_ENABLED = false;
+    private static final boolean PITR_ENABLED = true;
+    private static final Collection<Tag> EMPTY_TAGS = DefaultSdkAutoConstructList.getInstance();
+    private static final Collection<Tag> TAGS =
+            Collections.singletonList(Tag.builder().key("foo").value("bar").build());
 
     @Mock
     private DynamoDbAsyncClient dynamoDbClient;
@@ -112,6 +120,9 @@ public class DynamoDBLeaseRefresherTest {
     private CompletableFuture<CreateTableResponse> mockCreateTableFuture;
 
     @Mock
+    private CompletableFuture<UpdateContinuousBackupsResponse> mockUpdateContinuousBackupsFuture;
+
+    @Mock
     private Lease lease;
 
     @Rule
@@ -120,8 +131,7 @@ public class DynamoDBLeaseRefresherTest {
     private DynamoDBLeaseRefresher leaseRefresher;
     private DescribeTableRequest describeTableRequest;
     private CreateTableRequest createTableRequest;
-    private Collection<Tag> tags;
-
+    private UpdateContinuousBackupsRequest updateContinuousBackupsRequest;
     private Map<String, AttributeValue> serializedLease;
 
     @Before
@@ -138,6 +148,12 @@ public class DynamoDBLeaseRefresherTest {
                 .attributeDefinitions(leaseSerializer.getAttributeDefinitions())
                 .billingMode(BillingMode.PAY_PER_REQUEST)
                 .deletionProtectionEnabled(DELETION_PROTECTION_ENABLED)
+                .build();
+        updateContinuousBackupsRequest = UpdateContinuousBackupsRequest.builder()
+                .tableName(TABLE_NAME)
+                .pointInTimeRecoverySpecification(PointInTimeRecoverySpecification.builder()
+                        .pointInTimeRecoveryEnabled(PITR_ENABLED)
+                        .build())
                 .build();
     }
 
@@ -353,7 +369,6 @@ public class DynamoDBLeaseRefresherTest {
 
     @Test
     public void testCreateLeaseTableWithTagsIfNotExists() throws Exception {
-        tags = Collections.singletonList(Tag.builder().key("foo").value("bar").build());
         leaseRefresher = new DynamoDBLeaseRefresher(
                 TABLE_NAME,
                 dynamoDbClient,
@@ -363,7 +378,7 @@ public class DynamoDBLeaseRefresherTest {
                 LeaseManagementConfig.DEFAULT_REQUEST_TIMEOUT,
                 BillingMode.PROVISIONED,
                 DELETION_PROTECTION_ENABLED,
-                tags);
+                TAGS);
 
         when(dynamoDbClient.describeTable(describeTableRequest)).thenReturn(mockDescribeTableFuture);
         when(mockDescribeTableFuture.get(
@@ -382,7 +397,7 @@ public class DynamoDBLeaseRefresherTest {
                 .attributeDefinitions(leaseSerializer.getAttributeDefinitions())
                 .provisionedThroughput(throughput)
                 .deletionProtectionEnabled(DELETION_PROTECTION_ENABLED)
-                .tags(tags)
+                .tags(TAGS)
                 .build();
         when(dynamoDbClient.createTable(createTableRequest)).thenReturn(mockCreateTableFuture);
         when(mockCreateTableFuture.get(LeaseManagementConfig.DEFAULT_REQUEST_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS))
@@ -424,8 +439,48 @@ public class DynamoDBLeaseRefresherTest {
     }
 
     @Test
+    public void testCreateLeaseTableIfNotExistsWithPitrEnabled() throws Exception {
+        DynamoDBLeaseRefresher leaseRefresherWithEnabledPitr = new DynamoDBLeaseRefresher(
+                TABLE_NAME,
+                dynamoDbClient,
+                leaseSerializer,
+                CONSISTENT_READS,
+                tableCreatorCallback,
+                LeaseManagementConfig.DEFAULT_REQUEST_TIMEOUT,
+                BillingMode.PAY_PER_REQUEST,
+                DELETION_PROTECTION_ENABLED,
+                PITR_ENABLED,
+                EMPTY_TAGS);
+        when(dynamoDbClient.describeTable(describeTableRequest)).thenReturn(mockDescribeTableFuture);
+        when(mockDescribeTableFuture.get(
+                        eq(LeaseManagementConfig.DEFAULT_REQUEST_TIMEOUT.toMillis()), eq(TimeUnit.MILLISECONDS)))
+                .thenThrow(ResourceNotFoundException.builder()
+                        .message("Table doesn't exist")
+                        .build());
+        when(dynamoDbClient.createTable(createTableRequest)).thenReturn(mockCreateTableFuture);
+        when(mockCreateTableFuture.get(
+                        eq(LeaseManagementConfig.DEFAULT_REQUEST_TIMEOUT.toMillis()), eq(TimeUnit.MILLISECONDS)))
+                .thenReturn(null);
+        when(dynamoDbClient.updateContinuousBackups(updateContinuousBackupsRequest))
+                .thenReturn(mockUpdateContinuousBackupsFuture);
+        when(mockUpdateContinuousBackupsFuture.get(
+                        eq(LeaseManagementConfig.DEFAULT_REQUEST_TIMEOUT.toMillis()), eq(TimeUnit.MILLISECONDS)))
+                .thenReturn(null);
+        final boolean result = leaseRefresherWithEnabledPitr.createLeaseTableIfNotExists();
+
+        verify(dynamoDbClient, times(1)).describeTable(describeTableRequest);
+        verify(dynamoDbClient, times(1)).createTable(createTableRequest);
+        verify(dynamoDbClient, times(1)).updateContinuousBackups(updateContinuousBackupsRequest);
+        verify(mockDescribeTableFuture, times(1))
+                .get(eq(LeaseManagementConfig.DEFAULT_REQUEST_TIMEOUT.toMillis()), eq(TimeUnit.MILLISECONDS));
+        verify(mockCreateTableFuture, times(1))
+                .get(eq(LeaseManagementConfig.DEFAULT_REQUEST_TIMEOUT.toMillis()), eq(TimeUnit.MILLISECONDS));
+        Assert.assertTrue(result);
+    }
+
+    @Test
     public void testCreateLeaseTableProvisionedWithDeletionProtectionIfNotExists() throws Exception {
-        leaseRefresher = new DynamoDBLeaseRefresher(
+        DynamoDBLeaseRefresher leaseRefresherWithEnabledDeletionProtection = new DynamoDBLeaseRefresher(
                 TABLE_NAME,
                 dynamoDbClient,
                 leaseSerializer,
@@ -458,7 +513,7 @@ public class DynamoDBLeaseRefresherTest {
                         eq(LeaseManagementConfig.DEFAULT_REQUEST_TIMEOUT.toMillis()), eq(TimeUnit.MILLISECONDS)))
                 .thenReturn(null);
 
-        final boolean result = leaseRefresher.createLeaseTableIfNotExists(10L, 10L);
+        final boolean result = leaseRefresherWithEnabledDeletionProtection.createLeaseTableIfNotExists(10L, 10L);
 
         verify(dynamoDbClient, times(1)).describeTable(describeTableRequest);
         verify(dynamoDbClient, times(1)).createTable(createTableRequest);

--- a/amazon-kinesis-client/src/test/java/software/amazon/kinesis/leases/dynamodb/DynamoDBLeaseRefresherTest.java
+++ b/amazon-kinesis-client/src/test/java/software/amazon/kinesis/leases/dynamodb/DynamoDBLeaseRefresherTest.java
@@ -45,7 +45,6 @@ import software.amazon.awssdk.services.dynamodb.model.DynamoDbException;
 import software.amazon.awssdk.services.dynamodb.model.GetItemRequest;
 import software.amazon.awssdk.services.dynamodb.model.GetItemResponse;
 import software.amazon.awssdk.services.dynamodb.model.LimitExceededException;
-import software.amazon.awssdk.services.dynamodb.model.PointInTimeRecoverySpecification;
 import software.amazon.awssdk.services.dynamodb.model.ProvisionedThroughput;
 import software.amazon.awssdk.services.dynamodb.model.PutItemRequest;
 import software.amazon.awssdk.services.dynamodb.model.PutItemResponse;
@@ -151,9 +150,7 @@ public class DynamoDBLeaseRefresherTest {
                 .build();
         updateContinuousBackupsRequest = UpdateContinuousBackupsRequest.builder()
                 .tableName(TABLE_NAME)
-                .pointInTimeRecoverySpecification(PointInTimeRecoverySpecification.builder()
-                        .pointInTimeRecoveryEnabled(PITR_ENABLED)
-                        .build())
+                .pointInTimeRecoverySpecification(builder -> builder.pointInTimeRecoveryEnabled(PITR_ENABLED))
                 .build();
     }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Adds a configurable to enable PITR on the lease table `leaseTablePitrEnabled`
- Adds configurable in multilang for `leaseTableDeletionProtectionEnabled` and `leaseTablePitrEnabled`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
