### PR TITLE
Suppress LeaseAssignmentManager excessive WARN logs when there is no issue

### DIFF
--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/coordinator/assignment/LeaseAssignmentManager.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/coordinator/assignment/LeaseAssignmentManager.java
@@ -537,8 +537,8 @@ public final class LeaseAssignmentManager {
                     .filter(workerMetrics -> !workerMetrics.isValidWorkerMetric())
                     .map(WorkerMetricStats::getWorkerId)
                     .collect(Collectors.toList());
-            log.warn("List of workerIds with invalid entries : {}", listOfWorkerIdOfInvalidWorkerMetricsEntry);
             if (!listOfWorkerIdOfInvalidWorkerMetricsEntry.isEmpty()) {
+                log.warn("List of workerIds with invalid entries : {}", listOfWorkerIdOfInvalidWorkerMetricsEntry);
                 metricsScope.addData(
                         "NumWorkersWithInvalidEntry",
                         listOfWorkerIdOfInvalidWorkerMetricsEntry.size(),
@@ -567,8 +567,8 @@ public final class LeaseAssignmentManager {
 
             final Map.Entry<List<Lease>, List<String>> leaseListResponse = leaseListFuture.join();
             this.leaseList = leaseListResponse.getKey();
-            log.warn("Leases that failed deserialization : {}", leaseListResponse.getValue());
             if (!leaseListResponse.getValue().isEmpty()) {
+                log.warn("Leases that failed deserialization : {}", leaseListResponse.getValue());
                 MetricsUtil.addCount(
                         metricsScope,
                         "LeaseDeserializationFailureCount",


### PR DESCRIPTION
*Issue #, if available:* https://github.com/awslabs/amazon-kinesis-client/issues/1407

*Description of changes:*
This commit fixes https://github.com/awslabs/amazon-kinesis-client/issues/1407. The WARN level log statements should only be executed when a real problem had been detected.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
