### PR TITLE
Overriding the DataFetcher to return a custom GetRecordsResponseAdapter so that customers can have custom logic to send data to KinesisClientRecord

### DIFF
--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/DataFetcherResult.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/DataFetcherResult.java
@@ -14,8 +14,6 @@
  */
 package software.amazon.kinesis.retrieval;
 
-import software.amazon.awssdk.services.kinesis.model.GetRecordsResponse;
-
 /**
  * Represents the result from the DataFetcher, and allows the receiver to accept a result
  */
@@ -25,7 +23,7 @@ public interface DataFetcherResult {
      *
      * @return The result of the request, this can be null if the request failed.
      */
-    GetRecordsResponse getResult();
+    GetRecordsResponseAdapter getResult();
 
     /**
      * Accepts the result, and advances the shard iterator. A result from the data fetcher must be accepted before any
@@ -33,7 +31,7 @@ public interface DataFetcherResult {
      *
      * @return the result of the request, this can be null if the request failed.
      */
-    GetRecordsResponse accept();
+    GetRecordsResponseAdapter accept();
 
     /**
      * Indicates whether this result is at the end of the shard or not

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/GetRecordsResponseAdapter.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/GetRecordsResponseAdapter.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates.
+ * Licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package software.amazon.kinesis.retrieval;
+
+import java.util.List;
+
+import software.amazon.awssdk.services.kinesis.model.ChildShard;
+import software.amazon.kinesis.annotations.KinesisClientInternalApi;
+
+@KinesisClientInternalApi
+public interface GetRecordsResponseAdapter {
+
+    /**
+     * Returns the list of records retrieved from GetRecords.
+     * @return list of {@link KinesisClientRecord}
+     */
+    List<KinesisClientRecord> records();
+
+    /**
+     * The number of milliseconds the response is from the tip of the stream.
+     * @return long
+     */
+    Long millisBehindLatest();
+
+    /**
+     * Returns the list of child shards of the shard that was retrieved from GetRecords.
+     * @return list of {@link ChildShard}
+     */
+    List<ChildShard> childShards();
+
+    /**
+     * Returns the next shard iterator to be used to retrieve next set of records.
+     * @return String
+     */
+    String nextShardIterator();
+
+    /**
+     * Returns the request id of the GetRecords operation.
+     * @return String containing the request id
+     */
+    String requestId();
+}

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/GetRecordsRetrievalStrategy.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/GetRecordsRetrievalStrategy.java
@@ -16,7 +16,6 @@ package software.amazon.kinesis.retrieval;
 
 import java.util.Optional;
 
-import software.amazon.awssdk.services.kinesis.model.GetRecordsResponse;
 import software.amazon.kinesis.retrieval.polling.DataFetcher;
 import software.amazon.kinesis.retrieval.polling.KinesisDataFetcher;
 
@@ -34,7 +33,7 @@ public interface GetRecordsRetrievalStrategy {
      * @throws IllegalStateException
      *             if the strategy has been shutdown.
      */
-    GetRecordsResponse getRecords(int maxRecords);
+    GetRecordsResponseAdapter getRecords(int maxRecords);
 
     /**
      * Releases any resources used by the strategy. Once the strategy is shutdown it is no longer safe to call

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/KinesisClientRecord.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/KinesisClientRecord.java
@@ -46,6 +46,27 @@ public class KinesisClientRecord {
     private final boolean aggregated;
     private final Schema schema;
 
+    protected KinesisClientRecord(
+            String sequenceNumber,
+            Instant approximateArrivalTimestamp,
+            ByteBuffer data,
+            String partitionKey,
+            EncryptionType encryptionType,
+            long subSequenceNumber,
+            String explicitHashKey,
+            boolean aggregated,
+            Schema schema) {
+        this.sequenceNumber = sequenceNumber;
+        this.approximateArrivalTimestamp = approximateArrivalTimestamp;
+        this.data = data;
+        this.partitionKey = partitionKey;
+        this.encryptionType = encryptionType;
+        this.subSequenceNumber = subSequenceNumber;
+        this.explicitHashKey = explicitHashKey;
+        this.aggregated = aggregated;
+        this.schema = schema;
+    }
+
     public static KinesisClientRecord fromRecord(Record record) {
         return KinesisClientRecord.builder()
                 .sequenceNumber(record.sequenceNumber())

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/KinesisGetRecordsResponseAdapter.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/KinesisGetRecordsResponseAdapter.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates.
+ * Licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package software.amazon.kinesis.retrieval;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import lombok.EqualsAndHashCode;
+import lombok.RequiredArgsConstructor;
+import software.amazon.awssdk.services.kinesis.model.ChildShard;
+import software.amazon.awssdk.services.kinesis.model.GetRecordsResponse;
+import software.amazon.kinesis.annotations.KinesisClientInternalApi;
+
+@RequiredArgsConstructor
+@EqualsAndHashCode
+@KinesisClientInternalApi
+public class KinesisGetRecordsResponseAdapter implements GetRecordsResponseAdapter {
+
+    private final GetRecordsResponse getRecordsResponse;
+
+    @Override
+    public List<KinesisClientRecord> records() {
+        return getRecordsResponse.records().stream()
+                .map(KinesisClientRecord::fromRecord)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public Long millisBehindLatest() {
+        return getRecordsResponse.millisBehindLatest();
+    }
+
+    @Override
+    public List<ChildShard> childShards() {
+        return getRecordsResponse.childShards();
+    }
+
+    @Override
+    public String nextShardIterator() {
+        return getRecordsResponse.nextShardIterator();
+    }
+
+    @Override
+    public String requestId() {
+        return getRecordsResponse.responseMetadata().requestId();
+    }
+}

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/polling/AsynchronousGetRecordsRetrievalStrategy.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/polling/AsynchronousGetRecordsRetrievalStrategy.java
@@ -32,9 +32,9 @@ import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import software.amazon.awssdk.services.kinesis.model.ExpiredIteratorException;
-import software.amazon.awssdk.services.kinesis.model.GetRecordsResponse;
 import software.amazon.kinesis.annotations.KinesisClientInternalApi;
 import software.amazon.kinesis.retrieval.DataFetcherResult;
+import software.amazon.kinesis.retrieval.GetRecordsResponseAdapter;
 import software.amazon.kinesis.retrieval.GetRecordsRetrievalStrategy;
 
 /**
@@ -87,11 +87,11 @@ public class AsynchronousGetRecordsRetrievalStrategy implements GetRecordsRetrie
     }
 
     @Override
-    public GetRecordsResponse getRecords(final int maxRecords) {
+    public GetRecordsResponseAdapter getRecords(final int maxRecords) {
         if (executorService.isShutdown()) {
             throw new IllegalStateException("Strategy has been shutdown");
         }
-        GetRecordsResponse result = null;
+        GetRecordsResponseAdapter result = null;
         CompletionService<DataFetcherResult> completionService = completionServiceSupplier.get();
         Set<Future<DataFetcherResult>> futures = new HashSet<>();
         Callable<DataFetcherResult> retrieverCall = createRetrieverCallable();

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/polling/DataFetcher.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/polling/DataFetcher.java
@@ -15,13 +15,6 @@
 
 package software.amazon.kinesis.retrieval.polling;
 
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeoutException;
-
-import lombok.NonNull;
-import software.amazon.awssdk.services.kinesis.model.GetRecordsRequest;
-import software.amazon.awssdk.services.kinesis.model.GetRecordsResponse;
-import software.amazon.awssdk.services.kinesis.model.GetShardIteratorRequest;
 import software.amazon.kinesis.common.InitialPositionInStreamExtended;
 import software.amazon.kinesis.common.StreamIdentifier;
 import software.amazon.kinesis.retrieval.DataFetcherResult;
@@ -75,39 +68,6 @@ public interface DataFetcher {
      */
     void resetIterator(
             String shardIterator, String sequenceNumber, InitialPositionInStreamExtended initialPositionInStream);
-
-    /**
-     * Retrieves the response based on the request.
-     *
-     * @param request the current get records request used to receive a response.
-     * @return GetRecordsResponse response for getRecords
-     */
-    GetRecordsResponse getGetRecordsResponse(GetRecordsRequest request) throws Exception;
-
-    /**
-     * Retrieves the next get records request based on the current iterator.
-     *
-     * @param nextIterator specify the iterator to get the next record request
-     * @return {@link GetRecordsRequest}
-     */
-    GetRecordsRequest getGetRecordsRequest(String nextIterator);
-
-    /**
-     * Gets the next iterator based on the request.
-     *
-     * @param request used to obtain the next shard iterator
-     * @return next iterator string
-     */
-    String getNextIterator(GetShardIteratorRequest request)
-            throws ExecutionException, InterruptedException, TimeoutException;
-
-    /**
-     * Gets the next set of records based on the iterator.
-     *
-     * @param nextIterator specified shard iterator for getting the next set of records
-     * @return {@link GetRecordsResponse}
-     */
-    GetRecordsResponse getRecords(@NonNull String nextIterator);
 
     /**
      * Get the current account and stream information.

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/polling/SynchronousGetRecordsRetrievalStrategy.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/polling/SynchronousGetRecordsRetrievalStrategy.java
@@ -16,8 +16,8 @@ package software.amazon.kinesis.retrieval.polling;
 
 import lombok.Data;
 import lombok.NonNull;
-import software.amazon.awssdk.services.kinesis.model.GetRecordsResponse;
 import software.amazon.kinesis.annotations.KinesisClientInternalApi;
+import software.amazon.kinesis.retrieval.GetRecordsResponseAdapter;
 import software.amazon.kinesis.retrieval.GetRecordsRetrievalStrategy;
 
 /**
@@ -31,7 +31,7 @@ public class SynchronousGetRecordsRetrievalStrategy implements GetRecordsRetriev
     private final DataFetcher dataFetcher;
 
     @Override
-    public GetRecordsResponse getRecords(final int maxRecords) {
+    public GetRecordsResponseAdapter getRecords(final int maxRecords) {
         return dataFetcher.getRecords().accept();
     }
 

--- a/amazon-kinesis-client/src/test/java/software/amazon/kinesis/retrieval/polling/PrefetchRecordsPublisherIntegrationTest.java
+++ b/amazon-kinesis-client/src/test/java/software/amazon/kinesis/retrieval/polling/PrefetchRecordsPublisherIntegrationTest.java
@@ -46,7 +46,9 @@ import software.amazon.kinesis.lifecycle.events.ProcessRecordsInput;
 import software.amazon.kinesis.metrics.MetricsFactory;
 import software.amazon.kinesis.metrics.NullMetricsFactory;
 import software.amazon.kinesis.retrieval.DataFetcherResult;
+import software.amazon.kinesis.retrieval.GetRecordsResponseAdapter;
 import software.amazon.kinesis.retrieval.GetRecordsRetrievalStrategy;
+import software.amazon.kinesis.retrieval.KinesisGetRecordsResponseAdapter;
 import software.amazon.kinesis.retrieval.RecordsRetrieved;
 import software.amazon.kinesis.retrieval.ThrottlingReporter;
 import software.amazon.kinesis.retrieval.kpl.ExtendedSequenceNumber;
@@ -305,11 +307,12 @@ public class PrefetchRecordsPublisherIntegrationTest {
 
         @Override
         public DataFetcherResult getRecords() {
-            GetRecordsResponse getRecordsResult = GetRecordsResponse.builder()
-                    .records(new ArrayList<>(records))
-                    .nextShardIterator(nextShardIterator)
-                    .millisBehindLatest(1000L)
-                    .build();
+            GetRecordsResponseAdapter getRecordsResult =
+                    new KinesisGetRecordsResponseAdapter(GetRecordsResponse.builder()
+                            .records(new ArrayList<>(records))
+                            .nextShardIterator(nextShardIterator)
+                            .millisBehindLatest(1000L)
+                            .build());
 
             return new AdvancingResult(getRecordsResult);
         }


### PR DESCRIPTION
Currently, the KCL only accepts Kinesis GetRecordsResponse format, and given SDKv2 makes classes as final, custom adapters like the DDB adapter will have to implement their custom serialization / deserialization logic to populate this. Creating a GetRecordsResponseAdapter interface so that custom clients can have their own GetRecordsResponseAdapter

*Issue #, if available:*

*Description of changes:*

Created a GetRecordsResponseAdapter interface and changing the datafetcher result to return GetRecordsResponseAdapter in place of GetRecordsResponse

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
