### PR TITLE
Allow migration when fewer leases than workers (#1500)

### DIFF
--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/coordinator/migration/MigrationReadyMonitor.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/coordinator/migration/MigrationReadyMonitor.java
@@ -200,7 +200,8 @@ public class MigrationReadyMonitor implements Runnable {
         // However, those leases should be assigned to another worker and so the check in the next
         // iteration could succeed. This is intentional to make sure all leases owners are accounted for
         // and the old owner does not come back up without worker metrics and reacquires the lease.
-        final boolean localWorkerMetricsReady = leaseOwners.equals(workersWithActiveWorkerMetrics);
+        // final boolean localWorkerMetricsReady = leaseOwners.equals(workersWithActiveWorkerMetrics);
+        final boolean localWorkerMetricsReady = workersWithActiveWorkerMetrics.containsAll(leaseOwners);
         if (localWorkerMetricsReady != workerMetricsReady) {
             workerMetricsReady = localWorkerMetricsReady;
             log.info("WorkerMetricStats status changed to {}", workerMetricsReady);

--- a/amazon-kinesis-client/src/test/java/software/amazon/kinesis/coordinator/migration/MigrationReadyMonitorTest.java
+++ b/amazon-kinesis-client/src/test/java/software/amazon/kinesis/coordinator/migration/MigrationReadyMonitorTest.java
@@ -94,7 +94,12 @@ public class MigrationReadyMonitorTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {"WORKER_READY_CONDITION_MET", "WORKER_READY_CONDITION_MET_MULTISTREAM_MODE_SANITY"})
+    @ValueSource(
+            strings = {
+                "WORKER_READY_CONDITION_MET",
+                "WORKER_READY_CONDITION_MET_FEW_SHARDS",
+                "WORKER_READY_CONDITION_MET_MULTISTREAM_MODE_SANITY"
+            })
     public void verifyNonLeaderDoesNotPerformMigrationChecks(final TestDataType testDataType) throws Exception {
         final TestData data = TEST_DATA_MAP.get(testDataType);
         when(mockTimeProvider.call()).thenReturn(1000L);
@@ -114,7 +119,12 @@ public class MigrationReadyMonitorTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {"WORKER_READY_CONDITION_MET", "WORKER_READY_CONDITION_MET_MULTISTREAM_MODE_SANITY"})
+    @ValueSource(
+            strings = {
+                "WORKER_READY_CONDITION_MET",
+                "WORKER_READY_CONDITION_MET_FEW_SHARDS",
+                "WORKER_READY_CONDITION_MET_MULTISTREAM_MODE_SANITY"
+            })
     public void verifyLeaderPerformMigrationChecks(final TestDataType testDataType) throws Exception {
         final TestData data = TEST_DATA_MAP.get(testDataType);
         when(mockTimeProvider.call()).thenReturn(1000L);
@@ -136,6 +146,7 @@ public class MigrationReadyMonitorTest {
     @ParameterizedTest
     @CsvSource({
         "false, WORKER_READY_CONDITION_MET",
+        "false, WORKER_READY_CONDITION_MET_FEW_SHARDS",
         "false, WORKER_READY_CONDITION_MET_MULTISTREAM_MODE_SANITY",
         "true, WORKER_READY_CONDITION_NOT_MET_WITH_ZERO_WORKER_STATS",
         "true, WORKER_READY_CONDITION_NOT_MET_WITH_PARTIAL_WORKER_STATS",
@@ -397,6 +408,7 @@ public class MigrationReadyMonitorTest {
 
     public enum TestDataType {
         WORKER_READY_CONDITION_MET,
+        WORKER_READY_CONDITION_MET_FEW_SHARDS,
         WORKER_READY_CONDITION_NOT_MET_WITH_ZERO_WORKER_STATS,
         WORKER_READY_CONDITION_NOT_MET_WITH_PARTIAL_WORKER_STATS,
         WORKER_READY_CONDITION_NOT_MET_WITH_ALL_INACTIVE_WORKER_STATS,
@@ -439,6 +451,16 @@ public class MigrationReadyMonitorTest {
                                         .lastUpdateTime(ACTIVE_WORKER_STATS_LAST_UPDATE_TIME)
                                         .build())
                                 .collect(Collectors.toList())));
+
+        // If there are fewer shards than workers, so not all workers have leases.
+        TEST_DATA_MAP.put(
+                TestDataType.WORKER_READY_CONDITION_MET_FEW_SHARDS,
+                new TestData(
+                        TEST_DATA_MAP
+                                .get(TestDataType.WORKER_READY_CONDITION_MET)
+                                .leaseList
+                                .subList(0, 1),
+                        TEST_DATA_MAP.get(TestDataType.WORKER_READY_CONDITION_MET).workerMetrics));
 
         TEST_DATA_MAP.put(
                 TestDataType.WORKER_READY_CONDITION_NOT_MET_WITH_ZERO_WORKER_STATS,


### PR DESCRIPTION
*Issue #, if available:*

#1500 

*Description of changes:*

- Allow v3 migration to occur when not all active workers are lease owners. This can happen when there are more workers than shards to lease.
- Unit tests for same. They fail against the mainline code.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
