### PR TITLE
Ensuring backward compatibilty by putting back the removed interfaces in the DataFetcher component

### DIFF
--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/DataFetcherResult.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/DataFetcherResult.java
@@ -14,6 +14,8 @@
  */
 package software.amazon.kinesis.retrieval;
 
+import software.amazon.awssdk.services.kinesis.model.GetRecordsResponse;
+
 /**
  * Represents the result from the DataFetcher, and allows the receiver to accept a result
  */
@@ -21,9 +23,28 @@ public interface DataFetcherResult {
     /**
      * The result of the request to Kinesis
      *
+     * @return The result of the request, as a {@link GetRecordsResponseAdapter}.
+     */
+    default GetRecordsResponseAdapter getResultAdapter() {
+        return new KinesisGetRecordsResponseAdapter(getResult());
+    }
+
+    /**
+     * The result of the request to Kinesis
+     *
      * @return The result of the request, this can be null if the request failed.
      */
-    GetRecordsResponseAdapter getResult();
+    GetRecordsResponse getResult();
+
+    /**
+     * Accepts the result, and advances the shard iterator. A result from the data fetcher must be accepted before any
+     * further progress can be made.
+     *
+     * @return the result of the request as a {@link GetRecordsResponseAdapter}
+     */
+    default GetRecordsResponseAdapter acceptAdapter() {
+        return new KinesisGetRecordsResponseAdapter(accept());
+    }
 
     /**
      * Accepts the result, and advances the shard iterator. A result from the data fetcher must be accepted before any
@@ -31,7 +52,7 @@ public interface DataFetcherResult {
      *
      * @return the result of the request, this can be null if the request failed.
      */
-    GetRecordsResponseAdapter accept();
+    GetRecordsResponse accept();
 
     /**
      * Indicates whether this result is at the end of the shard or not

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/GetRecordsResponseAdapter.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/GetRecordsResponseAdapter.java
@@ -25,30 +25,35 @@ public interface GetRecordsResponseAdapter {
 
     /**
      * Returns the list of records retrieved from GetRecords.
+     *
      * @return list of {@link KinesisClientRecord}
      */
     List<KinesisClientRecord> records();
 
     /**
      * The number of milliseconds the response is from the tip of the stream.
+     *
      * @return long
      */
     Long millisBehindLatest();
 
     /**
      * Returns the list of child shards of the shard that was retrieved from GetRecords.
+     *
      * @return list of {@link ChildShard}
      */
     List<ChildShard> childShards();
 
     /**
      * Returns the next shard iterator to be used to retrieve next set of records.
+     *
      * @return String
      */
     String nextShardIterator();
 
     /**
      * Returns the request id of the GetRecords operation.
+     *
      * @return String containing the request id
      */
     String requestId();

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/GetRecordsRetrievalStrategy.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/GetRecordsRetrievalStrategy.java
@@ -16,6 +16,7 @@ package software.amazon.kinesis.retrieval;
 
 import java.util.Optional;
 
+import software.amazon.awssdk.services.kinesis.model.GetRecordsResponse;
 import software.amazon.kinesis.retrieval.polling.DataFetcher;
 import software.amazon.kinesis.retrieval.polling.KinesisDataFetcher;
 
@@ -33,11 +34,16 @@ public interface GetRecordsRetrievalStrategy {
      * @throws IllegalStateException
      *             if the strategy has been shutdown.
      */
-    GetRecordsResponseAdapter getRecords(int maxRecords);
+    default GetRecordsResponseAdapter getRecordsAdapter(int maxRecords) {
+        return new KinesisGetRecordsResponseAdapter(getRecords(maxRecords));
+    }
+
+    @Deprecated
+    GetRecordsResponse getRecords(int maxRecords);
 
     /**
      * Releases any resources used by the strategy. Once the strategy is shutdown it is no longer safe to call
-     * {@link #getRecords(int)}.
+     * {@link #getRecordsAdapter(int)}.
      */
     void shutdown();
 

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/KinesisGetRecordsResponseAdapter.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/KinesisGetRecordsResponseAdapter.java
@@ -19,14 +19,18 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import lombok.experimental.Accessors;
 import software.amazon.awssdk.services.kinesis.model.ChildShard;
 import software.amazon.awssdk.services.kinesis.model.GetRecordsResponse;
 import software.amazon.kinesis.annotations.KinesisClientInternalApi;
 
+@Getter
 @RequiredArgsConstructor
-@EqualsAndHashCode
 @KinesisClientInternalApi
+@Accessors(fluent = true)
+@EqualsAndHashCode
 public class KinesisGetRecordsResponseAdapter implements GetRecordsResponseAdapter {
 
     private final GetRecordsResponse getRecordsResponse;

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/polling/AsynchronousGetRecordsRetrievalStrategy.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/polling/AsynchronousGetRecordsRetrievalStrategy.java
@@ -32,9 +32,9 @@ import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import software.amazon.awssdk.services.kinesis.model.ExpiredIteratorException;
+import software.amazon.awssdk.services.kinesis.model.GetRecordsResponse;
 import software.amazon.kinesis.annotations.KinesisClientInternalApi;
 import software.amazon.kinesis.retrieval.DataFetcherResult;
-import software.amazon.kinesis.retrieval.GetRecordsResponseAdapter;
 import software.amazon.kinesis.retrieval.GetRecordsRetrievalStrategy;
 
 /**
@@ -87,11 +87,11 @@ public class AsynchronousGetRecordsRetrievalStrategy implements GetRecordsRetrie
     }
 
     @Override
-    public GetRecordsResponseAdapter getRecords(final int maxRecords) {
+    public GetRecordsResponse getRecords(final int maxRecords) {
         if (executorService.isShutdown()) {
             throw new IllegalStateException("Strategy has been shutdown");
         }
-        GetRecordsResponseAdapter result = null;
+        GetRecordsResponse result = null;
         CompletionService<DataFetcherResult> completionService = completionServiceSupplier.get();
         Set<Future<DataFetcherResult>> futures = new HashSet<>();
         Callable<DataFetcherResult> retrieverCall = createRetrieverCallable();

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/polling/BlockingRecordsPublisher.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/polling/BlockingRecordsPublisher.java
@@ -58,7 +58,7 @@ public class BlockingRecordsPublisher implements RecordsPublisher {
     }
 
     public ProcessRecordsInput getNextResult() {
-        GetRecordsResponseAdapter getRecordsResult = getRecordsRetrievalStrategy.getRecords(maxRecordsPerCall);
+        GetRecordsResponseAdapter getRecordsResult = getRecordsRetrievalStrategy.getRecordsAdapter(maxRecordsPerCall);
         final RequestDetails getRecordsRequestDetails =
                 new RequestDetails(getRecordsResult.requestId(), Instant.now().toString());
         setLastSuccessfulRequestDetails(getRecordsRequestDetails);

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/polling/DataFetcher.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/polling/DataFetcher.java
@@ -15,9 +15,17 @@
 
 package software.amazon.kinesis.retrieval.polling;
 
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
+
+import lombok.NonNull;
+import software.amazon.awssdk.services.kinesis.model.GetRecordsRequest;
+import software.amazon.awssdk.services.kinesis.model.GetRecordsResponse;
+import software.amazon.awssdk.services.kinesis.model.GetShardIteratorRequest;
 import software.amazon.kinesis.common.InitialPositionInStreamExtended;
 import software.amazon.kinesis.common.StreamIdentifier;
 import software.amazon.kinesis.retrieval.DataFetcherResult;
+import software.amazon.kinesis.retrieval.GetRecordsResponseAdapter;
 import software.amazon.kinesis.retrieval.kpl.ExtendedSequenceNumber;
 
 public interface DataFetcher {
@@ -81,4 +89,37 @@ public interface DataFetcher {
      * @return boolean to determine whether shard end is reached
      */
     boolean isShardEndReached();
+
+    /**
+     * Retrieves the response based on the request.
+     *
+     * @param request the current get records request used to receive a response.
+     * @return GetRecordsResponse response for getRecords
+     */
+    GetRecordsResponse getGetRecordsResponse(GetRecordsRequest request) throws Exception;
+
+    /**
+     * Gets the next set of records based on the iterator.
+     *
+     * @param nextIterator specified shard iterator for getting the next set of records
+     * @return {@link GetRecordsResponseAdapter}
+     */
+    GetRecordsRequest getGetRecordsRequest(String nextIterator);
+
+    /**
+     * Gets the next iterator based on the request.
+     *
+     * @param request used to obtain the next shard iterator
+     * @return next iterator string
+     */
+    String getNextIterator(GetShardIteratorRequest request)
+            throws ExecutionException, InterruptedException, TimeoutException;
+
+    /**
+     * Gets the next set of records based on the iterator.
+     *
+     * @param nextIterator specified shard iterator for getting the next set of records
+     * @return {@link GetRecordsResponse}
+     */
+    GetRecordsResponse getRecords(@NonNull final String nextIterator);
 }

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/polling/PrefetchRecordsPublisher.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/polling/PrefetchRecordsPublisher.java
@@ -540,7 +540,7 @@ public class PrefetchRecordsPublisher implements RecordsPublisher {
                 try {
                     sleepBeforeNextCall();
                     GetRecordsResponseAdapter getRecordsResult =
-                            getRecordsRetrievalStrategy.getRecords(maxRecordsPerCall);
+                            getRecordsRetrievalStrategy.getRecordsAdapter(maxRecordsPerCall);
                     lastSuccessfulCall = Instant.now();
                     lastMillisBehindLatest = getRecordsResult.millisBehindLatest();
                     lastGetRecordsReturnedRecordsCount =

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/polling/SynchronousGetRecordsRetrievalStrategy.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/polling/SynchronousGetRecordsRetrievalStrategy.java
@@ -16,6 +16,7 @@ package software.amazon.kinesis.retrieval.polling;
 
 import lombok.Data;
 import lombok.NonNull;
+import software.amazon.awssdk.services.kinesis.model.GetRecordsResponse;
 import software.amazon.kinesis.annotations.KinesisClientInternalApi;
 import software.amazon.kinesis.retrieval.GetRecordsResponseAdapter;
 import software.amazon.kinesis.retrieval.GetRecordsRetrievalStrategy;
@@ -30,9 +31,15 @@ public class SynchronousGetRecordsRetrievalStrategy implements GetRecordsRetriev
     @NonNull
     private final DataFetcher dataFetcher;
 
+    @Deprecated
     @Override
-    public GetRecordsResponseAdapter getRecords(final int maxRecords) {
+    public GetRecordsResponse getRecords(final int maxRecords) {
         return dataFetcher.getRecords().accept();
+    }
+
+    @Override
+    public GetRecordsResponseAdapter getRecordsAdapter(final int maxRecords) {
+        return dataFetcher.getRecords().acceptAdapter();
     }
 
     @Override

--- a/amazon-kinesis-client/src/test/java/software/amazon/kinesis/retrieval/polling/AsynchronousGetRecordsRetrievalStrategyIntegrationTest.java
+++ b/amazon-kinesis-client/src/test/java/software/amazon/kinesis/retrieval/polling/AsynchronousGetRecordsRetrievalStrategyIntegrationTest.java
@@ -103,13 +103,13 @@ public class AsynchronousGetRecordsRetrievalStrategyIntegrationTest {
                 GetRecordsResponse.builder().build());
 
         when(completionServiceSupplier.get()).thenReturn(completionService);
-        when(result.accept()).thenReturn(getRecordsResponse);
+        when(result.acceptAdapter()).thenReturn(getRecordsResponse);
     }
 
     @Test
     public void oneRequestMultithreadTest() {
-        when(result.accept()).thenReturn(null);
-        GetRecordsResponseAdapter getRecordsResult = getRecordsRetrivalStrategy.getRecords(numberOfRecords);
+        when(result.acceptAdapter()).thenReturn(null);
+        GetRecordsResponseAdapter getRecordsResult = getRecordsRetrivalStrategy.getRecordsAdapter(numberOfRecords);
         verify(dataFetcher, atLeast(getLeastNumberOfCalls())).getRecords();
         verify(executorService, atLeast(getLeastNumberOfCalls())).execute(any());
         assertNull(getRecordsResult);
@@ -120,16 +120,16 @@ public class AsynchronousGetRecordsRetrievalStrategyIntegrationTest {
         ExecutorCompletionService<DataFetcherResult> completionService1 =
                 spy(new ExecutorCompletionService<DataFetcherResult>(executorService));
         when(completionServiceSupplier.get()).thenReturn(completionService1);
-        GetRecordsResponseAdapter getRecordsResult = getRecordsRetrivalStrategy.getRecords(numberOfRecords);
+        GetRecordsResponseAdapter getRecordsResult = getRecordsRetrivalStrategy.getRecordsAdapter(numberOfRecords);
         verify(dataFetcher, atLeast(getLeastNumberOfCalls())).getRecords();
         verify(executorService, atLeast(getLeastNumberOfCalls())).execute(any());
         assertThat(getRecordsResult, equalTo(getRecordsResponse));
 
-        when(result.accept()).thenReturn(null);
+        when(result.acceptAdapter()).thenReturn(null);
         ExecutorCompletionService<DataFetcherResult> completionService2 =
                 spy(new ExecutorCompletionService<DataFetcherResult>(executorService));
         when(completionServiceSupplier.get()).thenReturn(completionService2);
-        getRecordsResult = getRecordsRetrivalStrategy.getRecords(numberOfRecords);
+        getRecordsResult = getRecordsRetrivalStrategy.getRecordsAdapter(numberOfRecords);
         assertThat(getRecordsResult, nullValue(GetRecordsResponseAdapter.class));
     }
 
@@ -146,7 +146,7 @@ public class AsynchronousGetRecordsRetrievalStrategyIntegrationTest {
         });
 
         try {
-            getRecordsRetrivalStrategy.getRecords(numberOfRecords);
+            getRecordsRetrivalStrategy.getRecordsAdapter(numberOfRecords);
         } finally {
             verify(dataFetcher, atLeast(getLeastNumberOfCalls())).getRecords();
             verify(executorService, atLeast(getLeastNumberOfCalls())).execute(any());

--- a/amazon-kinesis-client/src/test/java/software/amazon/kinesis/retrieval/polling/AsynchronousGetRecordsRetrievalStrategyTest.java
+++ b/amazon-kinesis-client/src/test/java/software/amazon/kinesis/retrieval/polling/AsynchronousGetRecordsRetrievalStrategyTest.java
@@ -83,7 +83,8 @@ public class AsynchronousGetRecordsRetrievalStrategyTest {
                 GetRecordsResponse.builder().build());
 
         when(completionServiceSupplier.get()).thenReturn(completionService);
-        when(dataFetcherResult.accept()).thenReturn(expectedResponses);
+        when(dataFetcherResult.accept())
+                .thenReturn(((KinesisGetRecordsResponseAdapter) expectedResponses).getRecordsResponse());
     }
 
     @Test
@@ -96,7 +97,7 @@ public class AsynchronousGetRecordsRetrievalStrategyTest {
         when(completionService.poll(anyLong(), any())).thenReturn(successfulFuture);
         when(successfulFuture.get()).thenReturn(dataFetcherResult);
 
-        GetRecordsResponseAdapter result = strategy.getRecords(10);
+        GetRecordsResponseAdapter result = strategy.getRecordsAdapter(10);
 
         verify(executorService).isShutdown();
         verify(completionService).submit(any());
@@ -119,7 +120,7 @@ public class AsynchronousGetRecordsRetrievalStrategyTest {
         when(successfulFuture.cancel(anyBoolean())).thenReturn(false);
         when(blockedFuture.cancel(anyBoolean())).thenReturn(true);
 
-        GetRecordsResponseAdapter actualResults = strategy.getRecords(10);
+        GetRecordsResponseAdapter actualResults = strategy.getRecordsAdapter(10);
 
         verify(completionService, times(2)).submit(any());
         verify(completionService, times(2)).poll(eq(RETRY_GET_RECORDS_IN_SECONDS), eq(TimeUnit.SECONDS));
@@ -138,7 +139,7 @@ public class AsynchronousGetRecordsRetrievalStrategyTest {
 
         when(executorService.isShutdown()).thenReturn(true);
 
-        strategy.getRecords(10);
+        strategy.getRecordsAdapter(10);
     }
 
     @Test
@@ -159,7 +160,7 @@ public class AsynchronousGetRecordsRetrievalStrategyTest {
         when(successfulFuture.cancel(anyBoolean())).thenReturn(false);
         when(blockedFuture.cancel(anyBoolean())).thenReturn(true);
 
-        GetRecordsResponseAdapter actualResult = strategy.getRecords(10);
+        GetRecordsResponseAdapter actualResult = strategy.getRecordsAdapter(10);
 
         verify(completionService, times(3)).submit(any());
         verify(completionService, times(3)).poll(eq(RETRY_GET_RECORDS_IN_SECONDS), eq(TimeUnit.SECONDS));
@@ -184,7 +185,7 @@ public class AsynchronousGetRecordsRetrievalStrategyTest {
                         .build()));
 
         try {
-            strategy.getRecords(10);
+            strategy.getRecordsAdapter(10);
         } finally {
             verify(executorService).isShutdown();
             verify(completionService, times(2)).submit(any());

--- a/amazon-kinesis-client/src/test/java/software/amazon/kinesis/retrieval/polling/KinesisDataFetcherTest.java
+++ b/amazon-kinesis-client/src/test/java/software/amazon/kinesis/retrieval/polling/KinesisDataFetcherTest.java
@@ -287,7 +287,7 @@ public class KinesisDataFetcherTest {
                 new SynchronousGetRecordsRetrievalStrategy(kinesisDataFetcher);
         try {
             // Call records of dataFetcher which will throw an exception
-            getRecordsRetrievalStrategy.getRecords(MAX_RECORDS);
+            getRecordsRetrievalStrategy.getRecordsAdapter(MAX_RECORDS);
         } finally {
             // Test shard has reached the end
             assertTrue("Shard should reach the end", kinesisDataFetcher.isShardEndReached());
@@ -321,7 +321,7 @@ public class KinesisDataFetcherTest {
                 new SynchronousGetRecordsRetrievalStrategy(kinesisDataFetcher);
 
         // Call records of dataFetcher which will throw an exception
-        getRecordsRetrievalStrategy.getRecords(MAX_RECORDS);
+        getRecordsRetrievalStrategy.getRecordsAdapter(MAX_RECORDS);
     }
 
     @Test
@@ -433,9 +433,9 @@ public class KinesisDataFetcherTest {
 
         DataFetcherResult terminal = kinesisDataFetcher.getRecords();
         assertTrue(terminal.isShardEnd());
-        assertNotNull(terminal.getResult());
+        assertNotNull(terminal.getResultAdapter());
 
-        final GetRecordsResponseAdapter terminalResult = terminal.getResult();
+        final GetRecordsResponseAdapter terminalResult = terminal.getResultAdapter();
         assertNotNull(terminalResult.records());
         assertEquals(0, terminalResult.records().size());
         assertNull(terminalResult.nextShardIterator());
@@ -459,10 +459,10 @@ public class KinesisDataFetcherTest {
         when(record.sequenceNumber()).thenReturn(sequenceNumber);
 
         kinesisDataFetcher.initialize(InitialPositionInStream.LATEST.toString(), INITIAL_POSITION_LATEST);
-        assertEquals(getRecordsResult, kinesisDataFetcher.getRecords().accept());
+        assertEquals(getRecordsResult, kinesisDataFetcher.getRecords().acceptAdapter());
 
         kinesisDataFetcher.restartIterator();
-        assertEquals(restartGetRecordsResponse, kinesisDataFetcher.getRecords().accept());
+        assertEquals(restartGetRecordsResponse, kinesisDataFetcher.getRecords().acceptAdapter());
     }
 
     @Test
@@ -536,19 +536,19 @@ public class KinesisDataFetcherTest {
                 new SynchronousGetRecordsRetrievalStrategy(kinesisDataFetcher);
 
         // Call records of dataFetcher which will throw an exception
-        getRecordsRetrievalStrategy.getRecords(MAX_RECORDS);
+        getRecordsRetrievalStrategy.getRecordsAdapter(MAX_RECORDS);
     }
 
     private DataFetcherResult assertAdvanced(
             GetRecordsResponse expectedResult, String previousValue, String nextValue) {
         DataFetcherResult acceptResult = kinesisDataFetcher.getRecords();
         KinesisGetRecordsResponseAdapter expectedResultAdapter = new KinesisGetRecordsResponseAdapter(expectedResult);
-        assertEquals(expectedResultAdapter, acceptResult.getResult());
+        assertEquals(expectedResultAdapter, acceptResult.getResultAdapter());
 
         assertEquals(previousValue, kinesisDataFetcher.getNextIterator());
         assertFalse(kinesisDataFetcher.isShardEndReached());
 
-        assertEquals(expectedResultAdapter, acceptResult.accept());
+        assertEquals(expectedResultAdapter, acceptResult.acceptAdapter());
         assertEquals(nextValue, kinesisDataFetcher.getNextIterator());
         if (nextValue == null) {
             assertTrue(kinesisDataFetcher.isShardEndReached());
@@ -561,7 +561,7 @@ public class KinesisDataFetcherTest {
         assertEquals(previousValue, kinesisDataFetcher.getNextIterator());
         DataFetcherResult noAcceptResult = kinesisDataFetcher.getRecords();
         KinesisGetRecordsResponseAdapter expectedResultAdapter = new KinesisGetRecordsResponseAdapter(expectedResult);
-        assertEquals(expectedResultAdapter, noAcceptResult.getResult());
+        assertEquals(expectedResultAdapter, noAcceptResult.getResultAdapter());
 
         assertEquals(previousValue, kinesisDataFetcher.getNextIterator());
 
@@ -603,7 +603,7 @@ public class KinesisDataFetcherTest {
 
         assertEquals(
                 expectedRecords,
-                getRecordsRetrievalStrategy.getRecords(MAX_RECORDS).records());
+                getRecordsRetrievalStrategy.getRecordsAdapter(MAX_RECORDS).records());
         verify(kinesisClient, times(1)).getShardIterator(any(GetShardIteratorRequest.class));
         verify(kinesisClient, times(1)).getRecords(any(GetRecordsRequest.class));
     }

--- a/amazon-kinesis-client/src/test/java/software/amazon/kinesis/retrieval/polling/PrefetchRecordsPublisherIntegrationTest.java
+++ b/amazon-kinesis-client/src/test/java/software/amazon/kinesis/retrieval/polling/PrefetchRecordsPublisherIntegrationTest.java
@@ -46,9 +46,7 @@ import software.amazon.kinesis.lifecycle.events.ProcessRecordsInput;
 import software.amazon.kinesis.metrics.MetricsFactory;
 import software.amazon.kinesis.metrics.NullMetricsFactory;
 import software.amazon.kinesis.retrieval.DataFetcherResult;
-import software.amazon.kinesis.retrieval.GetRecordsResponseAdapter;
 import software.amazon.kinesis.retrieval.GetRecordsRetrievalStrategy;
-import software.amazon.kinesis.retrieval.KinesisGetRecordsResponseAdapter;
 import software.amazon.kinesis.retrieval.RecordsRetrieved;
 import software.amazon.kinesis.retrieval.ThrottlingReporter;
 import software.amazon.kinesis.retrieval.kpl.ExtendedSequenceNumber;
@@ -309,12 +307,11 @@ public class PrefetchRecordsPublisherIntegrationTest {
 
         @Override
         public DataFetcherResult getRecords() {
-            GetRecordsResponseAdapter getRecordsResult =
-                    new KinesisGetRecordsResponseAdapter(GetRecordsResponse.builder()
-                            .records(new ArrayList<>(records))
-                            .nextShardIterator(nextShardIterator)
-                            .millisBehindLatest(1000L)
-                            .build());
+            GetRecordsResponse getRecordsResult = GetRecordsResponse.builder()
+                    .records(new ArrayList<>(records))
+                    .nextShardIterator(nextShardIterator)
+                    .millisBehindLatest(1000L)
+                    .build();
 
             return new AdvancingResult(getRecordsResult);
         }


### PR DESCRIPTION

*Issue #, if available:*

*Description of changes:*

Some methods were removed as part of this PR: https://github.com/awslabs/amazon-kinesis-client/pull/1479 causing backward compatibility issues. Fixing them in this PR

- Marking the methods which return GetRecordsResponse as deperecated
- Added a new method `getRecordsAdapter` in the RetrievalStrategy
- PrefetchRecordsPublisher will now call `getRecordsAdapter` of `GetRecordsRetrievalStrategy` to fetch records

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
