### PR TITLE
Remove early return for empty records at shard end

### DIFF
--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/lifecycle/ProcessTask.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/lifecycle/ProcessTask.java
@@ -152,12 +152,6 @@ public class ProcessTask implements ConsumerTask {
                             MetricsLevel.SUMMARY);
                 }
 
-                if (processRecordsInput.isAtShardEnd()
-                        && processRecordsInput.records().isEmpty()) {
-                    log.info("Reached end of shard {} and have no records to process", shardInfoId);
-                    return new TaskResult(null, true);
-                }
-
                 throttlingReporter.success();
                 List<KinesisClientRecord> records = deaggregateAnyKplRecords(processRecordsInput.records());
 

--- a/amazon-kinesis-client/src/test/java/software/amazon/kinesis/lifecycle/ProcessTaskTest.java
+++ b/amazon-kinesis-client/src/test/java/software/amazon/kinesis/lifecycle/ProcessTaskTest.java
@@ -81,7 +81,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static software.amazon.kinesis.retrieval.kpl.ExtendedSequenceNumber.TRIM_HORIZON;
 
@@ -188,7 +187,7 @@ public class ProcessTaskTest {
 
         TaskResult result = processTask.call();
         assertThat(result, shardEndTaskResult(true));
-        verifyNoInteractions(shardRecordProcessor);
+        verify(shardRecordProcessor).processRecords(any(ProcessRecordsInput.class));
     }
 
     @Test


### PR DESCRIPTION
*Description of changes:*
Removing the line that causes a shard transitioning to shard end without records to skip calling processRecords before going to the shutdown task. Now, processRecords will be called regardless if the consumer sets configsBuilder.processorConfig().callProcessRecordsEvenForEmptyRecordList(true). 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
