### PR TITLE
Bumped awssdk to 2.33.0 and apache.commons to 3.18.0

### DIFF
--- a/amazon-kinesis-client/pom.xml
+++ b/amazon-kinesis-client/pom.xml
@@ -107,7 +107,7 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
-      <version>3.14.0</version>
+      <version>3.18.0</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
   </scm>
 
   <properties>
-    <awssdk.version>2.25.64</awssdk.version>
+    <awssdk.version>2.33.0</awssdk.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 


### PR DESCRIPTION
Bumped awssdk from 2.31.77 to 2.33.0
Bumped apache.commons to 3.18.0  to address https://www.cve.org/CVERecord?id=CVE-2025-48924