### PR TITLE
Fix checkpointOwner copy issue for multistream lease

### DIFF
--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/leases/Lease.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/leases/Lease.java
@@ -163,6 +163,7 @@ public class Lease {
                 lease.childShardIds(),
                 lease.pendingCheckpointState(),
                 lease.hashKeyRangeForLease());
+        checkpointOwner(lease.checkpointOwner);
     }
 
     @Deprecated
@@ -458,8 +459,6 @@ public class Lease {
      * @return A deep copy of this object.
      */
     public Lease copy() {
-        final Lease lease = new Lease(this);
-        lease.checkpointOwner(this.checkpointOwner);
-        return lease;
+        return new Lease(this);
     }
 }

--- a/amazon-kinesis-client/src/test/java/software/amazon/kinesis/leases/LeaseTest.java
+++ b/amazon-kinesis-client/src/test/java/software/amazon/kinesis/leases/LeaseTest.java
@@ -10,6 +10,7 @@ import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
 import software.amazon.kinesis.retrieval.kpl.ExtendedSequenceNumber;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -107,6 +108,15 @@ public class LeaseTest {
     public void testIsEligibleForGracefulShutdownFalse_shutdownRequested_assertFalse() {
         eligibleForGracefulShutdownLease.checkpointOwner("owner");
         assertFalse(shutdownRequestedLease.isEligibleForGracefulShutdown());
+    }
+
+    @Test
+    public void testCopyingLease() {
+        final String checkpointOwner = "checkpointOwner";
+        final Lease original = new Lease();
+        original.checkpointOwner(checkpointOwner);
+        final Lease copy = original.copy();
+        assertEquals(checkpointOwner, copy.checkpointOwner());
     }
 
     private static Lease createLease(String leaseOwner, String leaseKey, long lastCounterIncrementNanos) {

--- a/amazon-kinesis-client/src/test/java/software/amazon/kinesis/leases/MultiStreamLeaseTest.java
+++ b/amazon-kinesis-client/src/test/java/software/amazon/kinesis/leases/MultiStreamLeaseTest.java
@@ -1,0 +1,19 @@
+package software.amazon.kinesis.leases;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class MultiStreamLeaseTest {
+
+    @Test
+    void testCopyingMultiStreamLease() {
+        final String checkpointOwner = "checkpointOwner";
+        final MultiStreamLease original = new MultiStreamLease();
+        original.checkpointOwner(checkpointOwner);
+        original.streamIdentifier("identifier");
+        original.shardId("shardId");
+        final MultiStreamLease copy = original.copy();
+        assertEquals(checkpointOwner, copy.checkpointOwner());
+    }
+}


### PR DESCRIPTION
*Description of changes:*

Fix issue with copying of the checkpointOwner attribute in multistream mode to allow the graceful lease handoff to happen correctly. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
