### PR TITLE
Decrease DDB lease renewal verbosity

### DIFF
--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/leases/dynamodb/DynamoDBLeaseRenewer.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/leases/dynamodb/DynamoDBLeaseRenewer.java
@@ -354,7 +354,7 @@ public class DynamoDBLeaseRenewer implements LeaseRenewer {
         boolean success = false;
         Lease authoritativeLeaseCopy = authoritativeLease.copy();
         try {
-            log.info("Updating lease from {} to {}", authoritativeLease, lease);
+            log.debug("Updating lease from {} to {}", authoritativeLease, lease);
             synchronized (authoritativeLease) {
                 authoritativeLease.update(lease);
                 boolean updatedLease = leaseRefresher.updateLease(authoritativeLease);


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Currently, for every lease renewal, there are two messages logged at INFO level:
 - [DynamoDBLeaseRenewer.java @ line 357](https://github.com/awslabs/amazon-kinesis-client/blob/master/amazon-kinesis-client/src/main/java/software/amazon/kinesis/leases/dynamodb/DynamoDBLeaseRenewer.java#L357) - resulting message length ~1578 characters 
 - [DynamoDBLeaseRefresher.java @ line 1357](https://github.com/awslabs/amazon-kinesis-client/blob/master/amazon-kinesis-client/src/main/java/software/amazon/kinesis/leases/dynamodb/DynamoDBLeaseRefresher.java#L1357) - resulting message length ~35 characters

This seems a little excessive. IMO, a library, in normal operation, with no anomalies (in the context of these classes, meaning network errors, lease stealing, etc.), should log little to nothing at INFO after initialization.

So this PR sets the log level of the first log event, the more verbose of the two, to be DEBUG.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
