### PR TITLE
Add StreamType to StreamIdentifier and skip hash range ERROR logs for…

### DIFF
--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/common/StreamIdentifier.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/common/StreamIdentifier.java
@@ -28,24 +28,54 @@ import software.amazon.awssdk.arns.Arn;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.utils.Validate;
 
-@Builder(toBuilder = true)
 @EqualsAndHashCode
 @Getter
 @Accessors(fluent = true)
 public class StreamIdentifier {
 
-    @Builder.Default
-    private final Optional<String> accountIdOptional = Optional.empty();
+    /**
+     * Stream type identifier for Amazon Kinesis Data Streams.
+     */
+    public static final String STREAM_TYPE_KINESIS = "Kinesis";
+
+    private final Optional<String> accountIdOptional;
 
     @NonNull
     private final String streamName;
 
-    @Builder.Default
-    private final Optional<Long> streamCreationEpochOptional = Optional.empty();
+    private final Optional<Long> streamCreationEpochOptional;
 
-    @Builder.Default
     @EqualsAndHashCode.Exclude
-    private final Optional<Arn> streamArnOptional = Optional.empty();
+    private final Optional<Arn> streamArnOptional;
+
+    /**
+     * The type of stream this identifier represents.
+     * Defaults to {@link #STREAM_TYPE_KINESIS} for standard Kinesis Data Streams.
+     * Adapters for other streaming sources may set a different value.
+     */
+    @EqualsAndHashCode.Exclude
+    private final String streamType;
+
+    @Builder(toBuilder = true)
+    private StreamIdentifier(
+            Optional<String> accountIdOptional,
+            @NonNull String streamName,
+            Optional<Long> streamCreationEpochOptional,
+            Optional<Arn> streamArnOptional,
+            String streamType) {
+        this.accountIdOptional = accountIdOptional;
+        this.streamName = streamName;
+        this.streamCreationEpochOptional = streamCreationEpochOptional;
+        this.streamArnOptional = streamArnOptional;
+        this.streamType = streamType;
+    }
+
+    public static class StreamIdentifierBuilder {
+        private Optional<String> accountIdOptional = Optional.empty();
+        private Optional<Long> streamCreationEpochOptional = Optional.empty();
+        private Optional<Arn> streamArnOptional = Optional.empty();
+        private String streamType = STREAM_TYPE_KINESIS;
+    }
 
     /**
      * Pattern for a serialized {@link StreamIdentifier}. The valid format is
@@ -97,6 +127,18 @@ public class StreamIdentifier {
      * @return StreamIdentifier with {@link #accountIdOptional} and {@link #streamCreationEpochOptional} present
      */
     public static StreamIdentifier multiStreamInstance(String streamIdentifierSer) {
+        return multiStreamInstance(streamIdentifierSer, STREAM_TYPE_KINESIS);
+    }
+
+    /**
+     * Create a multi stream instance for StreamIdentifier from serialized stream identifier
+     * of format {@link #STREAM_IDENTIFIER_PATTERN} with a specified stream type.
+     *
+     * @param streamIdentifierSer a String of {@code account:stream:creationEpoch}
+     * @param streamType the type of stream
+     * @return StreamIdentifier with {@link #accountIdOptional} and {@link #streamCreationEpochOptional} present
+     */
+    public static StreamIdentifier multiStreamInstance(String streamIdentifierSer, String streamType) {
         final Matcher matcher = STREAM_IDENTIFIER_PATTERN.matcher(streamIdentifierSer);
         if (matcher.matches()) {
             final String accountId = matcher.group("accountId");
@@ -109,6 +151,7 @@ public class StreamIdentifier {
                     .accountIdOptional(Optional.of(accountId))
                     .streamName(streamName)
                     .streamCreationEpochOptional(Optional.of(creationEpoch))
+                    .streamType(streamType)
                     .build();
         }
 
@@ -148,9 +191,22 @@ public class StreamIdentifier {
      * @param streamName stream name of a Kinesis stream
      */
     public static StreamIdentifier singleStreamInstance(String streamName) {
+        return singleStreamInstance(streamName, STREAM_TYPE_KINESIS);
+    }
+
+    /**
+     * Create a single stream instance for StreamIdentifier from stream name with a specified stream type.
+     *
+     * @param streamName stream name
+     * @param streamType the type of stream
+     */
+    public static StreamIdentifier singleStreamInstance(String streamName, String streamType) {
         Validate.notEmpty(streamName, "StreamName should not be empty");
 
-        return StreamIdentifier.builder().streamName(streamName).build();
+        return StreamIdentifier.builder()
+                .streamName(streamName)
+                .streamType(streamType)
+                .build();
     }
 
     /**
@@ -190,5 +246,13 @@ public class StreamIdentifier {
         if (creationEpoch <= 0) {
             throw new IllegalArgumentException("Creation epoch must be > 0; received " + creationEpoch);
         }
+    }
+
+    StreamIdentifier(
+            Optional<String> accountIdOptional,
+            @NonNull String streamName,
+            Optional<Long> streamCreationEpochOptional,
+            Optional<Arn> streamArnOptional) {
+        this(accountIdOptional, streamName, streamCreationEpochOptional, streamArnOptional, STREAM_TYPE_KINESIS);
     }
 }

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/coordinator/PeriodicShardSyncManager.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/coordinator/PeriodicShardSyncManager.java
@@ -65,6 +65,7 @@ import software.amazon.kinesis.metrics.MetricsScope;
 import software.amazon.kinesis.metrics.MetricsUtil;
 
 import static software.amazon.kinesis.common.HashKeyRangeForLease.fromHashKeyRange;
+import static software.amazon.kinesis.common.StreamIdentifier.STREAM_TYPE_KINESIS;
 
 /**
  * The top level orchestrator for coordinating the periodic shard sync related
@@ -453,7 +454,9 @@ class PeriodicShardSyncManager {
         // Sort the hash ranges by starting hash key.
         List<Lease> sortedLeasesWithHashKeyRanges = sortLeasesByHashRange(leasesWithHashKeyRanges);
         if (sortedLeasesWithHashKeyRanges.isEmpty()) {
-            log.error("No leases with valid hashranges found for stream {}", streamIdentifier);
+            if (isHashRangeErrorLoggingEnabled(streamIdentifier)) {
+                log.error("No leases with valid hashranges found for stream {}", streamIdentifier);
+            }
             return Optional.of(new HashRangeHole());
         }
         // Validate for hashranges bounds.
@@ -467,11 +470,13 @@ class PeriodicShardSyncManager {
                         .hashKeyRangeForLease()
                         .endingHashKey()
                         .equals(MAX_HASH_KEY)) {
-            log.error(
-                    "Incomplete hash range found for stream {} between {} and {}.",
-                    streamIdentifier,
-                    sortedLeasesWithHashKeyRanges.get(0),
-                    sortedLeasesWithHashKeyRanges.get(sortedLeasesWithHashKeyRanges.size() - 1));
+            if (isHashRangeErrorLoggingEnabled(streamIdentifier)) {
+                log.error(
+                        "Incomplete hash range found for stream {} between {} and {}.",
+                        streamIdentifier,
+                        sortedLeasesWithHashKeyRanges.get(0),
+                        sortedLeasesWithHashKeyRanges.get(sortedLeasesWithHashKeyRanges.size() - 1));
+            }
             return Optional.of(new HashRangeHole(
                     sortedLeasesWithHashKeyRanges.get(0).hashKeyRangeForLease(),
                     sortedLeasesWithHashKeyRanges
@@ -498,11 +503,13 @@ class PeriodicShardSyncManager {
                     // Case of non overlapping leases when rangediff is positive. signum() will be 1 for positive.
                     // If rangeDiff is 1, then it is a case of continuous hashrange. If not, it is a hole.
                     if (!rangeDiff.equals(BigInteger.ONE)) {
-                        log.error(
-                                "Incomplete hash range found for {} between {} and {}.",
-                                streamIdentifier,
-                                leftMostLeaseToReportInCaseOfHole,
-                                sortedLeasesWithHashKeyRanges.get(i));
+                        if (isHashRangeErrorLoggingEnabled(streamIdentifier)) {
+                            log.error(
+                                    "Incomplete hash range found for {} between {} and {}.",
+                                    streamIdentifier,
+                                    leftMostLeaseToReportInCaseOfHole,
+                                    sortedLeasesWithHashKeyRanges.get(i));
+                        }
                         return Optional.of(new HashRangeHole(
                                 leftMostLeaseToReportInCaseOfHole.hashKeyRangeForLease(),
                                 sortedLeasesWithHashKeyRanges.get(i).hashKeyRangeForLease()));
@@ -522,6 +529,15 @@ class PeriodicShardSyncManager {
         }
         Collections.sort(leasesWithHashKeyRanges, new HashKeyRangeComparator());
         return leasesWithHashKeyRanges;
+    }
+
+    /**
+     * Returns true if hash range error logging is enabled for the given stream.
+     * Streams with a non-Kinesis stream type may use different sharding mechanisms
+     * and do not log hash range errors.
+     */
+    private static boolean isHashRangeErrorLoggingEnabled(StreamIdentifier streamIdentifier) {
+        return STREAM_TYPE_KINESIS.equals(streamIdentifier.streamType());
     }
 
     @Value

--- a/amazon-kinesis-client/src/test/java/software/amazon/kinesis/common/StreamIdentifierTest.java
+++ b/amazon-kinesis-client/src/test/java/software/amazon/kinesis/common/StreamIdentifierTest.java
@@ -127,6 +127,24 @@ public class StreamIdentifierTest {
         assertEquals(Optional.of(EPOCH), actualStreamIdentifier.streamCreationEpochOptional());
     }
 
+    @Test
+    public void testStreamTypeDefaultsToKinesis() {
+        assertEquals(
+                StreamIdentifier.STREAM_TYPE_KINESIS,
+                StreamIdentifier.singleStreamInstance(STREAM_NAME).streamType());
+        assertEquals(
+                StreamIdentifier.STREAM_TYPE_KINESIS,
+                StreamIdentifier.multiStreamInstance(serialize()).streamType());
+    }
+
+    @Test
+    public void testStreamTypeExcludedFromEquality() {
+        StreamIdentifier kinesis =
+                StreamIdentifier.singleStreamInstance(STREAM_NAME, StreamIdentifier.STREAM_TYPE_KINESIS);
+        StreamIdentifier other = StreamIdentifier.singleStreamInstance(STREAM_NAME, "OtherStreamType");
+        assertEquals(kinesis, other);
+    }
+
     private void assertActualStreamIdentifierExpected(Arn expectedArn, StreamIdentifier actual) {
         assertEquals(STREAM_NAME, actual.streamName());
         assertEquals(Optional.of(TEST_ACCOUNT_ID), actual.accountIdOptional());


### PR DESCRIPTION
                                                                                                                                    
                                                                                                                                                                         
  Fixes backward compatibility issue introduced in #1709 (reverted by KCL team due to compat check failure).                                                             
                                                                                                                                                                         
  Description of changes:                                                                                                                                                
                                                                                                                                                                         
  Adds streamType field to StreamIdentifier to distinguish DynamoDB Streams from Kinesis Data Streams, allowing PeriodicShardSyncManager to skip hash range validation ERROR logs for non-Kinesis streams.                                                                                                                                    
                                                                                                                                                                         
  To fix the backward compatibility issue (adding a field changes Lombok's auto-generated constructor signature), moved @Builder(toBuilder = true) from the class to an explicit private constructor and added a package-private 4-arg constructor matching the old signature. A partial StreamIdentifierBuilder class provides field defaults (replacing @Builder.Default). Builder remains public for Pod1 ARN support.                                                                                             
                                                                                                                                                                         
  Files changed:                                                                                                                                                         
                                                                                                                                                                         
  - StreamIdentifier.java — streamType field, builder-on-constructor pattern, backward-compatible constructor, factory method overloads                                  
  - PeriodicShardSyncManager.java — skip hash range error logging for non-Kinesis streams                                                                                
  - StreamIdentifierTest.java — tests for streamType defaults and equality exclusion 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
