### PR TITLE
Ensure heartbeat is stopped for graceful handoff lease in shutting do…

### DIFF
--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/coordinator/Scheduler.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/coordinator/Scheduler.java
@@ -592,7 +592,18 @@ public class Scheduler implements Runnable {
             for (ShardInfo shardInfo : getShardInfoForAssignments()) {
                 ShardConsumer shardConsumer = createOrGetShardConsumer(
                         shardInfo, processorConfig.shardRecordProcessorFactory(), leaseCleanupManager);
-
+                if (shardConsumer.isShutdown()) {
+                    final Lease currentLease = leaseCoordinator.getCurrentlyHeldLease(ShardInfo.getLeaseKey(shardInfo));
+                    if (currentLease != null
+                            && currentLease.concurrencyToken() != null
+                            && shardInfo
+                                    .concurrencyToken()
+                                    .equals(currentLease.concurrencyToken().toString())) {
+                        // dropping the lease to stop heartbeat so it gets cleaned up in the next round
+                        log.warn("Unexpected that lease is shutdown but still held. Stop heartbeat {}", currentLease);
+                        leaseCoordinator.dropLease(currentLease);
+                    }
+                }
                 shardConsumer.executeLifecycle();
                 assignedShards.add(shardInfo);
             }

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/lifecycle/LeaseGracefulShutdownHandler.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/lifecycle/LeaseGracefulShutdownHandler.java
@@ -150,8 +150,7 @@ public class LeaseGracefulShutdownHandler {
                 final ShardInfo shardInfo = entry.getKey();
                 leaseKey = leasePendingShutdown.lease.leaseKey();
 
-                if (leasePendingShutdown.shardConsumer.isShutdown()
-                        || shardInfoShardConsumerMap.get(shardInfo) == null
+                if (shardInfoShardConsumerMap.get(shardInfo) == null
                         || leaseCoordinator.getCurrentlyHeldLease(leaseKey) == null) {
                     logTimeoutMessage(leasePendingShutdown);
                     shardInfoLeasePendingShutdownMap.remove(shardInfo);
@@ -197,18 +196,7 @@ public class LeaseGracefulShutdownHandler {
     private void transferLeaseIfOwner(LeasePendingShutdown leasePendingShutdown)
             throws ProvisionedThroughputException, InvalidStateException, DependencyException {
         final Lease lease = leasePendingShutdown.lease;
-        if (leaseCoordinator.workerIdentifier().equals(lease.checkpointOwner())) {
-            // assignLease will increment the leaseCounter which will cause the heartbeat to stop on the current owner
-            // for the lease
-            leaseCoordinator.leaseRefresher().assignLease(lease, lease.leaseOwner());
-        } else {
-            // the worker ID check is just for sanity. We don't expect it to be different from the current worker.
-            log.error(
-                    "Lease {} checkpoint owner mismatch found {} but it should be {}",
-                    lease.leaseKey(),
-                    lease.checkpointOwner(),
-                    leaseCoordinator.workerIdentifier());
-        }
+        attemptLeaseTransfer(lease, leaseCoordinator);
         // mark it true because we don't want to enter the method again because update is not possible anymore.
         leasePendingShutdown.leaseTransferCalled = true;
     }
@@ -224,5 +212,21 @@ public class LeaseGracefulShutdownHandler {
         long timeoutTimestampMillis;
         boolean shutdownRequested = false;
         boolean leaseTransferCalled = false;
+    }
+
+    public static void attemptLeaseTransfer(Lease lease, LeaseCoordinator leaseCoordinator)
+            throws ProvisionedThroughputException, InvalidStateException, DependencyException {
+        if (lease != null && lease.shutdownRequested()) {
+            if (leaseCoordinator.workerIdentifier().equals(lease.checkpointOwner())) {
+                leaseCoordinator.leaseRefresher().assignLease(lease, lease.leaseOwner());
+            } else {
+                // the worker ID check is just for sanity. We don't expect it to be different from the current worker.
+                log.warn(
+                        "Lease {} checkpoint owner mismatch found {} but it should be {}",
+                        lease.leaseKey(),
+                        lease.checkpointOwner(),
+                        leaseCoordinator.workerIdentifier());
+            }
+        }
     }
 }

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/lifecycle/ShutdownNotificationTask.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/lifecycle/ShutdownNotificationTask.java
@@ -21,9 +21,6 @@ import software.amazon.kinesis.annotations.KinesisClientInternalApi;
 import software.amazon.kinesis.leases.Lease;
 import software.amazon.kinesis.leases.LeaseCoordinator;
 import software.amazon.kinesis.leases.ShardInfo;
-import software.amazon.kinesis.leases.exceptions.DependencyException;
-import software.amazon.kinesis.leases.exceptions.InvalidStateException;
-import software.amazon.kinesis.leases.exceptions.ProvisionedThroughputException;
 import software.amazon.kinesis.lifecycle.events.ShutdownRequestedInput;
 import software.amazon.kinesis.processor.RecordProcessorCheckpointer;
 import software.amazon.kinesis.processor.ShardRecordProcessor;
@@ -50,7 +47,7 @@ public class ShutdownNotificationTask implements ConsumerTask {
                 shardRecordProcessor.shutdownRequested(ShutdownRequestedInput.builder()
                         .checkpointer(recordProcessorCheckpointer)
                         .build());
-                attemptLeaseTransfer(currentShardLease);
+                LeaseGracefulShutdownHandler.attemptLeaseTransfer(currentShardLease, leaseCoordinator);
             } catch (Exception ex) {
                 return new TaskResult(ex);
             }
@@ -63,15 +60,6 @@ public class ShutdownNotificationTask implements ConsumerTask {
                 // one. We need to drop lease like what's done in the shutdownNotificationComplete so we can
                 // transition to next state.
                 leaseCoordinator.dropLease(currentShardLease);
-            }
-        }
-    }
-
-    private void attemptLeaseTransfer(Lease lease)
-            throws ProvisionedThroughputException, InvalidStateException, DependencyException {
-        if (lease != null && lease.shutdownRequested()) {
-            if (leaseCoordinator.workerIdentifier().equals(lease.checkpointOwner())) {
-                leaseCoordinator.leaseRefresher().assignLease(lease, lease.leaseOwner());
             }
         }
     }

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/lifecycle/ShutdownTask.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/lifecycle/ShutdownTask.java
@@ -163,7 +163,23 @@ public class ShutdownTask implements ConsumerTask {
                     }
                 } else {
                     throwOnApplicationException(leaseKey, leaseLostAction, scope, startTime);
+                    // When shutdown reason is not SHARD_END (i.e., LEASE_LOST), the lease is typically
+                    // already lost and currentShardLease would be null. However, if a graceful lease
+                    // shutdown was requested but the ShardConsumer transitioned directly to ShutdownTask
+                    // (e.g., from WAITING_ON_PARENT_SHARDS) without going through
+                    // ShutdownNotificationTask, the lease may still be held. In that case, we need to
+                    // transfer the lease to the intended new owner and drop it locally.
+                    if (currentShardLease != null && currentShardLease.shutdownRequested()) {
+                        log.info("Attempting to transfer and drop shutdown requested lease {}", leaseKey);
+                        try {
+                            LeaseGracefulShutdownHandler.attemptLeaseTransfer(currentShardLease, leaseCoordinator);
+                        } catch (Exception e) {
+                            log.warn("Unable to transfer lease {}", leaseKey, e);
+                        }
+                        dropLease(currentShardLease, leaseKey);
+                    }
                 }
+
                 log.debug("Shutting down retrieval strategy for shard {}.", leaseKey);
                 recordsPublisher.shutdown();
 
@@ -388,7 +404,7 @@ public class ShutdownTask implements ConsumerTask {
                     leaseKey);
         } else {
             leaseCoordinator.dropLease(currentLease);
-            log.info("Dropped lease for shutting down ShardConsumer: " + currentLease.leaseKey());
+            log.info("Dropped lease for shutting down ShardConsumer: {}", currentLease.leaseKey());
         }
     }
 }

--- a/amazon-kinesis-client/src/test/java/software/amazon/kinesis/coordinator/SchedulerTest.java
+++ b/amazon-kinesis-client/src/test/java/software/amazon/kinesis/coordinator/SchedulerTest.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.function.Function;
@@ -74,6 +75,7 @@ import software.amazon.kinesis.coordinator.streamInfo.StreamInfoMode;
 import software.amazon.kinesis.exceptions.KinesisClientLibException;
 import software.amazon.kinesis.exceptions.KinesisClientLibNonRetryableException;
 import software.amazon.kinesis.leases.HierarchicalShardSyncer;
+import software.amazon.kinesis.leases.Lease;
 import software.amazon.kinesis.leases.LeaseCleanupManager;
 import software.amazon.kinesis.leases.LeaseCoordinator;
 import software.amazon.kinesis.leases.LeaseManagementConfig;
@@ -91,6 +93,7 @@ import software.amazon.kinesis.leases.exceptions.InvalidStateException;
 import software.amazon.kinesis.leases.exceptions.ProvisionedThroughputException;
 import software.amazon.kinesis.lifecycle.LifecycleConfig;
 import software.amazon.kinesis.lifecycle.ShardConsumer;
+import software.amazon.kinesis.lifecycle.ShutdownReason;
 import software.amazon.kinesis.lifecycle.events.InitializationInput;
 import software.amazon.kinesis.lifecycle.events.LeaseLostInput;
 import software.amazon.kinesis.lifecycle.events.ProcessRecordsInput;
@@ -1319,6 +1322,59 @@ public class SchedulerTest {
 
         verify(mockInitializer, times(1)).shutdown();
         verify(mockMigrationStateMachine, times(1)).shutdown();
+    }
+
+    @Test
+    public void testRunProcessLoopDropsLeaseWhenShardConsumerIsShutdownButLeaseStillHeld() {
+        final String shardId = "shardId-000000000000";
+        final UUID concurrencyUUID = UUID.randomUUID();
+        final ShardInfo shardInfo =
+                new ShardInfo(shardId, concurrencyUUID.toString(), null, ExtendedSequenceNumber.TRIM_HORIZON);
+
+        // Create a mock ShardConsumer that is shutdown with SHARD_END reason
+        // (createOrGetShardConsumer only replaces LEASE_LOST shutdowns, so SHARD_END is returned as-is)
+        final ShardConsumer mockConsumer = mock(ShardConsumer.class);
+        when(mockConsumer.isShutdown()).thenReturn(true);
+        when(mockConsumer.shutdownReason()).thenReturn(ShutdownReason.SHARD_END);
+        scheduler.shardInfoShardConsumerMap().put(shardInfo, mockConsumer);
+
+        // Set up lease with matching concurrency token
+        final Lease lease = new Lease();
+        lease.leaseKey(shardId);
+        lease.leaseOwner(workerIdentifier);
+        lease.concurrencyToken(concurrencyUUID);
+        when(leaseCoordinator.getCurrentAssignments()).thenReturn(Collections.singletonList(shardInfo));
+        when(leaseCoordinator.getCurrentlyHeldLease(shardId)).thenReturn(lease);
+
+        scheduler.runProcessLoop();
+
+        verify(leaseCoordinator).dropLease(lease);
+    }
+
+    @Test
+    public void testRunProcessLoopDoesNotDropLeaseWhenConcurrencyTokenMismatch() {
+        final String shardId = "shardId-000000000000";
+        final UUID consumerUUID = UUID.randomUUID();
+        final UUID leaseUUID = UUID.randomUUID();
+        final ShardInfo shardInfo =
+                new ShardInfo(shardId, consumerUUID.toString(), null, ExtendedSequenceNumber.TRIM_HORIZON);
+
+        final ShardConsumer mockConsumer = mock(ShardConsumer.class);
+        when(mockConsumer.isShutdown()).thenReturn(true);
+        when(mockConsumer.shutdownReason()).thenReturn(ShutdownReason.SHARD_END);
+        scheduler.shardInfoShardConsumerMap().put(shardInfo, mockConsumer);
+
+        // Set up lease with DIFFERENT concurrency token
+        final Lease lease = new Lease();
+        lease.leaseKey(shardId);
+        lease.leaseOwner(workerIdentifier);
+        lease.concurrencyToken(leaseUUID);
+        when(leaseCoordinator.getCurrentAssignments()).thenReturn(Collections.singletonList(shardInfo));
+        when(leaseCoordinator.getCurrentlyHeldLease(shardId)).thenReturn(lease);
+
+        scheduler.runProcessLoop();
+
+        verify(leaseCoordinator, never()).dropLease(any(Lease.class));
     }
 
     @Test

--- a/amazon-kinesis-client/src/test/java/software/amazon/kinesis/lifecycle/ShutdownTaskTest.java
+++ b/amazon-kinesis-client/src/test/java/software/amazon/kinesis/lifecycle/ShutdownTaskTest.java
@@ -348,6 +348,47 @@ public class ShutdownTaskTest {
         verify(shutdownNotification, never()).shutdownComplete();
     }
 
+    @Test
+    public void testLeaseLostWithShutdownRequestedTransfersAndDropsLease() throws Exception {
+        lease.checkpointOwner(LEASE_OWNER);
+        when(leaseCoordinator.workerIdentifier()).thenReturn(LEASE_OWNER);
+
+        final TaskResult result =
+                createShutdownTask(LEASE_LOST, Collections.emptyList()).call();
+
+        assertNull(result.getException());
+        verify(leaseRefresher).assignLease(lease, lease.leaseOwner());
+        verify(leaseCoordinator).dropLease(lease);
+        verify(recordsPublisher).shutdown();
+    }
+
+    @Test
+    public void testLeaseLostWithShutdownRequestedDropsLeaseEvenOnTransferFailure() throws Exception {
+        lease.checkpointOwner(LEASE_OWNER);
+        when(leaseCoordinator.workerIdentifier()).thenReturn(LEASE_OWNER);
+        when(leaseRefresher.assignLease(any(Lease.class), any(String.class)))
+                .thenThrow(new DependencyException(new RuntimeException()));
+
+        final TaskResult result =
+                createShutdownTask(LEASE_LOST, Collections.emptyList()).call();
+
+        assertNull(result.getException());
+        verify(leaseCoordinator).dropLease(lease);
+        verify(recordsPublisher).shutdown();
+    }
+
+    @Test
+    public void testLeaseLostWithoutShutdownRequestedDoesNotTransferOrDrop() throws Exception {
+        // lease exists but shutdownRequested is false (default)
+        final TaskResult result =
+                createShutdownTask(LEASE_LOST, Collections.emptyList()).call();
+
+        assertNull(result.getException());
+        verify(leaseRefresher, never()).assignLease(any(Lease.class), any(String.class));
+        verify(leaseCoordinator, never()).dropLease(any(Lease.class));
+        verify(recordsPublisher).shutdown();
+    }
+
     /**
      * Test method for {@link ShutdownTask#taskType()}.
      */


### PR DESCRIPTION
*Description of changes:*
Fix graceful lease handoff when a ShardConsumer receives a graceful handoff request before reaching the initialized state. Due to lifecycle management, the ShardConsumer transitions directly from WAITING_ON_PARENT_SHARDS to shutdown, skipping ShutdownNotificationTask, leaving the lease never transferred or dropped.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
