### PR TITLE
Treat expired pending handoff leases as available lease to take

### DIFF
--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/coordinator/assignment/LeaseAssignmentManager.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/coordinator/assignment/LeaseAssignmentManager.java
@@ -300,7 +300,8 @@ public final class LeaseAssignmentManager {
     private LeaseAssignmentDecider getLeaseAssignmentDecider(InMemoryStorageView inMemoryStorageView) {
         final LeaseAssignmentDecider leaseAssignmentDecider;
         if (leaseAssignmentStrategy == LeaseAssignmentStrategy.LEASE_COUNT_BASED) {
-            leaseAssignmentDecider = new LeaseCountBasedLeaseAssignmentDecider(inMemoryStorageView, maxLeasesForWorker);
+            leaseAssignmentDecider = new LeaseCountBasedLeaseAssignmentDecider(
+                    inMemoryStorageView, maxLeasesForWorker, nanoTimeProvider);
         } else {
             leaseAssignmentDecider = new VarianceBasedLeaseAssignmentDecider(
                     inMemoryStorageView,

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/coordinator/assignment/LeaseCountBasedLeaseAssignmentDecider.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/coordinator/assignment/LeaseCountBasedLeaseAssignmentDecider.java
@@ -21,6 +21,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import lombok.RequiredArgsConstructor;
@@ -47,6 +49,7 @@ public final class LeaseCountBasedLeaseAssignmentDecider implements LeaseAssignm
 
     private final LeaseAssignmentManager.InMemoryStorageView inMemoryStorageView;
     private final int maxLeasesForWorker;
+    private final Supplier<Long> nanoTimeProvider;
 
     /**
      * Assigns expired or unassigned leases to workers with the fewest current leases.
@@ -240,6 +243,7 @@ public final class LeaseCountBasedLeaseAssignmentDecider implements LeaseAssignm
         final Set<String> workersWithAvailableLeases = inMemoryStorageView.getWorkersOnVersionHash().stream()
                 .map(WorkerMetricStats::getWorkerId)
                 .collect(Collectors.toSet());
+        final long currentTimeMillis = TimeUnit.NANOSECONDS.toMillis(nanoTimeProvider.get());
 
         for (final Map.Entry<String, Set<Lease>> entry :
                 inMemoryStorageView.getWorkerToLeasesMap().entrySet()) {
@@ -248,7 +252,7 @@ public final class LeaseCountBasedLeaseAssignmentDecider implements LeaseAssignm
                 continue;
             }
             final List<Lease> workerAvailableLeases = entry.getValue().stream()
-                    .filter(lease -> !lease.shutdownRequested()) // Avoid leases pending handoff
+                    .filter(lease -> !lease.blockedOnPendingCheckpoint(currentTimeMillis))
                     .collect(Collectors.toList());
 
             if (!workerAvailableLeases.isEmpty()) {

--- a/amazon-kinesis-client/src/test/java/software/amazon/kinesis/coordinator/assignment/LeaseCountBasedLeaseAssignmentDeciderTest.java
+++ b/amazon-kinesis-client/src/test/java/software/amazon/kinesis/coordinator/assignment/LeaseCountBasedLeaseAssignmentDeciderTest.java
@@ -23,6 +23,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -52,6 +54,8 @@ class LeaseCountBasedLeaseAssignmentDeciderTest {
 
     private LeaseCountBasedLeaseAssignmentDecider decider;
     private static final int MAX_LEASES_FOR_WORKER = 10;
+    private static final long CURRENT_TIME_NANOS = TimeUnit.MILLISECONDS.toNanos(10000L);
+    private final Supplier<Long> nanoTimeProvider = () -> CURRENT_TIME_NANOS;
 
     private LeaseCountBasedLeaseAssignmentDecider createDecider(Set<String> workerIds) {
         List<WorkerMetricStats> workerMetrics = workerIds.stream()
@@ -68,13 +72,14 @@ class LeaseCountBasedLeaseAssignmentDeciderTest {
                 .thenReturn(true);
         when(inMemoryStorageView.isWorkerAssignedLeasesLessThanMaxLeases(anyString()))
                 .thenReturn(true);
-        return new LeaseCountBasedLeaseAssignmentDecider(inMemoryStorageView, MAX_LEASES_FOR_WORKER);
+        return new LeaseCountBasedLeaseAssignmentDecider(inMemoryStorageView, MAX_LEASES_FOR_WORKER, nanoTimeProvider);
     }
 
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
-        decider = new LeaseCountBasedLeaseAssignmentDecider(inMemoryStorageView, MAX_LEASES_FOR_WORKER);
+        decider =
+                new LeaseCountBasedLeaseAssignmentDecider(inMemoryStorageView, MAX_LEASES_FOR_WORKER, nanoTimeProvider);
     }
 
     @Test
@@ -292,6 +297,44 @@ class LeaseCountBasedLeaseAssignmentDeciderTest {
     }
 
     @Test
+    void balanceWorkerVariance_expiredHandoffLease_treatedAsAvailable() {
+        // Setup - worker1 has 2 leases (1 normal + 1 expired handoff), worker2 has 0
+        Lease normalLease = createLease("lease1", "worker1", 100L);
+        Lease expiredHandoffLease = mock(Lease.class);
+        when(expiredHandoffLease.leaseKey()).thenReturn("lease2");
+        when(expiredHandoffLease.leaseOwner()).thenReturn("worker1");
+        when(expiredHandoffLease.actualOwner()).thenReturn("worker1");
+        when(expiredHandoffLease.lastCounterIncrementNanos()).thenReturn(200L);
+        when(expiredHandoffLease.shutdownRequested()).thenReturn(true);
+        // Handoff expired - blockedOnPendingCheckpoint returns false
+        when(expiredHandoffLease.blockedOnPendingCheckpoint(TimeUnit.NANOSECONDS.toMillis(CURRENT_TIME_NANOS)))
+                .thenReturn(false);
+
+        Map<String, Set<Lease>> workerToLeasesMap = new HashMap<>();
+        Set<Lease> worker1Leases = new HashSet<>();
+        worker1Leases.add(normalLease);
+        worker1Leases.add(expiredHandoffLease);
+        workerToLeasesMap.put("worker1", worker1Leases);
+        workerToLeasesMap.put("worker2", new HashSet<>());
+
+        Set<String> workers = new HashSet<>();
+        workers.add("worker1");
+        workers.add("worker2");
+
+        when(inMemoryStorageView.getWorkerToLeasesMap()).thenReturn(workerToLeasesMap);
+        when(inMemoryStorageView.getActiveWorkerIdSet()).thenReturn(workers);
+        when(inMemoryStorageView.getLeaseList()).thenReturn(Arrays.asList(normalLease, expiredHandoffLease));
+
+        LeaseCountBasedLeaseAssignmentDecider decider = createDecider(workers);
+
+        // Execute
+        decider.balanceWorkerVariance();
+
+        // Verify expired handoff lease CAN be stolen for rebalancing
+        verify(inMemoryStorageView).performLeaseAssignment(any(), eq("worker2"));
+    }
+
+    @Test
     void balanceWorkerVariance_maxLeasesForWorkerLimitReached_stopsRebalancing() {
         // Setup - both workers have 12 leases (above max), no rebalancing should occur
         Map<String, Set<Lease>> workerToLeasesMap = new HashMap<>();
@@ -393,6 +436,8 @@ class LeaseCountBasedLeaseAssignmentDeciderTest {
         when(lease.actualOwner()).thenReturn(owner);
         when(lease.lastCounterIncrementNanos()).thenReturn(lastCounterIncrement);
         when(lease.shutdownRequested()).thenReturn(false);
+        when(lease.blockedOnPendingCheckpoint(TimeUnit.NANOSECONDS.toMillis(CURRENT_TIME_NANOS)))
+                .thenReturn(false);
         return lease;
     }
 
@@ -405,6 +450,8 @@ class LeaseCountBasedLeaseAssignmentDeciderTest {
         when(lease.actualOwner()).thenReturn(checkpointOwner); // During handoff, checkpointOwner is actual owner
         when(lease.lastCounterIncrementNanos()).thenReturn(lastCounterIncrement);
         when(lease.shutdownRequested()).thenReturn(true);
+        when(lease.blockedOnPendingCheckpoint(TimeUnit.NANOSECONDS.toMillis(CURRENT_TIME_NANOS)))
+                .thenReturn(true);
         return lease;
     }
 }


### PR DESCRIPTION
*Description of changes:*

`LeaseCountBasedLeaseAssignmentDecider.balanceWorkerVariance()` previously excluded all leases with `shutdownRequested=true` from rebalancing, even after the handoff timed out. This PR replaces the `shutdownRequested()` filter with `blockedOnPendingCheckpoint(currentTimeMillis)`, so expired handoff leases can be reassigned while active handoffs remain protected.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
