### PR TITLE
Prep for release 3.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ For **1.x** release notes, please see [v1.x/CHANGELOG.md](https://github.com/aws
 For **2.x** release notes, please see [v2.x/CHANGELOG.md](https://github.com/awslabs/amazon-kinesis-client/blob/v2.x/CHANGELOG.md)
 
 ---
+### Release 3.1.3 (September 24, 2025)
+* [#1619](https://github.com/awslabs/amazon-kinesis-client/pull/1619) Bump awssdk from 2.31.77 to 2.33.0 and bump fasterxml.jackson from 2.12.7.1 to 2.20.0
+
 ### Release 3.1.2 (Aug 20, 2025)
 * [#1501](https://github.com/awslabs/amazon-kinesis-client/pull/1501) Allow migration to KCL 3.x when there are fewer leases than workers
 * [#1496](https://github.com/awslabs/amazon-kinesis-client/pull/1496) Decrease DDB lease renewal verbosity

--- a/amazon-kinesis-client-multilang/pom.xml
+++ b/amazon-kinesis-client-multilang/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>amazon-kinesis-client-pom</artifactId>
     <groupId>software.amazon.kinesis</groupId>
-    <version>3.1.2</version>
+    <version>3.1.3</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/amazon-kinesis-client/pom.xml
+++ b/amazon-kinesis-client/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>software.amazon.kinesis</groupId>
     <artifactId>amazon-kinesis-client-pom</artifactId>
-    <version>3.1.2</version>
+    <version>3.1.3</version>
   </parent>
 
   <artifactId>amazon-kinesis-client</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
   <artifactId>amazon-kinesis-client-pom</artifactId>
   <packaging>pom</packaging>
   <name>Amazon Kinesis Client Library</name>
-  <version>3.1.2</version>
+  <version>3.1.3</version>
   <description>The Amazon Kinesis Client Library for Java enables Java developers to easily consume and process data
     from Amazon Kinesis.
   </description>


### PR DESCRIPTION
### Release 3.1.3 (September 24, 2025)
* [#1619](https://github.com/awslabs/amazon-kinesis-client/pull/1619) Bump awssdk from 2.31.77 to 2.33.0 and bump fasterxml.jackson from 2.12.7.1 to 2.20.0

