### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ The recommended way to use the KCL for Java is to consume it from Maven.
   <dependency>
       <groupId>software.amazon.kinesis</groupId>
       <artifactId>amazon-kinesis-client</artifactId>
-      <version>2.6.0</version>
+      <version>2.6.1</version>
   </dependency>
   ```
 


### PR DESCRIPTION
Update the version number in the dependency for KCL 2.x: 2.6.0 -> 2.6.1. We recommend using 2.6.1 or later for customers using KCL 2.x to avoid a rare condition that can block shard processing when stream capacity changes. The issue has been fixed in 2.6.1 or later in KCL 2.x, or 3.0.0 or later in KCL 3.x.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
