### PR TITLE
Remove unused synchronized keyword

### DIFF
--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/leases/HierarchicalShardSyncer.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/leases/HierarchicalShardSyncer.java
@@ -651,8 +651,8 @@ public class HierarchicalShardSyncer {
         return parentShardIds;
     }
 
-    public synchronized Lease createLeaseForChildShard(
-            final ChildShard childShard, final StreamIdentifier streamIdentifier) throws InvalidStateException {
+    public Lease createLeaseForChildShard(final ChildShard childShard, final StreamIdentifier streamIdentifier)
+            throws InvalidStateException {
         final MultiStreamArgs multiStreamArgs = new MultiStreamArgs(isMultiStreamMode, streamIdentifier);
 
         return multiStreamArgs.isMultiStreamMode()


### PR DESCRIPTION
*Description of changes:*
`createLeaseForChildShard` doesn't use any shared resources and is only used to build a local lease object, so it should be safe to remove the synchronized keyword.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
