### PR TITLE
Scheduler.run: properly close metricsScope

### DIFF
--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/coordinator/Scheduler.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/coordinator/Scheduler.java
@@ -486,6 +486,7 @@ public class Scheduler implements Runnable {
             shutdown();
         } finally {
             MetricsUtil.addSuccess(metricsScope, "Initialize", success, MetricsLevel.SUMMARY);
+            MetricsUtil.endScope(metricsScope);
         }
         while (!shouldShutdown()) {
             runProcessLoop();


### PR DESCRIPTION
`Scheduler.run()` is creating a `MetricsScope`, but it never calls `end()` on it, either directly or with `MetricsUtil.endScope`. This means that the metrics from `Scheduler.run()` are never published.

This issue has been present since KCL v3.0.0: fbfd74d / https://github.com/awslabs/amazon-kinesis-client/blame/fbfd74df39bf1714a2faee21d21bbff5b885f095/amazon-kinesis-client/src/main/java/software/amazon/kinesis/coordinator/Scheduler.java#L442-L455

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
