### PR TITLE
Bump schema-registry-common and schema-registry-serde from 1.1.19 to 1.1.24

### DIFF
--- a/amazon-kinesis-client/pom.xml
+++ b/amazon-kinesis-client/pom.xml
@@ -53,7 +53,7 @@
     <sqlite4java.native>libsqlite4java</sqlite4java.native>
     <sqlite4java.libpath>${project.build.directory}/test-lib</sqlite4java.libpath>
     <slf4j.version>2.0.13</slf4j.version>
-    <gsr.version>1.1.19</gsr.version>
+    <gsr.version>1.1.24</gsr.version>
     <skipITs>true</skipITs>
   </properties>
 


### PR DESCRIPTION
Bump schema-registry-common and schema-registry-serde from 1.1.19 to 1.1.24

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
