### PR TITLE
Add options to set leader lifetime and heartbeat

### DIFF
--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/coordinator/Scheduler.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/coordinator/Scheduler.java
@@ -427,7 +427,11 @@ public class Scheduler implements Runnable {
                 .deterministicLeaderDeciderCreator(() -> new DeterministicShuffleShardSyncLeaderDecider(
                         leaseRefresher, Executors.newSingleThreadScheduledExecutor(), 1, metricsFactory))
                 .ddbLockBasedLeaderDeciderCreator(() -> DynamoDBLockBasedLeaderDecider.create(
-                        coordinatorStateDAO, leaseCoordinator.workerIdentifier(), metricsFactory))
+                        coordinatorStateDAO,
+                        leaseCoordinator.workerIdentifier(),
+                        metricsFactory,
+                        leaseManagementConfig.dynamoLockBasedLeaderLeaseDurationInSeconds(),
+                        leaseManagementConfig.dynamoLockBasedLeaderHeartbeatPeriodInSeconds()))
                 .workerIdentifier(leaseCoordinator.workerIdentifier())
                 .workerUtilizationAwareAssignmentConfig(leaseManagementConfig.workerUtilizationAwareAssignmentConfig())
                 .leaseAssignmentModeProvider(leaseAssignmentModeProvider)

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/leader/DynamoDBLockBasedLeaderDecider.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/leader/DynamoDBLockBasedLeaderDecider.java
@@ -15,7 +15,6 @@
 
 package software.amazon.kinesis.leader;
 
-import java.time.Duration;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -46,11 +45,6 @@ import static software.amazon.kinesis.coordinator.CoordinatorState.LEADER_HASH_K
 @Slf4j
 @KinesisClientInternalApi
 public class DynamoDBLockBasedLeaderDecider implements LeaderDecider {
-    private static final Long DEFAULT_LEASE_DURATION_MILLIS =
-            Duration.ofMinutes(2).toMillis();
-    // Heartbeat frequency should be at-least 3 times smaller the lease duration according to LockClient documentation
-    private static final Long DEFAULT_HEARTBEAT_PERIOD_MILLIS =
-            Duration.ofSeconds(30).toMillis();
 
     private final CoordinatorStateDAO coordinatorStateDao;
     private final AmazonDynamoDBLockClient dynamoDBLockClient;
@@ -83,12 +77,16 @@ public class DynamoDBLockBasedLeaderDecider implements LeaderDecider {
     }
 
     public static DynamoDBLockBasedLeaderDecider create(
-            final CoordinatorStateDAO coordinatorStateDao, final String workerId, final MetricsFactory metricsFactory) {
+            final CoordinatorStateDAO coordinatorStateDao,
+            final String workerId,
+            final MetricsFactory metricsFactory,
+            long leaseDurationInSeconds,
+            long heartbeatPeriodInSeconds) {
         return create(
                 coordinatorStateDao,
                 workerId,
-                DEFAULT_LEASE_DURATION_MILLIS,
-                DEFAULT_HEARTBEAT_PERIOD_MILLIS,
+                leaseDurationInSeconds * 1000,
+                heartbeatPeriodInSeconds * 1000,
                 metricsFactory);
     }
 

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/leases/LeaseManagementConfig.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/leases/LeaseManagementConfig.java
@@ -282,6 +282,9 @@ public class LeaseManagementConfig {
     private long listShardsCacheAllowedAgeInSeconds = 30;
     private int cacheMissWarningModulus = 250;
 
+    private long dynamoLockBasedLeaderLeaseDurationInSeconds = 120;
+    private long dynamoLockBasedLeaderHeartbeatPeriodInSeconds = 30;
+
     private MetricsFactory metricsFactory = new NullMetricsFactory();
 
     @Deprecated


### PR DESCRIPTION
Hi!

We're using KCL in a possibly odd way - running with a single worker. After recently attempting an upgrade to KCL v3, we found that when the worker was replaced we'd experience a much longer delay before the new worker took over the leases and started processing. After some digging we've figured out that this is due to the change of the leader decider mechanism, which in v3 waits up to 2 minutes before invalidating the old leader.

https://github.com/awslabs/amazon-dynamodb-lock-client offers options for configuring the lease duration and heartbeat period, but KCL currently doesn't expose those options to consumers to allow them to choose values that better suit their usecases.

*Description of changes:*

Exposes two new properties on the `LeaseManagementConfig`, which allow changing the lease duration and heartbeat period from their defaults, which remain at 120 and 30 seconds respectively, and pass those values down into the dynamodb-lock-client.

If this doesn't sound right, I'd very happily take suggestions on other approaches.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
