### PR TITLE
Preparing for release v3.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ For **1.x** release notes, please see [v1.x/CHANGELOG.md](https://github.com/aws
 For **2.x** release notes, please see [v2.x/CHANGELOG.md](https://github.com/awslabs/amazon-kinesis-client/blob/v2.x/CHANGELOG.md)
 
 ---
-### Release (3.1.0 - June 05, 2025)
+### Release (3.1.0 - June 09, 2025)
 * [#1485](https://github.com/awslabs/amazon-kinesis-client/pull/1485) Fixing backward compatibility issue in RecordsFetcherFactory
 * [#1481](https://github.com/awslabs/amazon-kinesis-client/pull/1481) Convert awssdk object to lease early to release memory
 * [#1480](https://github.com/awslabs/amazon-kinesis-client/pull/1480) Added the ability to control sleep time in recordsfetcher

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ For **2.x** release notes, please see [v2.x/CHANGELOG.md](https://github.com/aws
 
 ---
 ### Release (3.1.0 - June 05, 2025)
+* [#1485](https://github.com/awslabs/amazon-kinesis-client/pull/1485) Fixing backward compatibility issue in RecordsFetcherFactory
 * [#1481](https://github.com/awslabs/amazon-kinesis-client/pull/1481) Convert awssdk object to lease early to release memory
 * [#1480](https://github.com/awslabs/amazon-kinesis-client/pull/1480) Added the ability to control sleep time in recordsfetcher
 * [#1479](https://github.com/awslabs/amazon-kinesis-client/pull/1479) Overriding the DataFetcher to return a custom GetRecordsResponseAdapter so that customers can have custom logic to send data to KinesisClientRecord

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,12 @@ For **2.x** release notes, please see [v2.x/CHANGELOG.md](https://github.com/aws
 ---
 ### Release (3.1.0 - June 09, 2025)
 * [#1485](https://github.com/awslabs/amazon-kinesis-client/pull/1485) Fixing backward compatibility issue in RecordsFetcherFactory
+* [#1484](https://github.com/awslabs/amazon-kinesis-client/pull/1484) Ensuring backward compatibilty by putting back the removed interfaces in the DataFetcher component
 * [#1481](https://github.com/awslabs/amazon-kinesis-client/pull/1481) Convert awssdk object to lease early to release memory
-* [#1480](https://github.com/awslabs/amazon-kinesis-client/pull/1480) Added the ability to control sleep time in recordsfetcher
+* [#1480](https://github.com/awslabs/amazon-kinesis-client/pull/1480) Having a way to control sleep time in recordsfetcher
 * [#1479](https://github.com/awslabs/amazon-kinesis-client/pull/1479) Overriding the DataFetcher to return a custom GetRecordsResponseAdapter so that customers can have custom logic to send data to KinesisClientRecord
 * [#1478](https://github.com/awslabs/amazon-kinesis-client/pull/1478) Bump commons-beanutils:commons-beanutils from 1.9.4 to 1.11.0 in /amazon-kinesis-client-multilang
-
+* 
 ### Release 3.0.3 (May 7, 2025)
 * [#1464](https://github.com/awslabs/amazon-kinesis-client/pull/1464) Add config for LeaseAssignmentManager frequency and improve assignment time of newly created leases
 * [#1463](https://github.com/awslabs/amazon-kinesis-client/pull/1463) Extend ShardConsumer constructor to have ConsumerTaskFactory as a parameter to support [DynamoDB Streams Kinesis Adapter](https://github.com/awslabs/dynamodb-streams-kinesis-adapter) compatibility

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ For **1.x** release notes, please see [v1.x/CHANGELOG.md](https://github.com/aws
 For **2.x** release notes, please see [v2.x/CHANGELOG.md](https://github.com/awslabs/amazon-kinesis-client/blob/v2.x/CHANGELOG.md)
 
 ---
+### Release (3.1.0 - June 05, 2025)
+* [#1481](https://github.com/awslabs/amazon-kinesis-client/pull/1481) Convert awssdk object to lease early to release memory
+* [#1480](https://github.com/awslabs/amazon-kinesis-client/pull/1480) Added the ability to control sleep time in recordsfetcher
+* [#1479](https://github.com/awslabs/amazon-kinesis-client/pull/1479) Overriding the DataFetcher to return a custom GetRecordsResponseAdapter so that customers can have custom logic to send data to KinesisClientRecord
+* [#1478](https://github.com/awslabs/amazon-kinesis-client/pull/1478) Bump commons-beanutils:commons-beanutils from 1.9.4 to 1.11.0 in /amazon-kinesis-client-multilang
+
 ### Release 3.0.3 (May 7, 2025)
 * [#1464](https://github.com/awslabs/amazon-kinesis-client/pull/1464) Add config for LeaseAssignmentManager frequency and improve assignment time of newly created leases
 * [#1463](https://github.com/awslabs/amazon-kinesis-client/pull/1463) Extend ShardConsumer constructor to have ConsumerTaskFactory as a parameter to support [DynamoDB Streams Kinesis Adapter](https://github.com/awslabs/dynamodb-streams-kinesis-adapter) compatibility

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,11 @@ For **2.x** release notes, please see [v2.x/CHANGELOG.md](https://github.com/aws
 
 ---
 ### Release (3.1.0 - June 09, 2025)
-* [#1485](https://github.com/awslabs/amazon-kinesis-client/pull/1485) Fixing backward compatibility issue in RecordsFetcherFactory
-* [#1484](https://github.com/awslabs/amazon-kinesis-client/pull/1484) Ensuring backward compatibilty by putting back the removed interfaces in the DataFetcher component
 * [#1481](https://github.com/awslabs/amazon-kinesis-client/pull/1481) Convert awssdk object to lease early to release memory
 * [#1480](https://github.com/awslabs/amazon-kinesis-client/pull/1480) Having a way to control sleep time in recordsfetcher
 * [#1479](https://github.com/awslabs/amazon-kinesis-client/pull/1479) Overriding the DataFetcher to return a custom GetRecordsResponseAdapter so that customers can have custom logic to send data to KinesisClientRecord
 * [#1478](https://github.com/awslabs/amazon-kinesis-client/pull/1478) Bump commons-beanutils:commons-beanutils from 1.9.4 to 1.11.0 in /amazon-kinesis-client-multilang
-* 
+
 ### Release 3.0.3 (May 7, 2025)
 * [#1464](https://github.com/awslabs/amazon-kinesis-client/pull/1464) Add config for LeaseAssignmentManager frequency and improve assignment time of newly created leases
 * [#1463](https://github.com/awslabs/amazon-kinesis-client/pull/1463) Extend ShardConsumer constructor to have ConsumerTaskFactory as a parameter to support [DynamoDB Streams Kinesis Adapter](https://github.com/awslabs/dynamodb-streams-kinesis-adapter) compatibility

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ For **2.x** release notes, please see [v2.x/CHANGELOG.md](https://github.com/aws
 ---
 ### Release (3.1.0 - June 09, 2025)
 * [#1481](https://github.com/awslabs/amazon-kinesis-client/pull/1481) Convert awssdk object to lease early to release memory
-* [#1480](https://github.com/awslabs/amazon-kinesis-client/pull/1480) Having a way to control sleep time in recordsfetcher
+* [#1480](https://github.com/awslabs/amazon-kinesis-client/pull/1480) Added the ability to control sleep time in recordsfetcher
 * [#1479](https://github.com/awslabs/amazon-kinesis-client/pull/1479) Overriding the DataFetcher to return a custom GetRecordsResponseAdapter so that customers can have custom logic to send data to KinesisClientRecord
 * [#1478](https://github.com/awslabs/amazon-kinesis-client/pull/1478) Bump commons-beanutils:commons-beanutils from 1.9.4 to 1.11.0 in /amazon-kinesis-client-multilang
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ The recommended way to use the KCL for Java is to consume it from Maven.
   <dependency>
       <groupId>software.amazon.kinesis</groupId>
       <artifactId>amazon-kinesis-client</artifactId>
-      <version>3.0.3</version>
+      <version>3.1.0</version>
   </dependency>
   ```
 

--- a/amazon-kinesis-client-multilang/pom.xml
+++ b/amazon-kinesis-client-multilang/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>amazon-kinesis-client-pom</artifactId>
     <groupId>software.amazon.kinesis</groupId>
-    <version>3.0.3</version>
+    <version>3.1.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/amazon-kinesis-client/pom.xml
+++ b/amazon-kinesis-client/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>software.amazon.kinesis</groupId>
     <artifactId>amazon-kinesis-client-pom</artifactId>
-    <version>3.0.3</version>
+    <version>3.1.0</version>
   </parent>
 
   <artifactId>amazon-kinesis-client</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
   <artifactId>amazon-kinesis-client-pom</artifactId>
   <packaging>pom</packaging>
   <name>Amazon Kinesis Client Library</name>
-  <version>3.0.3</version>
+  <version>3.1.0</version>
   <description>The Amazon Kinesis Client Library for Java enables Java developers to easily consume and process data
     from Amazon Kinesis.
   </description>


### PR DESCRIPTION
### Release (3.1.0 - June 09, 2025)
* [#1481](https://github.com/awslabs/amazon-kinesis-client/pull/1481) Convert awssdk object to lease early to release memory
* [#1480](https://github.com/awslabs/amazon-kinesis-client/pull/1480) Added the ability to control sleep time in recordsfetcher
* [#1479](https://github.com/awslabs/amazon-kinesis-client/pull/1479) Overriding the DataFetcher to return a custom GetRecordsResponseAdapter so that customers can have custom logic to send data to KinesisClientRecord
* [#1478](https://github.com/awslabs/amazon-kinesis-client/pull/1478) Bump commons-beanutils:commons-beanutils from 1.9.4 to 1.11.0 in /amazon-kinesis-client-multilang