### PR TITLE
Prep for release 2.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 For **1.x** release notes, please see [v1.x/CHANGELOG.md](https://github.com/awslabs/amazon-kinesis-client/blob/v1.x/CHANGELOG.md)
 
 ---
+## Release 2.7.2 (2025-09-29)
+* [#1626](https://github.com/awslabs/amazon-kinesis-client/pull/1626) Upgrade awssdk from 2.25.64 to 2.33.0 and apache.commons from 3.14.0 to 3.18.0
+* [#1525](https://github.com/awslabs/amazon-kinesis-client/pull/1525) Bump com.google.protobuf:protobuf-java from 4.27.5 to 4.31.1
+
 ### Release 2.7.1 (2025-07-11)
 * [#1508](https://github.com/awslabs/amazon-kinesis-client/pull/1508) Upgrade schema-registry-common and schema-registry-serde from 1.1.19 to 1.1.24
 

--- a/amazon-kinesis-client-multilang/pom.xml
+++ b/amazon-kinesis-client-multilang/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>amazon-kinesis-client-pom</artifactId>
     <groupId>software.amazon.kinesis</groupId>
-    <version>2.7.1</version>
+    <version>2.7.2</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/amazon-kinesis-client/pom.xml
+++ b/amazon-kinesis-client/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>software.amazon.kinesis</groupId>
     <artifactId>amazon-kinesis-client-pom</artifactId>
-    <version>2.7.1</version>
+    <version>2.7.2</version>
   </parent>
 
   <artifactId>amazon-kinesis-client</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
   <artifactId>amazon-kinesis-client-pom</artifactId>
   <packaging>pom</packaging>
   <name>Amazon Kinesis Client Library</name>
-  <version>2.7.1</version>
+  <version>2.7.2</version>
   <description>The Amazon Kinesis Client Library for Java enables Java developers to easily consume and process data
     from Amazon Kinesis.
   </description>


### PR DESCRIPTION
## Release 2.7.2 (2025-09-29)
* [#1626](https://github.com/awslabs/amazon-kinesis-client/pull/1626) Upgrade awssdk from 2.25.64 to 2.33.0 and apache.commons from 3.14.0 to 3.18.0

* [#1525](https://github.com/awslabs/amazon-kinesis-client/pull/1525) Bump com.google.protobuf:protobuf-java from 4.27.5 to 4.31.1
