### PR TITLE
bugfix: debug or trace logging level now properly logs all worker loops

### DIFF
--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/Worker.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/Worker.java
@@ -1205,7 +1205,7 @@ public class Worker implements Runnable {
 
         private void resetInfoLogging() {
             if (infoReporting) {
-                // We just logged at minimum INFO level for a pass through worker loop
+                // We just logged at INFO level for a pass through worker loop
                 if (!LOG.isDebugEnabled() || !LOG.isTraceEnabled()) {
                     infoReporting = false;
                     nextReportTime = System.currentTimeMillis() + reportIntervalMillis;

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/Worker.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/Worker.java
@@ -1206,7 +1206,7 @@ public class Worker implements Runnable {
         private void resetInfoLogging() {
             if (infoReporting) {
                 // We just logged at INFO level for a pass through worker loop
-                if (!LOG.isDebugEnabled() || !LOG.isTraceEnabled()) {
+                if (!LOG.isDebugEnabled() && !LOG.isTraceEnabled()) {
                     infoReporting = false;
                     nextReportTime = System.currentTimeMillis() + reportIntervalMillis;
                 } // else is DEBUG or TRACE so leave reporting true

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/Worker.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/Worker.java
@@ -1205,8 +1205,8 @@ public class Worker implements Runnable {
 
         private void resetInfoLogging() {
             if (infoReporting) {
-                // We just logged at INFO level for a pass through worker loop
-                if (LOG.isInfoEnabled()) {
+                // We just logged at minimum INFO level for a pass through worker loop
+                if (!LOG.isDebugEnabled() || !LOG.isTraceEnabled()) {
                     infoReporting = false;
                     nextReportTime = System.currentTimeMillis() + reportIntervalMillis;
                 } // else is DEBUG or TRACE so leave reporting true


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The logging description for the worker states that 
```
Logger for suppressing too much INFO logging. To avoid too much logging information Worker will output logging at
INFO level for a single pass through the main loop every minute. At DEBUG level it will output all INFO logs on every pass.
```

The previous implementation would only check if the info log level is enabled. However, if debug or trace logging level is enabled, info level would also be enabled since debug/trace log level is a higher log level than info and still only emit info logs every minute


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
