### PR TITLE
Fix FanoutRecordsPublisher restartFrom behavior at SHARD_END

### DIFF
--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/fanout/FanOutRecordsPublisher.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/fanout/FanOutRecordsPublisher.java
@@ -159,9 +159,7 @@ public class FanOutRecordsPublisher implements RecordsPublisher {
                 throw new IllegalArgumentException(
                         "Provided ProcessRecordsInput not created from the FanOutRecordsPublisher");
             }
-            ExtendedSequenceNumber continuationSeqNum =
-                    ((FanoutRecordsRetrieved) recordsRetrieved).continuationSequenceNumber();
-            currentSequenceNumber = continuationSeqNum;
+            currentSequenceNumber = ((FanoutRecordsRetrieved) recordsRetrieved).continuationSequenceNumber();;
         }
     }
 

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/fanout/FanOutRecordsPublisher.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/fanout/FanOutRecordsPublisher.java
@@ -84,7 +84,7 @@ public class FanOutRecordsPublisher implements RecordsPublisher {
 
     @Getter
     @VisibleForTesting
-    private String currentSequenceNumber;
+    private ExtendedSequenceNumber currentSequenceNumber;
 
     private InitialPositionInStreamExtended initialPositionInStreamExtended;
     private boolean isFirstConnection = true;
@@ -130,7 +130,7 @@ public class FanOutRecordsPublisher implements RecordsPublisher {
                     extendedSequenceNumber,
                     initialPositionInStreamExtended);
             this.initialPositionInStreamExtended = initialPositionInStreamExtended;
-            this.currentSequenceNumber = extendedSequenceNumber.sequenceNumber();
+            this.currentSequenceNumber = extendedSequenceNumber;
             this.isFirstConnection = true;
         }
     }
@@ -159,7 +159,9 @@ public class FanOutRecordsPublisher implements RecordsPublisher {
                 throw new IllegalArgumentException(
                         "Provided ProcessRecordsInput not created from the FanOutRecordsPublisher");
             }
-            currentSequenceNumber = ((FanoutRecordsRetrieved) recordsRetrieved).continuationSequenceNumber();
+            ExtendedSequenceNumber continuationSeqNum =
+                    ((FanoutRecordsRetrieved) recordsRetrieved).continuationSequenceNumber();
+            currentSequenceNumber = continuationSeqNum;
         }
     }
 
@@ -207,7 +209,9 @@ public class FanOutRecordsPublisher implements RecordsPublisher {
             // Take action based on the time spent by the event in queue.
             takeDelayedDeliveryActionIfRequired(streamAndShardId, recordsRetrievedContext.getEnqueueTimestamp(), log);
             // Update current sequence number for the successfully delivered event.
-            currentSequenceNumber = ((FanoutRecordsRetrieved) recordsRetrieved).continuationSequenceNumber();
+            ExtendedSequenceNumber continuationSeqNum =
+                    ((FanoutRecordsRetrieved) recordsRetrieved).continuationSequenceNumber();
+            currentSequenceNumber = continuationSeqNum;
             // Update the triggering flow for post scheduling upstream request.
             flowToBeReturned = recordsRetrievedContext.getRecordFlow();
             // Try scheduling the next event in the queue or execute the subscription shutdown action.
@@ -314,21 +318,31 @@ public class FanOutRecordsPublisher implements RecordsPublisher {
         return flow != null;
     }
 
-    private void subscribeToShard(String sequenceNumber) {
+    private void subscribeToShard(ExtendedSequenceNumber sequenceNumber) {
         synchronized (lockObject) {
             // Clear the delivery queue so that any stale entries from previous subscription are discarded.
             resetRecordsDeliveryStateOnSubscriptionOnInit();
+            log.info("ShardId: {}, consumrArn: {}", shardId, consumerArn);
             SubscribeToShardRequest.Builder builder = KinesisRequestsBuilder.subscribeToShardRequestBuilder()
                     .shardId(shardId)
                     .consumerARN(consumerArn);
             builder.streamId(StreamIdCache.get(streamIdentifier));
 
             SubscribeToShardRequest request;
-            if (isFirstConnection) {
-                request = IteratorBuilder.request(builder, sequenceNumber, initialPositionInStreamExtended)
+
+            // If sequenceNumber is SHARD_END, then we have reached the end of the shard before and this is
+            // reconnecting.
+            // Skip forward to the end of the shard.
+            if (sequenceNumber == ExtendedSequenceNumber.SHARD_END) {
+                request = IteratorBuilder.request(builder, "LATEST", initialPositionInStreamExtended)
+                        .build();
+            } else if (isFirstConnection) {
+                request = IteratorBuilder.request(
+                                builder, sequenceNumber.sequenceNumber(), initialPositionInStreamExtended)
                         .build();
             } else {
-                request = IteratorBuilder.reconnectRequest(builder, sequenceNumber, initialPositionInStreamExtended)
+                request = IteratorBuilder.reconnectRequest(
+                                builder, sequenceNumber.sequenceNumber(), initialPositionInStreamExtended)
                         .build();
             }
 
@@ -459,7 +473,7 @@ public class FanOutRecordsPublisher implements RecordsPublisher {
                             .isAtShardEnd(true)
                             .childShards(Collections.emptyList())
                             .build(),
-                    null,
+                    ExtendedSequenceNumber.SHARD_END,
                     triggeringFlow != null ? triggeringFlow.getSubscribeToShardId() : shardId + "-no-flow-found");
             subscriber.onNext(response);
             subscriber.onComplete();
@@ -569,8 +583,16 @@ public class FanOutRecordsPublisher implements RecordsPublisher {
                         .records(records)
                         .childShards(recordBatchEvent.childShards())
                         .build();
+                final ExtendedSequenceNumber continuationSequenceNumber;
+                if (recordBatchEvent.continuationSequenceNumber() == null) {
+                    continuationSequenceNumber = ExtendedSequenceNumber.SHARD_END;
+                } else {
+                    continuationSequenceNumber =
+                            new ExtendedSequenceNumber(recordBatchEvent.continuationSequenceNumber());
+                }
+
                 FanoutRecordsRetrieved recordsRetrieved = new FanoutRecordsRetrieved(
-                        input, recordBatchEvent.continuationSequenceNumber(), triggeringFlow.subscribeToShardId);
+                        input, continuationSequenceNumber, triggeringFlow.subscribeToShardId);
                 bufferCurrentEventAndScheduleIfRequired(recordsRetrieved, triggeringFlow);
             } catch (Throwable t) {
                 log.warn(
@@ -633,7 +655,7 @@ public class FanOutRecordsPublisher implements RecordsPublisher {
                 return;
             }
 
-            if (currentSequenceNumber != null) {
+            if (currentSequenceNumber != ExtendedSequenceNumber.SHARD_END) {
                 log.debug("{}: Shard hasn't ended. Resubscribing.", streamAndShardId);
                 subscribeToShard(currentSequenceNumber);
             } else {
@@ -792,10 +814,10 @@ public class FanOutRecordsPublisher implements RecordsPublisher {
 
     @Accessors(fluent = true)
     @Data
-    static class FanoutRecordsRetrieved implements RecordsRetrieved {
+    public static class FanoutRecordsRetrieved implements RecordsRetrieved {
 
         private final ProcessRecordsInput processRecordsInput;
-        private final String continuationSequenceNumber;
+        private final ExtendedSequenceNumber continuationSequenceNumber;
         private final String flowIdentifier;
         private final String batchUniqueIdentifier = UUID.randomUUID().toString();
 

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/fanout/FanOutRecordsPublisher.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/fanout/FanOutRecordsPublisher.java
@@ -322,7 +322,6 @@ public class FanOutRecordsPublisher implements RecordsPublisher {
         synchronized (lockObject) {
             // Clear the delivery queue so that any stale entries from previous subscription are discarded.
             resetRecordsDeliveryStateOnSubscriptionOnInit();
-            log.info("ShardId: {}, consumrArn: {}", shardId, consumerArn);
             SubscribeToShardRequest.Builder builder = KinesisRequestsBuilder.subscribeToShardRequestBuilder()
                     .shardId(shardId)
                     .consumerARN(consumerArn);
@@ -814,7 +813,7 @@ public class FanOutRecordsPublisher implements RecordsPublisher {
 
     @Accessors(fluent = true)
     @Data
-    public static class FanoutRecordsRetrieved implements RecordsRetrieved {
+    static class FanoutRecordsRetrieved implements RecordsRetrieved {
 
         private final ProcessRecordsInput processRecordsInput;
         private final ExtendedSequenceNumber continuationSequenceNumber;

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/fanout/FanOutRecordsPublisher.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/fanout/FanOutRecordsPublisher.java
@@ -159,7 +159,7 @@ public class FanOutRecordsPublisher implements RecordsPublisher {
                 throw new IllegalArgumentException(
                         "Provided ProcessRecordsInput not created from the FanOutRecordsPublisher");
             }
-            currentSequenceNumber = ((FanoutRecordsRetrieved) recordsRetrieved).continuationSequenceNumber();;
+            currentSequenceNumber = ((FanoutRecordsRetrieved) recordsRetrieved).continuationSequenceNumber();
         }
     }
 

--- a/amazon-kinesis-client/src/test/java/software/amazon/kinesis/retrieval/fanout/FanOutRecordsPublisherTest.java
+++ b/amazon-kinesis-client/src/test/java/software/amazon/kinesis/retrieval/fanout/FanOutRecordsPublisherTest.java
@@ -1748,7 +1748,6 @@ public class FanOutRecordsPublisherTest {
                         ProcessRecordsInput.builder().build(),
                         ExtendedSequenceNumber.SHARD_END,
                         recordFlow.getSubscribeToShardId());
-        final int[] totalRecordsRetrieved = {0};
         source.restartFrom(shardEndRecordsRetrieved);
         source.subscribe(subscriber);
 

--- a/amazon-kinesis-client/src/test/java/software/amazon/kinesis/retrieval/fanout/FanOutRecordsPublisherTest.java
+++ b/amazon-kinesis-client/src/test/java/software/amazon/kinesis/retrieval/fanout/FanOutRecordsPublisherTest.java
@@ -73,7 +73,6 @@ import software.amazon.kinesis.utils.SubscribeToShardRequestMatcher;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -361,7 +360,7 @@ public class FanOutRecordsPublisherTest {
             }
         });
 
-        assertThat(source.getCurrentSequenceNumber(), equalTo("3000"));
+        assertThat(source.getCurrentSequenceNumber(), equalTo(new ExtendedSequenceNumber("3000")));
     }
 
     @Test
@@ -446,7 +445,7 @@ public class FanOutRecordsPublisherTest {
             }
         });
 
-        assertThat(source.getCurrentSequenceNumber(), equalTo("1000"));
+        assertThat(source.getCurrentSequenceNumber(), equalTo(new ExtendedSequenceNumber("1000")));
     }
 
     @Test
@@ -502,7 +501,7 @@ public class FanOutRecordsPublisherTest {
                     public void onNext(RecordsRetrieved input) {
                         receivedInput.add(input.processRecordsInput());
                         assertEquals(
-                                "" + ++lastSeenSeqNum,
+                                new ExtendedSequenceNumber("" + ++lastSeenSeqNum),
                                 ((FanOutRecordsPublisher.FanoutRecordsRetrieved) input).continuationSequenceNumber());
                         subscription.request(1);
                         servicePublisher.request(1);
@@ -552,7 +551,9 @@ public class FanOutRecordsPublisherTest {
             }
         });
 
-        assertThat(source.getCurrentSequenceNumber(), equalTo(totalServicePublisherEvents + ""));
+        assertThat(
+                source.getCurrentSequenceNumber(),
+                equalTo(new ExtendedSequenceNumber(totalServicePublisherEvents + "")));
     }
 
     @Test
@@ -624,7 +625,7 @@ public class FanOutRecordsPublisherTest {
                     public void onNext(RecordsRetrieved input) {
                         receivedInput.add(input.processRecordsInput());
                         assertEquals(
-                                "" + ++lastSeenSeqNum,
+                                new ExtendedSequenceNumber("" + ++lastSeenSeqNum),
                                 ((FanOutRecordsPublisher.FanoutRecordsRetrieved) input).continuationSequenceNumber());
                         subscription.request(1);
                         servicePublisher.request(1);
@@ -675,7 +676,8 @@ public class FanOutRecordsPublisherTest {
             }
         });
 
-        assertThat(source.getCurrentSequenceNumber(), equalTo(triggerCompleteAtNthEvent + ""));
+        assertThat(
+                source.getCurrentSequenceNumber(), equalTo(new ExtendedSequenceNumber(triggerCompleteAtNthEvent + "")));
         // In non-shard end cases, upon successful completion, the publisher would re-subscribe to service.
         // Let's wait for sometime to allow the publisher to re-subscribe
         onS2SCallLatch.await(5000, TimeUnit.MILLISECONDS);
@@ -815,7 +817,7 @@ public class FanOutRecordsPublisherTest {
             }
         });
 
-        assertNull(source.getCurrentSequenceNumber());
+        assertEquals(source.getCurrentSequenceNumber(), ExtendedSequenceNumber.SHARD_END);
         // With shard end event, onComplete must be propagated to the subscriber.
         onCompleteLatch.await(5000, TimeUnit.MILLISECONDS);
         assertTrue("OnComplete should be triggered", isOnCompleteTriggered[0]);
@@ -882,7 +884,7 @@ public class FanOutRecordsPublisherTest {
                     public void onNext(RecordsRetrieved input) {
                         receivedInput.add(input.processRecordsInput());
                         assertEquals(
-                                "" + ++lastSeenSeqNum,
+                                new ExtendedSequenceNumber("" + ++lastSeenSeqNum),
                                 ((FanOutRecordsPublisher.FanoutRecordsRetrieved) input).continuationSequenceNumber());
                         subscription.request(1);
                         servicePublisher.request(1);
@@ -933,7 +935,7 @@ public class FanOutRecordsPublisherTest {
             }
         });
 
-        assertThat(source.getCurrentSequenceNumber(), equalTo(triggerErrorAtNthEvent + ""));
+        assertThat(source.getCurrentSequenceNumber(), equalTo(new ExtendedSequenceNumber(triggerErrorAtNthEvent + "")));
         onErrorReceiveLatch.await(5000, TimeUnit.MILLISECONDS);
         assertTrue("OnError should have been thrown", isOnErrorThrown[0]);
     }
@@ -993,7 +995,7 @@ public class FanOutRecordsPublisherTest {
                     public void onNext(RecordsRetrieved input) {
                         receivedInput.add(input.processRecordsInput());
                         assertEquals(
-                                "" + ++lastSeenSeqNum,
+                                new ExtendedSequenceNumber("" + ++lastSeenSeqNum),
                                 ((FanOutRecordsPublisher.FanoutRecordsRetrieved) input).continuationSequenceNumber());
                         subscription.request(1);
                         servicePublisher.request(1);
@@ -1043,7 +1045,9 @@ public class FanOutRecordsPublisherTest {
             }
         });
 
-        assertThat(source.getCurrentSequenceNumber(), equalTo(totalServicePublisherEvents + ""));
+        assertThat(
+                source.getCurrentSequenceNumber(),
+                equalTo(new ExtendedSequenceNumber(totalServicePublisherEvents + "")));
     }
 
     @Test
@@ -1102,7 +1106,7 @@ public class FanOutRecordsPublisherTest {
                     public void onNext(RecordsRetrieved input) {
                         receivedInput.add(input.processRecordsInput());
                         assertEquals(
-                                "" + ++lastSeenSeqNum,
+                                new ExtendedSequenceNumber("" + ++lastSeenSeqNum),
                                 ((FanOutRecordsPublisher.FanoutRecordsRetrieved) input).continuationSequenceNumber());
                         subscription.request(1);
                         servicePublisher.request(1);
@@ -1287,7 +1291,9 @@ public class FanOutRecordsPublisherTest {
         ArgumentCaptor<FanOutRecordsPublisher.RecordFlow> flowCaptor =
                 ArgumentCaptor.forClass(FanOutRecordsPublisher.RecordFlow.class);
         ArgumentCaptor<RecordsRetrieved> inputCaptor = ArgumentCaptor.forClass(RecordsRetrieved.class);
-
+        source.start(
+                ExtendedSequenceNumber.LATEST,
+                InitialPositionInStreamExtended.newInitialPosition(InitialPositionInStream.LATEST));
         source.subscribe(subscriber);
 
         verify(kinesisClient).subscribeToShard(any(SubscribeToShardRequest.class), flowCaptor.capture());
@@ -1317,7 +1323,9 @@ public class FanOutRecordsPublisherTest {
 
         ArgumentCaptor<FanOutRecordsPublisher.RecordFlow> flowCaptor =
                 ArgumentCaptor.forClass(FanOutRecordsPublisher.RecordFlow.class);
-
+        source.start(
+                ExtendedSequenceNumber.LATEST,
+                InitialPositionInStreamExtended.newInitialPosition(InitialPositionInStream.LATEST));
         source.subscribe(subscriber);
 
         verify(kinesisClient).subscribeToShard(any(SubscribeToShardRequest.class), flowCaptor.capture());
@@ -1430,6 +1438,9 @@ public class FanOutRecordsPublisherTest {
         FanOutRecordsPublisher.RecordFlow recordFlow =
                 new FanOutRecordsPublisher.RecordFlow(fanOutRecordsPublisher, Instant.now(), "shard-001-001");
         final int[] totalRecordsRetrieved = {0};
+        fanOutRecordsPublisher.start(
+                ExtendedSequenceNumber.LATEST,
+                InitialPositionInStreamExtended.newInitialPosition(InitialPositionInStream.LATEST));
         fanOutRecordsPublisher.subscribe(new Subscriber<RecordsRetrieved>() {
             @Override
             public void onSubscribe(Subscription subscription) {}
@@ -1459,6 +1470,9 @@ public class FanOutRecordsPublisherTest {
         FanOutRecordsPublisher.RecordFlow recordFlow =
                 new FanOutRecordsPublisher.RecordFlow(fanOutRecordsPublisher, Instant.now(), "shard-001");
         final int[] totalRecordsRetrieved = {0};
+        fanOutRecordsPublisher.start(
+                ExtendedSequenceNumber.LATEST,
+                InitialPositionInStreamExtended.newInitialPosition(InitialPositionInStream.LATEST));
         fanOutRecordsPublisher.subscribe(new Subscriber<RecordsRetrieved>() {
             @Override
             public void onSubscribe(Subscription subscription) {}
@@ -1492,6 +1506,9 @@ public class FanOutRecordsPublisherTest {
         FanOutRecordsPublisher.RecordFlow recordFlow =
                 new FanOutRecordsPublisher.RecordFlow(fanOutRecordsPublisher, Instant.now(), "shard-001");
         final int[] totalRecordsRetrieved = {0};
+        fanOutRecordsPublisher.start(
+                ExtendedSequenceNumber.LATEST,
+                InitialPositionInStreamExtended.newInitialPosition(InitialPositionInStream.LATEST));
         fanOutRecordsPublisher.subscribe(new Subscriber<RecordsRetrieved>() {
             @Override
             public void onSubscribe(Subscription subscription) {}
@@ -1514,7 +1531,9 @@ public class FanOutRecordsPublisherTest {
         IntStream.rangeClosed(1, 137)
                 .forEach(i -> fanOutRecordsPublisher.bufferCurrentEventAndScheduleIfRequired(
                         new FanOutRecordsPublisher.FanoutRecordsRetrieved(
-                                ProcessRecordsInput.builder().build(), i + "", recordFlow.getSubscribeToShardId()),
+                                ProcessRecordsInput.builder().build(),
+                                new ExtendedSequenceNumber(i + ""),
+                                recordFlow.getSubscribeToShardId()),
                         recordFlow));
         assertEquals(137, totalRecordsRetrieved[0]);
     }
@@ -1526,6 +1545,9 @@ public class FanOutRecordsPublisherTest {
         FanOutRecordsPublisher.RecordFlow recordFlow =
                 new FanOutRecordsPublisher.RecordFlow(fanOutRecordsPublisher, Instant.now(), "shard-001");
         final int[] totalRecordsRetrieved = {0};
+        fanOutRecordsPublisher.start(
+                ExtendedSequenceNumber.LATEST,
+                InitialPositionInStreamExtended.newInitialPosition(InitialPositionInStream.LATEST));
         fanOutRecordsPublisher.subscribe(new Subscriber<RecordsRetrieved>() {
             @Override
             public void onSubscribe(Subscription subscription) {}
@@ -1553,7 +1575,9 @@ public class FanOutRecordsPublisherTest {
         IntStream.rangeClosed(1, 100)
                 .forEach(i -> fanOutRecordsPublisher.bufferCurrentEventAndScheduleIfRequired(
                         new FanOutRecordsPublisher.FanoutRecordsRetrieved(
-                                ProcessRecordsInput.builder().build(), i + "", recordFlow.getSubscribeToShardId()),
+                                ProcessRecordsInput.builder().build(),
+                                new ExtendedSequenceNumber(i + ""),
+                                recordFlow.getSubscribeToShardId()),
                         recordFlow));
         assertEquals(100, totalRecordsRetrieved[0]);
     }
@@ -1567,6 +1591,9 @@ public class FanOutRecordsPublisherTest {
                 new FanOutRecordsPublisher.RecordFlow(fanOutRecordsPublisher, Instant.now(), "shard-001");
         final int[] totalRecordsRetrieved = {0};
         BlockingQueue<BatchUniqueIdentifier> ackQueue = new LinkedBlockingQueue<>();
+        fanOutRecordsPublisher.start(
+                ExtendedSequenceNumber.LATEST,
+                InitialPositionInStreamExtended.newInitialPosition(InitialPositionInStream.LATEST));
         fanOutRecordsPublisher.subscribe(new Subscriber<RecordsRetrieved>() {
             @Override
             public void onSubscribe(Subscription subscription) {}
@@ -1588,7 +1615,9 @@ public class FanOutRecordsPublisherTest {
         IntStream.rangeClosed(1, 10)
                 .forEach(i -> fanOutRecordsPublisher.bufferCurrentEventAndScheduleIfRequired(
                         new FanOutRecordsPublisher.FanoutRecordsRetrieved(
-                                ProcessRecordsInput.builder().build(), i + "", recordFlow.getSubscribeToShardId()),
+                                ProcessRecordsInput.builder().build(),
+                                new ExtendedSequenceNumber(i + ""),
+                                recordFlow.getSubscribeToShardId()),
                         recordFlow));
         BatchUniqueIdentifier batchUniqueIdentifierQueued;
         int count = 0;
@@ -1611,6 +1640,9 @@ public class FanOutRecordsPublisherTest {
                 new FanOutRecordsPublisher.RecordFlow(fanOutRecordsPublisher, Instant.now(), "Shard-001-1");
         final int[] totalRecordsRetrieved = {0};
         BlockingQueue<BatchUniqueIdentifier> ackQueue = new LinkedBlockingQueue<>();
+        fanOutRecordsPublisher.start(
+                ExtendedSequenceNumber.LATEST,
+                InitialPositionInStreamExtended.newInitialPosition(InitialPositionInStream.LATEST));
         fanOutRecordsPublisher.subscribe(new Subscriber<RecordsRetrieved>() {
             @Override
             public void onSubscribe(Subscription subscription) {}
@@ -1632,7 +1664,9 @@ public class FanOutRecordsPublisherTest {
         IntStream.rangeClosed(1, 10)
                 .forEach(i -> fanOutRecordsPublisher.bufferCurrentEventAndScheduleIfRequired(
                         new FanOutRecordsPublisher.FanoutRecordsRetrieved(
-                                ProcessRecordsInput.builder().build(), i + "", recordFlow.getSubscribeToShardId()),
+                                ProcessRecordsInput.builder().build(),
+                                new ExtendedSequenceNumber(i + ""),
+                                recordFlow.getSubscribeToShardId()),
                         recordFlow));
         BatchUniqueIdentifier batchUniqueIdentifierQueued;
         int count = 0;
@@ -1701,6 +1735,34 @@ public class FanOutRecordsPublisherTest {
 
         assertThat(onErrorEvent, equalTo(Optional.of(new OnErrorEvent(exception))));
         assertThat(acquireTimeoutLogged.get(), equalTo(true));
+    }
+
+    @Test
+    public void restartFromShardEndCallsSubscribeToShardAtLatest() {
+        final FanOutRecordsPublisher source =
+                new FanOutRecordsPublisher(kinesisClient, SHARD_ID, CONSUMER_ARN, streamIdentifier);
+        FanOutRecordsPublisher.RecordFlow recordFlow =
+                new FanOutRecordsPublisher.RecordFlow(source, Instant.now(), "shard-001");
+        final FanOutRecordsPublisher.FanoutRecordsRetrieved shardEndRecordsRetrieved =
+                new FanOutRecordsPublisher.FanoutRecordsRetrieved(
+                        ProcessRecordsInput.builder().build(),
+                        ExtendedSequenceNumber.SHARD_END,
+                        recordFlow.getSubscribeToShardId());
+        final int[] totalRecordsRetrieved = {0};
+        source.restartFrom(shardEndRecordsRetrieved);
+        source.subscribe(subscriber);
+
+        final SubscribeToShardRequest expectedRequest = SubscribeToShardRequest.builder()
+                .shardId(SHARD_ID)
+                .consumerARN(CONSUMER_ARN)
+                .startingPosition(StartingPosition.builder()
+                        .type(ShardIteratorType.LATEST)
+                        .build())
+                .build();
+        verify(kinesisClient)
+                .subscribeToShard(
+                        argThat(new SubscribeToShardRequestMatcher(expectedRequest)),
+                        any(FanOutRecordsPublisher.RecordFlow.class));
     }
 
     private void verifyRecords(List<KinesisClientRecord> clientRecordsList, List<KinesisClientRecordMatcher> matchers) {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
If the FanoutRecordsPublisher reaches the last SubscribeToShardEvent, the `continuationSequenceNumber` returned by the service is `null`. This causes an issue if the publisher runs into an error and the ShardConsumerSubscriber calls `restartFrom` for the lastAccepted event ([ref](https://github.com/awslabs/amazon-kinesis-client/blob/master/amazon-kinesis-client/src/main/java/software/amazon/kinesis/lifecycle/ShardConsumerSubscriber.java#L99)). The FanoutRecordsPublisher would set the continuationSequenceNumber to `null` ([ref](https://github.com/awslabs/amazon-kinesis-client/blob/master/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/fanout/FanOutRecordsPublisher.java#L162))causing the subscribeToShard requests to continuously fail where the only remediation would be to force the worker to drop the lease.

This commit updates the FanoutRecordsPublisher to handle the SHARD_END event case. If the publisher restartsFrom SHARD_END, it will instead call subscribeToShard with LATEST, which will return the last SHARD_END event from the service and continue the normal SHARD_END tasks through the ShardConsumer and RecordProcessor.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
