### PR TITLE
Updated software.amazon.awssdk.annoations dependency

### DIFF
--- a/amazon-kinesis-client/pom.xml
+++ b/amazon-kinesis-client/pom.xml
@@ -186,7 +186,7 @@
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>annotations</artifactId>
-      <version>2.25.64</version>
+      <version>${awssdk.version}</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>


### PR DESCRIPTION
Updated software.amazon.awssdk.annoations dependency to use the same SDK Version as others. This is to ensure that when the AWS SDK gets upgraded, all dependencies do as well.