### PR TITLE
use processRecordsInput.toBuilder() and not drop childShards

### DIFF
--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/lifecycle/ProcessTask.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/lifecycle/ProcessTask.java
@@ -245,13 +245,9 @@ public class ProcessTask implements ConsumerTask {
     private void callProcessRecords(ProcessRecordsInput input, List<KinesisClientRecord> records) {
         log.debug("Calling application processRecords() with {} records from {}", records.size(), shardInfoId);
 
-        final ProcessRecordsInput processRecordsInput = ProcessRecordsInput.builder()
+        final ProcessRecordsInput processRecordsInput = input.toBuilder()
                 .records(records)
-                .cacheExitTime(input.cacheExitTime())
-                .cacheEntryTime(input.cacheEntryTime())
-                .isAtShardEnd(input.isAtShardEnd())
                 .checkpointer(recordProcessorCheckpointer)
-                .millisBehindLatest(input.millisBehindLatest())
                 .build();
 
         final MetricsScope scope = MetricsUtil.createMetricsWithOperation(metricsFactory, PROCESS_TASK_OPERATION);


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* 

Avoid copying over fields and derive from original input.

Per [javadoc](https://github.com/awslabs/amazon-kinesis-client/blob/master/amazon-kinesis-client/src/main/java/software/amazon/kinesis/lifecycle/events/ProcessRecordsInput.java) of ProcessRecordsInput, also passing childShards when shard has ended. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
