### PR TITLE
Fixed plugin related to skipping tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,9 +51,9 @@ To disable running unit tests in the build, add the property `-Dskip.ut=true`.
 Note that running integration tests creates AWS resources.
 Integration tests require valid AWS credentials.
 This will look for a default AWS profile specified in your local `.aws/credentials`.
-To run all integration tests: `mvn verify -DskipITs=false`.
-To run one integration tests, specify the integration test class: `mvn -Dit.test="BasicStreamConsumerIntegrationTest" -DskipITs=false verify`
-Optionally, you can provide the name of an IAM user/role to run tests with as a string using this command: `mvn -DskipITs=false -DawsProfile="<PROFILE_NAME>" verify`.
+To run all integration tests: `mvn verify -DskipTests=false`.
+To run one integration tests, specify the integration test class: `mvn -Dit.test="BasicStreamConsumerIntegrationTest" -DskipTests=false verify`
+Optionally, you can provide the name of an IAM user/role to run tests with as a string using this command: `mvn -DskipTests=false -DawsProfile="<PROFILE_NAME>" verify`.
 
 ## Integration with the Kinesis Producer Library
 For producer-side developers using the **[Kinesis Producer Library (KPL)][kinesis-guide-kpl]**, the KCL integrates without additional effort. When the KCL retrieves an aggregated Amazon Kinesis record consisting of multiple KPL user records, it will automatically invoke the KPL to extract the individual user records before returning them to the user.

--- a/README.md
+++ b/README.md
@@ -44,16 +44,16 @@ After you have downloaded the code from GitHub, you can build it using Maven. To
 this command: `mvn clean install -Dgpg.skip=true`.
 Note: This command does not run integration tests.
 
-To disable running unit tests in the build, add the property `-Dskip.ut=true`.
+To disable running unit tests in the build, add the property `-DskipUT=true`.
 
 ## Running Integration Tests
 
 Note that running integration tests creates AWS resources.
 Integration tests require valid AWS credentials.
 This will look for a default AWS profile specified in your local `.aws/credentials`.
-To run all integration tests: `mvn verify -DskipTests=false`.
-To run one integration tests, specify the integration test class: `mvn -Dit.test="BasicStreamConsumerIntegrationTest" -DskipTests=false verify`
-Optionally, you can provide the name of an IAM user/role to run tests with as a string using this command: `mvn -DskipTests=false -DawsProfile="<PROFILE_NAME>" verify`.
+To run all integration tests: `mvn verify -DskipIT=false`.
+To run one integration tests, specify the integration test class: `mvn -Dit.test="BasicStreamConsumerIntegrationTest" -DskipIT=false verify`
+Optionally, you can provide the name of an IAM user/role to run tests with as a string using this command: `mvn -DskipIT=false -DawsProfile="<PROFILE_NAME>" verify`.
 
 ## Integration with the Kinesis Producer Library
 For producer-side developers using the **[Kinesis Producer Library (KPL)][kinesis-guide-kpl]**, the KCL integrates without additional effort. When the KCL retrieves an aggregated Amazon Kinesis record consisting of multiple KPL user records, it will automatically invoke the KPL to extract the individual user records before returning them to the user.

--- a/README.md
+++ b/README.md
@@ -44,16 +44,16 @@ After you have downloaded the code from GitHub, you can build it using Maven. To
 this command: `mvn clean install -Dgpg.skip=true`.
 Note: This command does not run integration tests.
 
-To disable running unit tests in the build, add the property `-DskipUT=true`.
+To disable running unit tests in the build, add the property `-DskipUTs=true`.
 
 ## Running Integration Tests
 
 Note that running integration tests creates AWS resources.
 Integration tests require valid AWS credentials.
 This will look for a default AWS profile specified in your local `.aws/credentials`.
-To run all integration tests: `mvn verify -DskipIT=false`.
-To run one integration tests, specify the integration test class: `mvn -Dit.test="BasicStreamConsumerIntegrationTest" -DskipIT=false verify`
-Optionally, you can provide the name of an IAM user/role to run tests with as a string using this command: `mvn -DskipIT=false -DawsProfile="<PROFILE_NAME>" verify`.
+To run all integration tests: `mvn verify -DskipITs=false`.
+To run one integration tests, specify the integration test class: `mvn -Dit.test="BasicStreamConsumerIntegrationTest" -DskipITs=false verify`
+Optionally, you can provide the name of an IAM user/role to run tests with as a string using this command: `mvn -DskipITs=false -DawsProfile="<PROFILE_NAME>" verify`.
 
 ## Integration with the Kinesis Producer Library
 For producer-side developers using the **[Kinesis Producer Library (KPL)][kinesis-guide-kpl]**, the KCL integrates without additional effort. When the KCL retrieves an aggregated Amazon Kinesis record consisting of multiple KPL user records, it will automatically invoke the KPL to extract the individual user records before returning them to the user.

--- a/amazon-kinesis-client/pom.xml
+++ b/amazon-kinesis-client/pom.xml
@@ -54,7 +54,8 @@
     <sqlite4java.libpath>${project.build.directory}/test-lib</sqlite4java.libpath>
     <slf4j.version>2.0.13</slf4j.version>
     <gsr.version>1.1.19</gsr.version>
-    <skipTests>true</skipTests>
+    <skipUT>false</skipUT>
+    <skipIT>true</skipIT>
   </properties>
 
   <dependencies>
@@ -349,7 +350,7 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <version>3.2.5</version>
         <configuration>
-          <skipTests>${skipTests}</skipTests>
+          <skipTests>${skipUT}</skipTests>
           <excludes>
             <exclude>**/*IntegrationTest.java</exclude>
           </excludes>
@@ -364,7 +365,7 @@
         <artifactId>maven-failsafe-plugin</artifactId>
         <version>3.2.5</version>
         <configuration>
-          <skipITs>${skipTests}</skipITs>
+          <skipITs>${skipIT}</skipITs>
           <includes>
             <include>**/*IntegrationTest.java</include>
           </includes>

--- a/amazon-kinesis-client/pom.xml
+++ b/amazon-kinesis-client/pom.xml
@@ -54,8 +54,8 @@
     <sqlite4java.libpath>${project.build.directory}/test-lib</sqlite4java.libpath>
     <slf4j.version>2.0.13</slf4j.version>
     <gsr.version>1.1.19</gsr.version>
-    <skipUT>false</skipUT>
-    <skipIT>true</skipIT>
+    <skipUTs>false</skipUTs>
+    <skipITs>true</skipITs>
   </properties>
 
   <dependencies>
@@ -350,7 +350,7 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <version>3.2.5</version>
         <configuration>
-          <skipTests>${skipUT}</skipTests>
+          <skipTests>${skipUTs}</skipTests>
           <excludes>
             <exclude>**/*IntegrationTest.java</exclude>
           </excludes>
@@ -365,7 +365,7 @@
         <artifactId>maven-failsafe-plugin</artifactId>
         <version>3.2.5</version>
         <configuration>
-          <skipITs>${skipIT}</skipITs>
+          <skipITs>${skipITs}</skipITs>
           <includes>
             <include>**/*IntegrationTest.java</include>
           </includes>

--- a/amazon-kinesis-client/pom.xml
+++ b/amazon-kinesis-client/pom.xml
@@ -54,7 +54,7 @@
     <sqlite4java.libpath>${project.build.directory}/test-lib</sqlite4java.libpath>
     <slf4j.version>2.0.13</slf4j.version>
     <gsr.version>1.1.19</gsr.version>
-    <skipITs>true</skipITs>
+    <skipTests>true</skipTests>
   </properties>
 
   <dependencies>
@@ -349,8 +349,7 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <version>3.2.5</version>
         <configuration>
-          <skipTests>${skip.ut}</skipTests>
-          <skipITs>${skipITs}</skipITs>
+          <skipTests>${skipTests}</skipTests>
           <excludes>
             <exclude>**/*IntegrationTest.java</exclude>
           </excludes>
@@ -365,6 +364,7 @@
         <artifactId>maven-failsafe-plugin</artifactId>
         <version>3.2.5</version>
         <configuration>
+          <skipITs>${skipTests}</skipITs>
           <includes>
             <include>**/*IntegrationTest.java</include>
           </includes>


### PR DESCRIPTION
### Background
Currently, the actual skip tests functionality was broken as ``<skipITs>${skipITs}</skipITs>`` is part of ``maven-failsafe-plugin`` and not ``maven-surefire-plugin``

Because of this, running ``mvn install`` leads to 
```
[WARNING] Parameter 'skipITs' is unknown for plugin 'maven-surefire-plugin:3.2.5:test (default-test)'
```