### PR TITLE
Update scheduler to not drop terminated lease if reason is ShardEnd

### DIFF
--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/coordinator/Scheduler.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/coordinator/Scheduler.java
@@ -592,7 +592,7 @@ public class Scheduler implements Runnable {
             for (ShardInfo shardInfo : getShardInfoForAssignments()) {
                 ShardConsumer shardConsumer = createOrGetShardConsumer(
                         shardInfo, processorConfig.shardRecordProcessorFactory(), leaseCleanupManager);
-                if (shardConsumer.isShutdown()) {
+                if (shardConsumer.isShutdown() && !ShutdownReason.SHARD_END.equals(shardConsumer.shutdownReason())) {
                     final Lease currentLease = leaseCoordinator.getCurrentlyHeldLease(ShardInfo.getLeaseKey(shardInfo));
                     if (currentLease != null
                             && currentLease.concurrencyToken() != null

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/lifecycle/ShutdownTask.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/lifecycle/ShutdownTask.java
@@ -162,7 +162,6 @@ public class ShutdownTask implements ConsumerTask {
                         throwOnApplicationException(leaseKey, leaseLostAction, scope, startTime);
                     }
                 } else {
-                    throwOnApplicationException(leaseKey, leaseLostAction, scope, startTime);
                     // When shutdown reason is not SHARD_END (i.e., LEASE_LOST), the lease is typically
                     // already lost and currentShardLease would be null. However, if a graceful lease
                     // shutdown was requested but the ShardConsumer transitioned directly to ShutdownTask
@@ -178,6 +177,7 @@ public class ShutdownTask implements ConsumerTask {
                         }
                         dropLease(currentShardLease, leaseKey);
                     }
+                    throwOnApplicationException(leaseKey, leaseLostAction, scope, startTime);
                 }
 
                 log.debug("Shutting down retrieval strategy for shard {}.", leaseKey);

--- a/amazon-kinesis-client/src/test/java/software/amazon/kinesis/coordinator/SchedulerTest.java
+++ b/amazon-kinesis-client/src/test/java/software/amazon/kinesis/coordinator/SchedulerTest.java
@@ -1335,7 +1335,7 @@ public class SchedulerTest {
         // (createOrGetShardConsumer only replaces LEASE_LOST shutdowns, so SHARD_END is returned as-is)
         final ShardConsumer mockConsumer = mock(ShardConsumer.class);
         when(mockConsumer.isShutdown()).thenReturn(true);
-        when(mockConsumer.shutdownReason()).thenReturn(ShutdownReason.SHARD_END);
+        when(mockConsumer.shutdownReason()).thenReturn(ShutdownReason.REQUESTED);
         scheduler.shardInfoShardConsumerMap().put(shardInfo, mockConsumer);
 
         // Set up lease with matching concurrency token
@@ -1352,6 +1352,29 @@ public class SchedulerTest {
     }
 
     @Test
+    public void testRunProcessLoopDoesNotDropLeaseWhenShutdownWithShardEndReason() {
+        final String shardId = "shardId-000000000000";
+        final UUID concurrencyUUID = UUID.randomUUID();
+        final ShardInfo shardInfo =
+                new ShardInfo(shardId, concurrencyUUID.toString(), null, ExtendedSequenceNumber.TRIM_HORIZON);
+
+        final ShardConsumer mockConsumer = mock(ShardConsumer.class);
+        when(mockConsumer.isShutdown()).thenReturn(true);
+        when(mockConsumer.shutdownReason()).thenReturn(ShutdownReason.SHARD_END);
+        scheduler.shardInfoShardConsumerMap().put(shardInfo, mockConsumer);
+
+        final Lease lease = new Lease();
+        lease.leaseKey(shardId);
+        lease.leaseOwner(workerIdentifier);
+        lease.concurrencyToken(concurrencyUUID);
+        when(leaseCoordinator.getCurrentAssignments()).thenReturn(Collections.singletonList(shardInfo));
+
+        scheduler.runProcessLoop();
+
+        verify(leaseCoordinator, never()).dropLease(any(Lease.class));
+    }
+
+    @Test
     public void testRunProcessLoopDoesNotDropLeaseWhenConcurrencyTokenMismatch() {
         final String shardId = "shardId-000000000000";
         final UUID consumerUUID = UUID.randomUUID();
@@ -1361,10 +1384,9 @@ public class SchedulerTest {
 
         final ShardConsumer mockConsumer = mock(ShardConsumer.class);
         when(mockConsumer.isShutdown()).thenReturn(true);
-        when(mockConsumer.shutdownReason()).thenReturn(ShutdownReason.SHARD_END);
+        when(mockConsumer.shutdownReason()).thenReturn(ShutdownReason.REQUESTED);
         scheduler.shardInfoShardConsumerMap().put(shardInfo, mockConsumer);
 
-        // Set up lease with DIFFERENT concurrency token
         final Lease lease = new Lease();
         lease.leaseKey(shardId);
         lease.leaseOwner(workerIdentifier);


### PR DESCRIPTION
*Description of changes:*
Ignore dropping shardEnd leases in the newly added lease state validation logic in Scheduler. ShardEnd lease is supposed to receive heartbeat from the current owner to know cause the lease to get reassigned since it doesn't need to be reassigned. Also flipped the ordering between dropping the leases and calling leaseLost since lease dropping is expected to happen before leaseLost 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
