### PR TITLE
Fix flaky LeaseAssignmentManager retry behavior test

### DIFF
--- a/amazon-kinesis-client/src/test/java/software/amazon/kinesis/coordinator/assignment/LeaseAssignmentManagerTest.java
+++ b/amazon-kinesis-client/src/test/java/software/amazon/kinesis/coordinator/assignment/LeaseAssignmentManagerTest.java
@@ -729,7 +729,6 @@ class LeaseAssignmentManagerTest {
     @Test
     void performAssignment_testRetryBehaviorForLeaseRefresher()
             throws ProvisionedThroughputException, InvalidStateException, DependencyException {
-        final WorkerMetricStatsDAO mockedWorkerMetricsDAO = Mockito.mock(WorkerMetricStatsDAO.class);
         final LeaseRefresher mockedLeaseRefresher = Mockito.mock(LeaseRefresher.class);
 
         when(mockedLeaseRefresher.listLeasesParallely(any(), anyInt())).thenThrow(new RuntimeException());

--- a/amazon-kinesis-client/src/test/java/software/amazon/kinesis/coordinator/assignment/LeaseAssignmentManagerTest.java
+++ b/amazon-kinesis-client/src/test/java/software/amazon/kinesis/coordinator/assignment/LeaseAssignmentManagerTest.java
@@ -727,36 +727,43 @@ class LeaseAssignmentManagerTest {
     }
 
     @Test
-    void performAssignment_testRetryBehavior()
+    void performAssignment_testRetryBehaviorForLeaseRefresher()
             throws ProvisionedThroughputException, InvalidStateException, DependencyException {
-
         final WorkerMetricStatsDAO mockedWorkerMetricsDAO = Mockito.mock(WorkerMetricStatsDAO.class);
         final LeaseRefresher mockedLeaseRefresher = Mockito.mock(LeaseRefresher.class);
 
         when(mockedLeaseRefresher.listLeasesParallely(any(), anyInt())).thenThrow(new RuntimeException());
-        when(mockedWorkerMetricsDAO.getAllWorkerMetricStats()).thenThrow(new RuntimeException());
 
-        final LeaseAssignmentManager leaseAssignmentManager = new LeaseAssignmentManager(
-                mockedLeaseRefresher,
-                mockedWorkerMetricsDAO,
-                mockLeaderDecider,
+        createLeaseAssignmentManager(
                 getWorkerUtilizationAwareAssignmentConfig(Double.MAX_VALUE, 20),
-                TEST_LEADER_WORKER_ID,
                 100L,
-                new NullMetricsFactory(),
-                scheduledExecutorService,
                 System::nanoTime,
                 Integer.MAX_VALUE,
-                LeaseManagementConfig.GracefulLeaseHandoffConfig.builder()
-                        .isGracefulLeaseHandoffEnabled(false)
-                        .build(),
-                2 * 100L);
-
-        leaseAssignmentManager.start();
+                mockedLeaseRefresher,
+                workerMetricsDAO);
 
         leaseAssignmentManagerRunnable.run();
 
         verify(mockedLeaseRefresher, times(2)).listLeasesParallely(any(), anyInt());
+    }
+
+    @Test
+    void performAssignment_testRetryBehaviorForWorkerMetricsDAO()
+            throws ProvisionedThroughputException, InvalidStateException, DependencyException {
+        final WorkerMetricStatsDAO mockedWorkerMetricsDAO = Mockito.mock(WorkerMetricStatsDAO.class);
+
+        when(mockedWorkerMetricsDAO.getAllWorkerMetricStats()).thenThrow(new RuntimeException());
+
+        createLeaseAssignmentManager(
+                getWorkerUtilizationAwareAssignmentConfig(Double.MAX_VALUE, 20),
+                100L,
+                System::nanoTime,
+                Integer.MAX_VALUE,
+                leaseRefresher,
+                mockedWorkerMetricsDAO);
+
+        leaseAssignmentManagerRunnable.run();
+
         verify(mockedWorkerMetricsDAO, times(2)).getAllWorkerMetricStats();
     }
 
@@ -1200,9 +1207,21 @@ class LeaseAssignmentManagerTest {
             final Supplier<Long> nanoTimeProvider,
             final int maxLeasesPerWorker) {
 
+        return createLeaseAssignmentManager(
+                config, leaseDurationMillis, nanoTimeProvider, maxLeasesPerWorker, leaseRefresher, workerMetricsDAO);
+    }
+
+    private LeaseAssignmentManager createLeaseAssignmentManager(
+            final LeaseManagementConfig.WorkerUtilizationAwareAssignmentConfig config,
+            final Long leaseDurationMillis,
+            final Supplier<Long> nanoTimeProvider,
+            final int maxLeasesPerWorker,
+            LeaseRefresher leaseRefresher,
+            WorkerMetricStatsDAO workerMetricStatsDao) {
+
         final LeaseAssignmentManager leaseAssignmentManager = new LeaseAssignmentManager(
                 leaseRefresher,
-                workerMetricsDAO,
+                workerMetricStatsDao,
                 mockLeaderDecider,
                 config,
                 TEST_LEADER_WORKER_ID,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Previously, the testRetryBehavior test would mock an exception on both the `leaseRefresher` and `workerMetricStatsDao`. In the LAM, however, these calls are asynchronous ([ref](https://github.com/awslabs/amazon-kinesis-client/blob/master/amazon-kinesis-client/src/main/java/software/amazon/kinesis/coordinator/assignment/LeaseAssignmentManager.java#L522-L525)), causing some runs to run into the mocked exception on the `workerMetricStatsDao` twice and exit the `loadInMemoryStorageView` method before `leaseRefresher` could throw the mocked exception since we only retry once. Technically, the race occurs if either one of the async calls throw twice before the other async call can throw once, since that will throw an exception in the method and exit the method.

On [this failed run](https://github.com/awslabs/amazon-kinesis-client/actions/runs/16176026775/job/45661264985#step:4:9940) on line 9940, the first exception caught is from `workerMetricStatsDao` and the method exits to [here](https://github.com/awslabs/amazon-kinesis-client/blob/master/amazon-kinesis-client/src/main/java/software/amazon/kinesis/coordinator/assignment/LeaseAssignmentManager.java#L263) without any exception from `leaseRefresher`

[This successful run](https://github.com/awslabs/amazon-kinesis-client/actions/runs/16177376262/job/45665652148#step:4:9940) on line 9940 catches the `leaseRefresher` exception first and then the `workerMetricStatsDao` exception.

This commit splits up the test retry behavior so this race in the unit tests does not occur. One test mocks an exception on the `leaseRefresher` and verifies that it is called twice. The second test mocks the exception on the `workerMetricStatsDao` and verifies that it is called twice.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
