### PR TITLE
Fix checkpointing logic to handle shard end correctly #211

### DIFF
--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/checkpoint/ShardRecordProcessorCheckpointer.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/checkpoint/ShardRecordProcessorCheckpointer.java
@@ -300,8 +300,13 @@ public class ShardRecordProcessorCheckpointer implements RecordProcessorCheckpoi
             checkpointToRecord = ExtendedSequenceNumber.SHARD_END;
         }
 
-        // Don't checkpoint a value we already successfully checkpointed
-        if (extendedSequenceNumber != null && !extendedSequenceNumber.equals(lastCheckpointValue)) {
+        // Don't checkpoint a value we already successfully checkpointed. Compare against
+        // checkpointToRecord (which may have been rewritten to SHARD_END above) rather than the
+        // caller-supplied extendedSequenceNumber; otherwise the transition to SHARD_END is skipped
+        // when the last record's sequence number was already checkpointed, causing the shard-end
+        // shutdown to throw "Application didn't checkpoint at end of shard" in a loop. See
+        // upstream issue https://github.com/awslabs/amazon-kinesis-client/issues/211.
+        if (checkpointToRecord != null && !checkpointToRecord.equals(lastCheckpointValue)) {
             try {
                 if (log.isDebugEnabled()) {
                     log.debug(

--- a/amazon-kinesis-client/src/test/java/software/amazon/kinesis/checkpoint/ShardShardRecordProcessorCheckpointerTest.java
+++ b/amazon-kinesis-client/src/test/java/software/amazon/kinesis/checkpoint/ShardShardRecordProcessorCheckpointerTest.java
@@ -832,6 +832,50 @@ public class ShardShardRecordProcessorCheckpointerTest {
         }
     }
 
+    /**
+     * Regression test for upstream issue
+     * <a href="https://github.com/awslabs/amazon-kinesis-client/issues/211">#211</a>
+     * ("Application didn't checkpoint at end of shard").
+     *
+     * <p>Reproduces the case where the application checkpoints the last record of the shard during
+     * {@code processRecords}, and then the framework calls {@code checkpoint(lastSequenceNumber)}
+     * again during shard-end shutdown after {@code sequenceNumberAtShardEnd} has been set.
+     */
+    @Test
+    public final void testCheckpointAdvancesToShardEndWhenSequenceAlreadyCheckpointed() throws Exception {
+        ShardRecordProcessorCheckpointer processingCheckpointer =
+                new ShardRecordProcessorCheckpointer(shardInfo, checkpoint);
+        processingCheckpointer.setInitialCheckpointValue(startingExtendedSequenceNumber);
+
+        // Simulate the record processor receiving and checkpointing the final record of the shard.
+        ExtendedSequenceNumber lastRecordSequenceNumber = new ExtendedSequenceNumber("6789");
+        processingCheckpointer.largestPermittedCheckpointValue(lastRecordSequenceNumber);
+        processingCheckpointer.checkpoint(
+                lastRecordSequenceNumber.sequenceNumber(), lastRecordSequenceNumber.subSequenceNumber());
+        assertThat(processingCheckpointer.lastCheckpointValue(), equalTo(lastRecordSequenceNumber));
+        assertThat(checkpoint.getCheckpoint(shardId), equalTo(lastRecordSequenceNumber));
+
+        // Simulate ShutdownTask preparing to checkpoint at shard end.
+        processingCheckpointer.sequenceNumberAtShardEnd(lastRecordSequenceNumber);
+        processingCheckpointer.largestPermittedCheckpointValue(ExtendedSequenceNumber.SHARD_END);
+
+        // The framework re-issues a checkpoint at the last record's sequence number. Internally
+        // advancePosition should rewrite this to SHARD_END and persist it, even though the numeric
+        // value matches lastCheckpointValue.
+        processingCheckpointer.checkpoint(
+                lastRecordSequenceNumber.sequenceNumber(), lastRecordSequenceNumber.subSequenceNumber());
+
+        assertThat(
+                "Checkpointing the final record after sequenceNumberAtShardEnd is set must advance "
+                        + "lastCheckpointValue to SHARD_END",
+                processingCheckpointer.lastCheckpointValue(),
+                equalTo(ExtendedSequenceNumber.SHARD_END));
+        assertThat(
+                "The persisted checkpoint must be SHARD_END so the lease can be completed",
+                checkpoint.getCheckpoint(shardId),
+                equalTo(ExtendedSequenceNumber.SHARD_END));
+    }
+
     @Test
     public final void testUnsetMetricsScopeDuringCheckpointing() throws Exception {
         // First call to checkpoint


### PR DESCRIPTION
*Issue #, if available:* #211

While the issue was originally reported a long time ago, I see this issue in production with KCL 3.3.0.

In ShardRecordProcessorCheckpointer.advancePosition(ExtendedSequenceNumber), the guard that suppresses re‑checkpointing an already‑checkpointed value compared the caller‑supplied extendedSequenceNumber against lastCheckpointValue. But just above that guard, the method may rewrite the checkpoint target to SHARD_END when the sequence number matches sequenceNumberAtShardEnd. Because the guard still looked at the pre‑rewrite value, the following very common shard‑end sequence was broken:

1. Record processor checkpoints the last record N during processRecords → lastCheckpointValue = N.
2. Framework transitions the shard: sequenceNumberAtShardEnd = N, largestPermittedCheckpointValue = SHARD_END.
3. On shutdown the app calls checkpoint(N), which re‑enters advancePosition(N). checkpointToRecord is rewritten to SHARD_END, but the guard evaluated !N.equals(N) == false and short‑circuited — SHARD_END was never persisted and lastCheckpointValue stayed at N.
4. ShutdownTask.applicationCheckpointAndVerification then raises IllegalArgumentException: Application didn't checkpoint at end of shard 

*Description of changes:*

One-line change in ShardRecordProcessorCheckpointer. Compare checkpointToRecord (the post‑rewrite value that will actually be persisted) instead of extendedSequenceNumber. This is the exact fix proposed by @posac in the original 2017 upstream issue (and endorsed by @klesniewski in 2018), which was never merged.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
