### PR TITLE
Remove var keyword from unit test

### DIFF
--- a/amazon-kinesis-client/src/test/java/software/amazon/kinesis/coordinator/assignment/LeaseAssignmentManagerTest.java
+++ b/amazon-kinesis-client/src/test/java/software/amazon/kinesis/coordinator/assignment/LeaseAssignmentManagerTest.java
@@ -360,7 +360,8 @@ class LeaseAssignmentManagerTest {
         populateLeasesInLeaseTable(lease1, lease2, lease3, lease4);
 
         // 1. test with the config set to false. No lease should be picked
-        final var config = getWorkerUtilizationAwareAssignmentConfig(Double.MAX_VALUE, 10);
+        final LeaseManagementConfig.WorkerUtilizationAwareAssignmentConfig config =
+                getWorkerUtilizationAwareAssignmentConfig(Double.MAX_VALUE, 10);
         config.allowThroughputOvershoot(false);
         createLeaseAssignmentManager(config, Duration.ofHours(1).toMillis(), System::nanoTime, Integer.MAX_VALUE);
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
var keyword is only in Java 10+. Since this library should be compatible with Java 8, replace this keyword

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
