### PR TITLE
Add consumer ID as the hashed lease table arn in UserAgent for Kinesis requests

### DIFF
--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/common/KinesisRequestsBuilder.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/common/KinesisRequestsBuilder.java
@@ -37,6 +37,10 @@ public class KinesisRequestsBuilder {
         return appendUserAgent(ListShardsRequest.builder());
     }
 
+    public static ListShardsRequest.Builder listShardsRequestBuilder(String consumerId) {
+        return appendUserAgent(ListShardsRequest.builder(), consumerId);
+    }
+
     public static SubscribeToShardRequest.Builder subscribeToShardRequestBuilder() {
         return appendUserAgent(SubscribeToShardRequest.builder());
     }
@@ -45,8 +49,16 @@ public class KinesisRequestsBuilder {
         return appendUserAgent(GetRecordsRequest.builder());
     }
 
+    public static GetRecordsRequest.Builder getRecordsRequestBuilder(String consumerId) {
+        return appendUserAgent(GetRecordsRequest.builder(), consumerId);
+    }
+
     public static GetShardIteratorRequest.Builder getShardIteratorRequestBuilder() {
         return appendUserAgent(GetShardIteratorRequest.builder());
+    }
+
+    public static GetShardIteratorRequest.Builder getShardIteratorRequestBuilder(String consumerId) {
+        return appendUserAgent(GetShardIteratorRequest.builder(), consumerId);
     }
 
     public static DescribeStreamSummaryRequest.Builder describeStreamSummaryRequestBuilder() {
@@ -66,6 +78,16 @@ public class KinesisRequestsBuilder {
         return (T) builder.overrideConfiguration(AwsRequestOverrideConfiguration.builder()
                 .addApiName(ApiName.builder()
                         .name(RetrievalConfig.KINESIS_CLIENT_LIB_USER_AGENT)
+                        .version(RetrievalConfig.KINESIS_CLIENT_LIB_USER_AGENT_VERSION)
+                        .build())
+                .build());
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T extends AwsRequest.Builder> T appendUserAgent(final T builder, String consumerId) {
+        return (T) builder.overrideConfiguration(AwsRequestOverrideConfiguration.builder()
+                .addApiName(ApiName.builder()
+                        .name(String.format("%s-%s", RetrievalConfig.KINESIS_CLIENT_LIB_USER_AGENT, consumerId))
                         .version(RetrievalConfig.KINESIS_CLIENT_LIB_USER_AGENT_VERSION)
                         .build())
                 .build());

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/common/UserAgentUtils.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/common/UserAgentUtils.java
@@ -1,0 +1,38 @@
+package software.amazon.kinesis.common;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Base64;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+
+@Slf4j
+public class UserAgentUtils {
+    private static final String CONSUMER_ID_PREFIX = "KCL-ConsumerId-";
+    private static final String HASH_ALGORITHM = "SHA-256";
+
+    public static String generateConsumerId(String tableArn) {
+        if (StringUtils.isEmpty(tableArn)) {
+            log.warn("Table ARN is empty, cannot generate consumer ID");
+            return null;
+        }
+
+        try {
+            MessageDigest digest = MessageDigest.getInstance(HASH_ALGORITHM);
+            byte[] hashBytes = digest.digest(tableArn.getBytes(StandardCharsets.UTF_8));
+            String hash = Base64.getEncoder().encodeToString(hashBytes);
+            // Use only a portion of the hash to keep the UserAgent header reasonably sized
+            String shortHash = hash.substring(0, Math.min(hash.length(), 16));
+            return CONSUMER_ID_PREFIX + shortHash;
+        } catch (NoSuchAlgorithmException e) {
+            log.error("Failed to generate consumer ID due to hashing algorithm error", e);
+            return null;
+        }
+    }
+
+    public static String getConsumerId(String tableArn) {
+        return generateConsumerId(tableArn);
+    }
+}

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/leases/LeaseCoordinator.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/leases/LeaseCoordinator.java
@@ -161,4 +161,10 @@ public interface LeaseCoordinator {
      * @return instance of {@link LeaseStatsRecorder}
      */
     LeaseStatsRecorder leaseStatsRecorder();
+
+    /**
+     * @return consumerId The consumerId of the lease table. For {@link DynamoDBLeaseCoordinator}, this is the
+     * hash of the lease table arn
+     */
+    String getConsumerId();
 }

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/leases/LeaseRefresher.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/leases/LeaseRefresher.java
@@ -350,4 +350,8 @@ public interface LeaseRefresher {
      */
     ExtendedSequenceNumber getCheckpoint(String leaseKey)
             throws ProvisionedThroughputException, InvalidStateException, DependencyException;
+
+    default String getLeaseTableIdentifier() throws DependencyException {
+        return "";
+    }
 }

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/leases/ShardDetector.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/leases/ShardDetector.java
@@ -47,6 +47,15 @@ public interface ShardDetector {
     List<Shard> listShards();
 
     /**
+     * List shards.
+     *
+     * @return Shards
+     */
+    default List<Shard> listShards(String consumerId) {
+        return listShards();
+    }
+
+    /**
      * This method behaves exactly similar to listShards except the fact that this does not consume and throw
      * ResourceNotFoundException instead of returning empty list.
      *
@@ -57,12 +66,32 @@ public interface ShardDetector {
     }
 
     /**
+     * This method behaves exactly similar to listShards except the fact that this does not consume and throw
+     * ResourceNotFoundException instead of returning empty list.
+     *
+     * @return Shards
+     */
+    default List<Shard> listShardsWithoutConsumingResourceNotFoundException(String consumerId) {
+        throw new UnsupportedOperationException("listShardsWithoutConsumingResourceNotFoundException not implemented");
+    }
+
+    /**
      * List shards with shard filter.
      *
      * @param shardFilter
      * @return Shards
      */
     default List<Shard> listShardsWithFilter(ShardFilter shardFilter) {
+        throw new UnsupportedOperationException("listShardsWithFilter not available.");
+    }
+
+    /**
+     * List shards with shard filter.
+     *
+     * @param shardFilter
+     * @return Shards
+     */
+    default List<Shard> listShardsWithFilter(ShardFilter shardFilter, String consumerId) {
         throw new UnsupportedOperationException("listShardsWithFilter not available.");
     }
 

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/leases/dynamodb/DynamoDBLeaseCoordinator.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/leases/dynamodb/DynamoDBLeaseCoordinator.java
@@ -31,6 +31,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import software.amazon.kinesis.annotations.KinesisClientInternalApi;
@@ -102,6 +103,9 @@ public class DynamoDBLeaseCoordinator implements LeaseCoordinator {
     private ScheduledExecutorService leaseCoordinatorThreadPool;
     private ScheduledFuture<?> leaseDiscoveryFuture;
     private ScheduledFuture<?> takerFuture;
+
+    @Getter
+    private String consumerId;
 
     private volatile boolean running = false;
 
@@ -273,6 +277,7 @@ public class DynamoDBLeaseCoordinator implements LeaseCoordinator {
         if (!isTableActive) {
             throw new DependencyException(new IllegalStateException("Creating table timeout"));
         }
+        this.consumerId = leaseRefresher.getLeaseTableIdentifier();
     }
 
     @Override

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/leases/dynamodb/DynamoDBLeaseRefresher.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/leases/dynamodb/DynamoDBLeaseRefresher.java
@@ -76,6 +76,7 @@ import software.amazon.kinesis.annotations.KinesisClientInternalApi;
 import software.amazon.kinesis.common.DdbTableConfig;
 import software.amazon.kinesis.common.FutureUtils;
 import software.amazon.kinesis.common.StreamIdentifier;
+import software.amazon.kinesis.common.UserAgentUtils;
 import software.amazon.kinesis.leases.DynamoUtils;
 import software.amazon.kinesis.leases.Lease;
 import software.amazon.kinesis.leases.LeaseRefresher;
@@ -1403,6 +1404,12 @@ public class DynamoDBLeaseRefresher implements LeaseRefresher {
             checkpoint = lease.checkpoint();
         }
         return checkpoint;
+    }
+
+    @Override
+    public String getLeaseTableIdentifier() throws DependencyException {
+        DescribeTableResponse response = describeLeaseTable();
+        return nonNull(response) ? UserAgentUtils.getConsumerId(response.table().tableArn()) : "";
     }
 
     /*

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/lifecycle/ShardConsumerArgument.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/lifecycle/ShardConsumerArgument.java
@@ -89,4 +89,115 @@ public class ShardConsumerArgument {
 
     private final LeaseCleanupManager leaseCleanupManager;
     private final SchemaRegistryDecoder schemaRegistryDecoder;
+
+    /**
+     * Consumer ID generated from lease table ARN to uniquely identify this KCL application
+     */
+    private String consumerId;
+
+    public ShardConsumerArgument(
+            @NonNull ShardInfo shardInfo,
+            @NonNull StreamIdentifier streamIdentifier,
+            LeaseCoordinator leaseCoordinator,
+            ExecutorService executorService,
+            RecordsPublisher recordsPublisher,
+            ShardRecordProcessor shardRecordProcessor,
+            Checkpointer checkpoint,
+            ShardRecordProcessorCheckpointer recordProcessorCheckpointer,
+            long parentShardPollIntervalMillis,
+            long taskBackoffTimeMillis,
+            boolean skipShardSyncAtWorkerInitializationIfLeasesExist,
+            long listShardsBackoffTimeMillis,
+            int maxListShardsRetryAttempts,
+            boolean shouldCallProcessRecordsEvenForEmptyRecordList,
+            long idleTimeInMilliseconds,
+            InitialPositionInStreamExtended initialPositionInStream,
+            boolean cleanupLeasesUponShardCompletion,
+            boolean ignoreUnexpectedChildShards,
+            ShardDetector shardDetector,
+            AggregatorUtil aggregatorUtil,
+            HierarchicalShardSyncer hierarchicalShardSyncer,
+            MetricsFactory metricsFactory,
+            @NonNull LeaseCleanupManager leaseCleanupManager,
+            SchemaRegistryDecoder schemaRegistryDecoder) {
+        this(
+                shardInfo,
+                streamIdentifier,
+                leaseCoordinator,
+                executorService,
+                recordsPublisher,
+                shardRecordProcessor,
+                checkpoint,
+                recordProcessorCheckpointer,
+                parentShardPollIntervalMillis,
+                taskBackoffTimeMillis,
+                skipShardSyncAtWorkerInitializationIfLeasesExist,
+                listShardsBackoffTimeMillis,
+                maxListShardsRetryAttempts,
+                shouldCallProcessRecordsEvenForEmptyRecordList,
+                idleTimeInMilliseconds,
+                initialPositionInStream,
+                cleanupLeasesUponShardCompletion,
+                ignoreUnexpectedChildShards,
+                shardDetector,
+                aggregatorUtil,
+                hierarchicalShardSyncer,
+                metricsFactory,
+                leaseCleanupManager,
+                schemaRegistryDecoder,
+                null);
+    }
+
+    public ShardConsumerArgument(
+            @NonNull ShardInfo shardInfo,
+            @NonNull StreamIdentifier streamIdentifier,
+            LeaseCoordinator leaseCoordinator,
+            ExecutorService executorService,
+            RecordsPublisher recordsPublisher,
+            ShardRecordProcessor shardRecordProcessor,
+            Checkpointer checkpoint,
+            ShardRecordProcessorCheckpointer recordProcessorCheckpointer,
+            long parentShardPollIntervalMillis,
+            long taskBackoffTimeMillis,
+            boolean skipShardSyncAtWorkerInitializationIfLeasesExist,
+            long listShardsBackoffTimeMillis,
+            int maxListShardsRetryAttempts,
+            boolean shouldCallProcessRecordsEvenForEmptyRecordList,
+            long idleTimeInMilliseconds,
+            InitialPositionInStreamExtended initialPositionInStream,
+            boolean cleanupLeasesUponShardCompletion,
+            boolean ignoreUnexpectedChildShards,
+            ShardDetector shardDetector,
+            AggregatorUtil aggregatorUtil,
+            HierarchicalShardSyncer hierarchicalShardSyncer,
+            MetricsFactory metricsFactory,
+            @NonNull LeaseCleanupManager leaseCleanupManager,
+            SchemaRegistryDecoder schemaRegistryDecoder,
+            String consumerId) {
+        this.shardInfo = shardInfo;
+        this.streamIdentifier = streamIdentifier;
+        this.leaseCoordinator = leaseCoordinator;
+        this.executorService = executorService;
+        this.recordsPublisher = recordsPublisher;
+        this.shardRecordProcessor = shardRecordProcessor;
+        this.checkpoint = checkpoint;
+        this.recordProcessorCheckpointer = recordProcessorCheckpointer;
+        this.parentShardPollIntervalMillis = parentShardPollIntervalMillis;
+        this.taskBackoffTimeMillis = taskBackoffTimeMillis;
+        this.skipShardSyncAtWorkerInitializationIfLeasesExist = skipShardSyncAtWorkerInitializationIfLeasesExist;
+        this.listShardsBackoffTimeInMillis = listShardsBackoffTimeMillis;
+        this.maxListShardsRetryAttempts = maxListShardsRetryAttempts;
+        this.shouldCallProcessRecordsEvenForEmptyRecordList = shouldCallProcessRecordsEvenForEmptyRecordList;
+        this.idleTimeInMilliseconds = idleTimeInMilliseconds;
+        this.initialPositionInStream = initialPositionInStream;
+        this.cleanupLeasesOfCompletedShards = cleanupLeasesUponShardCompletion;
+        this.ignoreUnexpectedChildShards = ignoreUnexpectedChildShards;
+        this.shardDetector = shardDetector;
+        this.aggregatorUtil = aggregatorUtil;
+        this.hierarchicalShardSyncer = hierarchicalShardSyncer;
+        this.metricsFactory = metricsFactory;
+        this.leaseCleanupManager = leaseCleanupManager;
+        this.schemaRegistryDecoder = schemaRegistryDecoder;
+        this.consumerId = consumerId;
+    }
 }

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/DataFetcherProviderConfig.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/DataFetcherProviderConfig.java
@@ -46,4 +46,6 @@ public interface DataFetcherProviderConfig {
      * Gets timeout for kinesis request.
      */
     Duration getKinesisRequestTimeout();
+
+    String consumerId();
 }

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/KinesisDataFetcherProviderConfig.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/KinesisDataFetcherProviderConfig.java
@@ -19,6 +19,8 @@ import java.time.Duration;
 
 import lombok.Data;
 import lombok.NonNull;
+import lombok.experimental.Accessors;
+import org.jetbrains.annotations.NotNull;
 import software.amazon.kinesis.common.StreamIdentifier;
 import software.amazon.kinesis.metrics.MetricsFactory;
 
@@ -42,4 +44,31 @@ public class KinesisDataFetcherProviderConfig implements DataFetcherProviderConf
 
     @NonNull
     private Duration kinesisRequestTimeout;
+
+    @Accessors(fluent = true)
+    private String consumerId;
+
+    public KinesisDataFetcherProviderConfig(
+            @NonNull StreamIdentifier streamIdentifier,
+            @NonNull String shardId,
+            @NonNull MetricsFactory metricsFactory,
+            int maxRecords,
+            @NonNull Duration kinesisRequestTimeout) {
+        this(streamIdentifier, shardId, metricsFactory, maxRecords, kinesisRequestTimeout, "");
+    }
+
+    public KinesisDataFetcherProviderConfig(
+            @NonNull StreamIdentifier streamIdentifier,
+            @NotNull String shardId,
+            @NonNull MetricsFactory metricsFactory,
+            int maxRecords,
+            @NotNull Duration kinesisRequestTimeout,
+            String consumerId) {
+        this.streamIdentifier = streamIdentifier;
+        this.shardId = shardId;
+        this.metricsFactory = metricsFactory;
+        this.maxRecords = maxRecords;
+        this.kinesisRequestTimeout = kinesisRequestTimeout;
+        this.consumerId = consumerId;
+    }
 }

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/RetrievalFactory.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/RetrievalFactory.java
@@ -55,4 +55,9 @@ public interface RetrievalFactory {
             ShardInfo shardInfo, StreamConfig streamConfig, MetricsFactory metricsFactory) {
         return createGetRecordsCache(shardInfo, metricsFactory);
     }
+
+    default RecordsPublisher createGetRecordsCache(
+            ShardInfo shardInfo, StreamConfig streamConfig, MetricsFactory metricsFactory, String consumerId) {
+        return createGetRecordsCache(shardInfo, streamConfig, metricsFactory);
+    }
 }

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/polling/SynchronousBlockingRetrievalFactory.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/polling/SynchronousBlockingRetrievalFactory.java
@@ -90,6 +90,19 @@ public class SynchronousBlockingRetrievalFactory implements RetrievalFactory {
         return new SynchronousGetRecordsRetrievalStrategy(dataFetcher);
     }
 
+    private GetRecordsRetrievalStrategy createGetRecordsRetrievalStrategy(
+            @NonNull final ShardInfo shardInfo,
+            @NonNull final StreamIdentifier streamIdentifier,
+            @NonNull final MetricsFactory metricsFactory,
+            String consumerId) {
+        final DataFetcherProviderConfig kinesisDataFetcherProviderConfig = new KinesisDataFetcherProviderConfig(
+                streamIdentifier, shardInfo.shardId(), metricsFactory, maxRecords, kinesisRequestTimeout, consumerId);
+
+        final DataFetcher dataFetcher = this.dataFetcherProvider.apply(kinesisDataFetcherProviderConfig);
+
+        return new SynchronousGetRecordsRetrievalStrategy(dataFetcher);
+    }
+
     @Override
     public RecordsPublisher createGetRecordsCache(
             @NonNull final ShardInfo shardInfo,
@@ -97,6 +110,20 @@ public class SynchronousBlockingRetrievalFactory implements RetrievalFactory {
             @NonNull final MetricsFactory metricsFactory) {
         return recordsFetcherFactory.createRecordsFetcher(
                 createGetRecordsRetrievalStrategy(shardInfo, streamConfig.streamIdentifier(), metricsFactory),
+                shardInfo.shardId(),
+                metricsFactory,
+                maxRecords,
+                getSleepTimeController());
+    }
+
+    public RecordsPublisher createGetRecordsCache(
+            @NonNull final ShardInfo shardInfo,
+            @NonNull final StreamConfig streamConfig,
+            @NonNull final MetricsFactory metricsFactory,
+            String consumerId) {
+        return recordsFetcherFactory.createRecordsFetcher(
+                createGetRecordsRetrievalStrategy(
+                        shardInfo, streamConfig.streamIdentifier(), metricsFactory, consumerId),
                 shardInfo.shardId(),
                 metricsFactory,
                 maxRecords,

--- a/amazon-kinesis-client/src/test/java/software/amazon/kinesis/coordinator/SchedulerTest.java
+++ b/amazon-kinesis-client/src/test/java/software/amazon/kinesis/coordinator/SchedulerTest.java
@@ -148,6 +148,7 @@ public class SchedulerTest {
     private static final String TEST_SHARD_ID = "shardId-000000000001";
     private static final InitialPositionInStreamExtended TEST_INITIAL_POSITION =
             InitialPositionInStreamExtended.newInitialPosition(InitialPositionInStream.TRIM_HORIZON);
+    private static final String CONSUMER_ID = "CONSUMER_ID";
 
     private Scheduler scheduler;
     private ShardRecordProcessorFactory shardRecordProcessorFactory;
@@ -224,10 +225,11 @@ public class SchedulerTest {
                 new RetrievalConfig(kinesisClient, streamName, applicationName).retrievalFactory(retrievalFactory);
         when(leaseCoordinator.leaseRefresher()).thenReturn(dynamoDBLeaseRefresher);
         when(leaseCoordinator.workerIdentifier()).thenReturn(workerIdentifier);
+        when(leaseCoordinator.getConsumerId()).thenReturn(CONSUMER_ID);
         when(dynamoDBLeaseRefresher.waitUntilLeaseOwnerToLeaseKeyIndexExists(anyLong(), anyLong()))
                 .thenReturn(true);
         when(retrievalFactory.createGetRecordsCache(
-                        any(ShardInfo.class), any(StreamConfig.class), any(MetricsFactory.class)))
+                        any(ShardInfo.class), any(StreamConfig.class), any(MetricsFactory.class), anyString()))
                 .thenReturn(recordsPublisher);
         when(kinesisClient.serviceClientConfiguration())
                 .thenReturn(KinesisServiceClientConfiguration.builder()
@@ -1432,7 +1434,7 @@ public class SchedulerTest {
                 .createStreamConfig(StreamIdentifier.multiStreamInstance(streamIdentifierSerializationForOrphan));
 
         final ArgumentCaptor<StreamConfig> streamConfigArgumentCaptor = ArgumentCaptor.forClass(StreamConfig.class);
-        verify(retrievalFactory).createGetRecordsCache(any(), streamConfigArgumentCaptor.capture(), any());
+        verify(retrievalFactory).createGetRecordsCache(any(), streamConfigArgumentCaptor.capture(), any(), anyString());
 
         final StreamConfig actualStreamConfigForOrphan = streamConfigArgumentCaptor.getValue();
         final Optional<Arn> streamArnForOrphan =


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Having a hash of the lease table arn and passing it to the requests made to Kinesis Service in the useragent. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
