### PR TITLE
Add backpressure-aware subscription management for EFO consumers

### DIFF
--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/coordinator/Scheduler.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/coordinator/Scheduler.java
@@ -1128,6 +1128,7 @@ public class Scheduler implements Runnable {
         } else if (metricsFactory instanceof OtelMetricsFactory) {
             ((OtelMetricsFactory) metricsFactory).shutdown();
         }
+        retrievalConfig.retrievalFactory().shutdown();
         shutdownComplete = true;
         finalShutdownLatch.countDown();
     }

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/RetrievalFactory.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/RetrievalFactory.java
@@ -60,4 +60,10 @@ public interface RetrievalFactory {
             ShardInfo shardInfo, StreamConfig streamConfig, MetricsFactory metricsFactory, String consumerId) {
         return createGetRecordsCache(shardInfo, streamConfig, metricsFactory);
     }
+
+    /**
+     * Called during Scheduler shutdown to release any resources held by this factory
+     * (e.g., executor threads). Default implementation is a no-op.
+     */
+    default void shutdown() {}
 }

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/fanout/FanOutConfig.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/fanout/FanOutConfig.java
@@ -20,6 +20,7 @@ import lombok.Data;
 import lombok.NonNull;
 import lombok.experimental.Accessors;
 import org.apache.commons.lang3.ObjectUtils;
+import org.apache.commons.lang3.Validate;
 import software.amazon.awssdk.services.kinesis.KinesisAsyncClient;
 import software.amazon.kinesis.leases.exceptions.DependencyException;
 import software.amazon.kinesis.retrieval.RetrievalFactory;
@@ -78,9 +79,35 @@ public class FanOutConfig implements RetrievalSpecificConfig {
      */
     private long retryBackoffMillis = 1000;
 
+    /**
+     * Duration in milliseconds after which a SubscribeToShard subscription will be cancelled if the consumer is
+     * unable to keep up (backpressure). When the consumer catches up and demand resumes, the publisher will
+     * re-subscribe from the last successfully processed sequence number.
+     *
+     * <p>This prevents OOM caused by unbounded network buffer growth in the HTTP/2 stream when the consumer
+     * blocks in processRecords(). The subscription cancellation terminates the HTTP/2 stream, stopping further
+     * data from accumulating at the network layer.</p>
+     *
+     * <p>A value of 0 (default) disables this feature, preserving existing behavior where subscriptions remain
+     * alive for their full duration regardless of consumer processing speed.</p>
+     *
+     * <p>If enabled, must be at least 1000ms to avoid subscription thrashing.</p>
+     */
+    private long backpressureTimeoutMillis = 0;
+
+    public FanOutConfig backpressureTimeoutMillis(long value) {
+        Validate.isTrue(
+                value == 0 || value >= 1000,
+                "backpressureTimeoutMillis must be 0 (disabled) or >= 1000, got: %d",
+                value);
+        this.backpressureTimeoutMillis = value;
+        return this;
+    }
+
     @Override
     public RetrievalFactory retrievalFactory() {
-        return new FanOutRetrievalFactory(kinesisClient, streamName, consumerArn, this::getOrCreateConsumerArn);
+        return new FanOutRetrievalFactory(
+                kinesisClient, streamName, consumerArn, this::getOrCreateConsumerArn, backpressureTimeoutMillis);
     }
 
     @Override

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/fanout/FanOutRecordsPublisher.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/fanout/FanOutRecordsPublisher.java
@@ -21,8 +21,12 @@ import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
+import javax.annotation.Nullable;
 
 import com.google.common.annotations.VisibleForTesting;
 import lombok.AccessLevel;
@@ -77,6 +81,11 @@ public class FanOutRecordsPublisher implements RecordsPublisher {
     private final String consumerArn;
     private final String streamAndShardId;
     private final StreamIdentifier streamIdentifier;
+    private final long backpressureTimeoutMillis;
+
+    @Nullable
+    private final ScheduledExecutorService backpressureTimerExecutor;
+
     private final Object lockObject = new Object();
 
     private final AtomicInteger subscribeToShardId = new AtomicInteger(0);
@@ -97,13 +106,32 @@ public class FanOutRecordsPublisher implements RecordsPublisher {
 
     private RequestDetails lastSuccessfulRequestDetails = new RequestDetails();
 
+    // Backpressure timer state — guarded by lockObject
+    private ScheduledFuture<?> backpressureTimerFuture;
+    private RecordFlow backpressureTimerTargetFlow;
+    private boolean cancelledByBackpressure = false;
+    private long backpressureTimerEpoch = 0;
+
     public FanOutRecordsPublisher(
             KinesisAsyncClient kinesis, String shardId, String consumerArn, StreamIdentifier streamIdentifier) {
-        this.kinesis = kinesis;
-        this.shardId = shardId;
-        this.consumerArn = consumerArn;
-        this.streamAndShardId = shardId;
-        this.streamIdentifier = streamIdentifier;
+        this(kinesis, shardId, consumerArn, null, streamIdentifier, 0, null);
+    }
+
+    public FanOutRecordsPublisher(
+            KinesisAsyncClient kinesis,
+            String shardId,
+            String consumerArn,
+            StreamIdentifier streamIdentifier,
+            long backpressureTimeoutMillis,
+            @Nullable ScheduledExecutorService backpressureTimerExecutor) {
+        this(
+                kinesis,
+                shardId,
+                consumerArn,
+                null,
+                streamIdentifier,
+                backpressureTimeoutMillis,
+                backpressureTimerExecutor);
     }
 
     public FanOutRecordsPublisher(
@@ -112,11 +140,24 @@ public class FanOutRecordsPublisher implements RecordsPublisher {
             String consumerArn,
             String streamIdentifierSer,
             StreamIdentifier streamIdentifier) {
+        this(kinesis, shardId, consumerArn, streamIdentifierSer, streamIdentifier, 0, null);
+    }
+
+    public FanOutRecordsPublisher(
+            KinesisAsyncClient kinesis,
+            String shardId,
+            String consumerArn,
+            @Nullable String streamIdentifierSer,
+            StreamIdentifier streamIdentifier,
+            long backpressureTimeoutMillis,
+            @Nullable ScheduledExecutorService backpressureTimerExecutor) {
         this.kinesis = kinesis;
         this.shardId = shardId;
         this.consumerArn = consumerArn;
-        this.streamAndShardId = streamIdentifierSer + ":" + shardId;
+        this.streamAndShardId = streamIdentifierSer != null ? streamIdentifierSer + ":" + shardId : shardId;
         this.streamIdentifier = streamIdentifier;
+        this.backpressureTimeoutMillis = backpressureTimeoutMillis;
+        this.backpressureTimerExecutor = backpressureTimerExecutor;
     }
 
     @Override
@@ -138,6 +179,7 @@ public class FanOutRecordsPublisher implements RecordsPublisher {
     @Override
     public void shutdown() {
         synchronized (lockObject) {
+            cancelBackpressureTimer();
             if (flow != null) {
                 flow.cancel();
             }
@@ -381,6 +423,7 @@ public class FanOutRecordsPublisher implements RecordsPublisher {
             ThrowableCategory category = throwableCategory(propagationThrowable);
 
             if (isActiveFlow(triggeringFlow)) {
+                cancelBackpressureTimer();
                 if (flow != null) {
                     String logMessage = String.format(
                             "%s: [SubscriptionLifetime] - (FanOutRecordsPublisher#errorOccurred) @ %s id: %s -- %s."
@@ -615,7 +658,70 @@ public class FanOutRecordsPublisher implements RecordsPublisher {
             availableQueueSpace--;
             if (availableQueueSpace > 0) {
                 triggeringFlow.request(1);
+                rescheduleBackpressureTimer();
             }
+        }
+    }
+
+    // Called under lockObject. Reschedules the backpressure timer after each flow.request(1).
+    // If the timer fires without being rescheduled, it means no upstream request was made
+    // for the timeout duration — the consumer is blocked and the HTTP/2 stream should be cancelled.
+    private void rescheduleBackpressureTimer() {
+        assert Thread.holdsLock(lockObject);
+        if (backpressureTimeoutMillis <= 0 || backpressureTimerExecutor == null) {
+            return;
+        }
+        if (flow == null) {
+            return;
+        }
+
+        if (backpressureTimerFuture != null) {
+            backpressureTimerFuture.cancel(false);
+        }
+
+        long epoch = ++backpressureTimerEpoch;
+        backpressureTimerTargetFlow = flow;
+        backpressureTimerFuture = backpressureTimerExecutor.schedule(
+                () -> onBackpressureTimeout(epoch), backpressureTimeoutMillis, TimeUnit.MILLISECONDS);
+    }
+
+    // Called under lockObject
+    private void cancelBackpressureTimer() {
+        assert Thread.holdsLock(lockObject);
+        if (backpressureTimerFuture != null) {
+            backpressureTimerFuture.cancel(false);
+            backpressureTimerFuture = null;
+            backpressureTimerTargetFlow = null;
+        }
+    }
+
+    private void onBackpressureTimeout(long epoch) {
+        synchronized (lockObject) {
+            if (epoch != backpressureTimerEpoch) {
+                return;
+            }
+            if (backpressureTimerFuture == null) {
+                return;
+            }
+            if (flow == null || flow != backpressureTimerTargetFlow) {
+                backpressureTimerFuture = null;
+                backpressureTimerTargetFlow = null;
+                return;
+            }
+
+            log.warn(
+                    "{}: [SubscriptionLifetime] Backpressure timeout fired ({}ms) -- cancelling flow id: {}."
+                            + " Will re-subscribe when demand resumes.",
+                    streamAndShardId,
+                    backpressureTimeoutMillis,
+                    flow.subscribeToShardId);
+
+            flow.cancel();
+            flow = null;
+            cancelledByBackpressure = true;
+
+            backpressureTimerFuture = null;
+            backpressureTimerTargetFlow = null;
         }
     }
 
@@ -631,6 +737,7 @@ public class FanOutRecordsPublisher implements RecordsPublisher {
                     triggeringFlow.connectionStartedAt,
                     triggeringFlow.subscribeToShardId);
 
+            cancelBackpressureTimer();
             triggeringFlow.cancel();
             if (!hasValidSubscriber()) {
                 log.debug(
@@ -714,6 +821,26 @@ public class FanOutRecordsPublisher implements RecordsPublisher {
                                     lastSuccessfulRequestDetails);
                             return;
                         }
+                        if (flow == null && cancelledByBackpressure) {
+                            cancelledByBackpressure = false;
+                            availableQueueSpace += n;
+                            log.info(
+                                    "{}: [SubscriptionLifetime] Demand resumed after backpressure cancellation."
+                                            + " Re-subscribing from {}",
+                                    streamAndShardId,
+                                    currentSequenceNumber);
+                            try {
+                                subscribeToShard(currentSequenceNumber);
+                            } catch (Throwable t) {
+                                log.warn(
+                                        "{}: [SubscriptionLifetime] Re-subscribe after backpressure failed",
+                                        streamAndShardId,
+                                        t);
+                                subscriber.onError(t);
+                                subscriber = null;
+                            }
+                            return;
+                        }
                         if (flow == null) {
                             //
                             // Flow has been terminated, so we can't make any requests on it anymore.
@@ -728,6 +855,7 @@ public class FanOutRecordsPublisher implements RecordsPublisher {
                         availableQueueSpace += n;
                         if (previous <= 0) {
                             flow.request(1);
+                            rescheduleBackpressureTimer();
                         }
                     }
                 }
@@ -753,6 +881,8 @@ public class FanOutRecordsPublisher implements RecordsPublisher {
                                     lastSuccessfulRequestDetails);
                         }
                         subscriber = null;
+                        cancelBackpressureTimer();
+                        cancelledByBackpressure = false;
                         if (flow != null) {
                             log.debug(
                                     "{}: [SubscriptionLifetime]: (FanOutRecordsPublisher/Subscription#cancel) @ {} id: {}",
@@ -769,6 +899,8 @@ public class FanOutRecordsPublisher implements RecordsPublisher {
     }
 
     private void terminateExistingFlow() {
+        cancelBackpressureTimer();
+        cancelledByBackpressure = false;
         if (flow != null) {
             RecordFlow current = flow;
             flow = null;
@@ -1145,6 +1277,7 @@ public class FanOutRecordsPublisher implements RecordsPublisher {
                         parent.availableQueueSpace);
                 if (parent.availableQueueSpace > 0) {
                     request(1);
+                    parent.rescheduleBackpressureTimer();
                 }
             }
         }

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/fanout/FanOutRetrievalFactory.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/fanout/FanOutRetrievalFactory.java
@@ -18,11 +18,13 @@ package software.amazon.kinesis.retrieval.fanout;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Function;
 import javax.annotation.Nullable;
 
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
 import software.amazon.awssdk.services.kinesis.KinesisAsyncClient;
 import software.amazon.kinesis.annotations.KinesisClientInternalApi;
 import software.amazon.kinesis.common.StreamConfig;
@@ -32,7 +34,6 @@ import software.amazon.kinesis.metrics.MetricsFactory;
 import software.amazon.kinesis.retrieval.RecordsPublisher;
 import software.amazon.kinesis.retrieval.RetrievalFactory;
 
-@RequiredArgsConstructor
 @KinesisClientInternalApi
 public class FanOutRetrievalFactory implements RetrievalFactory {
 
@@ -40,8 +41,39 @@ public class FanOutRetrievalFactory implements RetrievalFactory {
     private final String defaultStreamName;
     private final String defaultConsumerArn;
     private final Function<String, String> consumerArnCreator;
+    private final long backpressureTimeoutMillis;
+
+    @Nullable
+    private final ScheduledExecutorService backpressureTimerExecutor;
 
     private final Map<StreamIdentifier, String> implicitConsumerArnTracker = new HashMap<>();
+
+    public FanOutRetrievalFactory(
+            KinesisAsyncClient kinesisClient,
+            String defaultStreamName,
+            String defaultConsumerArn,
+            Function<String, String> consumerArnCreator) {
+        this(kinesisClient, defaultStreamName, defaultConsumerArn, consumerArnCreator, 0);
+    }
+
+    public FanOutRetrievalFactory(
+            KinesisAsyncClient kinesisClient,
+            String defaultStreamName,
+            String defaultConsumerArn,
+            Function<String, String> consumerArnCreator,
+            long backpressureTimeoutMillis) {
+        this.kinesisClient = kinesisClient;
+        this.defaultStreamName = defaultStreamName;
+        this.defaultConsumerArn = defaultConsumerArn;
+        this.consumerArnCreator = consumerArnCreator;
+        this.backpressureTimeoutMillis = backpressureTimeoutMillis;
+        this.backpressureTimerExecutor = backpressureTimeoutMillis > 0
+                ? Executors.newSingleThreadScheduledExecutor(new ThreadFactoryBuilder()
+                        .setDaemon(true)
+                        .setNameFormat("kinesis-backpressure-timer-%d")
+                        .build())
+                : null;
+    }
 
     @Override
     public RecordsPublisher createGetRecordsCache(
@@ -55,13 +87,23 @@ public class FanOutRetrievalFactory implements RetrievalFactory {
                     shardInfo.shardId(),
                     getOrCreateConsumerArn(streamConfig.streamIdentifier(), streamConfig.consumerArn()),
                     streamIdentifierStr.get(),
-                    streamConfig.streamIdentifier());
+                    streamConfig.streamIdentifier(),
+                    backpressureTimeoutMillis,
+                    backpressureTimerExecutor);
         } else {
             return new FanOutRecordsPublisher(
                     kinesisClient,
                     shardInfo.shardId(),
                     getOrCreateConsumerArn(streamConfig.streamIdentifier(), defaultConsumerArn),
-                    streamConfig.streamIdentifier());
+                    streamConfig.streamIdentifier(),
+                    backpressureTimeoutMillis,
+                    backpressureTimerExecutor);
+        }
+    }
+
+    public void shutdown() {
+        if (backpressureTimerExecutor != null) {
+            backpressureTimerExecutor.shutdownNow();
         }
     }
 

--- a/amazon-kinesis-client/src/test/java/software/amazon/kinesis/retrieval/fanout/FanOutRecordsPublisherTest.java
+++ b/amazon-kinesis-client/src/test/java/software/amazon/kinesis/retrieval/fanout/FanOutRecordsPublisherTest.java
@@ -14,6 +14,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -73,6 +74,7 @@ import software.amazon.kinesis.utils.SubscribeToShardRequestMatcher;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -1919,6 +1921,470 @@ public class FanOutRecordsPublisherTest {
         public void setErrorTrigger(Integer sendErrorAt, Runnable errorAction) {
             this.sendErrorAt = sendErrorAt;
             this.errorAction = errorAction;
+        }
+    }
+
+    // --- Backpressure timeout tests ---
+
+    @Test
+    public void testBackpressureTimerStartsOnFirstUpstreamRequest() throws Exception {
+        ScheduledExecutorService timerExecutor = Executors.newSingleThreadScheduledExecutor();
+        try {
+            FanOutRecordsPublisher source = new FanOutRecordsPublisher(
+                    kinesisClient, SHARD_ID, CONSUMER_ARN, streamIdentifier, 30000, timerExecutor);
+
+            ArgumentCaptor<FanOutRecordsPublisher.RecordSubscription> captor =
+                    ArgumentCaptor.forClass(FanOutRecordsPublisher.RecordSubscription.class);
+            ArgumentCaptor<FanOutRecordsPublisher.RecordFlow> flowCaptor =
+                    ArgumentCaptor.forClass(FanOutRecordsPublisher.RecordFlow.class);
+
+            doNothing().when(publisher).subscribe(captor.capture());
+
+            source.start(
+                    ExtendedSequenceNumber.LATEST,
+                    InitialPositionInStreamExtended.newInitialPosition(InitialPositionInStream.LATEST));
+
+            // Subscribe but DON'T request more after initial — simulates blocked consumer
+            final Subscription[] subHolder = new Subscription[1];
+            source.subscribe(new ShardConsumerNotifyingSubscriber(
+                    new Subscriber<RecordsRetrieved>() {
+                        @Override
+                        public void onSubscribe(Subscription s) {
+                            subHolder[0] = s;
+                            s.request(1);
+                        }
+
+                        @Override
+                        public void onNext(RecordsRetrieved input) {
+                            // Don't request more — simulate backpressure
+                        }
+
+                        @Override
+                        public void onError(Throwable t) {}
+
+                        @Override
+                        public void onComplete() {}
+                    },
+                    source));
+
+            verify(kinesisClient).subscribeToShard(any(SubscribeToShardRequest.class), flowCaptor.capture());
+            flowCaptor.getValue().onEventStream(publisher);
+            captor.getValue().onSubscribe(subscription);
+
+            SubscribeToShardEvent event = SubscribeToShardEvent.builder()
+                    .millisBehindLatest(100L)
+                    .records(Collections.singletonList(makeRecord(1)))
+                    .continuationSequenceNumber("seq-1")
+                    .childShards(Collections.emptyList())
+                    .build();
+
+            // Deliver one event — after processing, no more flow.request(1) will be issued
+            // because the subscriber doesn't call request(1) in onNext (simulates blocked consumer).
+            // The timer was started on the initial flow.request(1) at onSubscribe.
+            captor.getValue().onNext(event);
+
+            // Timer is scheduled but timeout is 30s — should NOT fire within a short window
+            Thread.sleep(100);
+            verify(subscription, never()).cancel();
+        } finally {
+            timerExecutor.shutdownNow();
+        }
+    }
+
+    @Test
+    public void testBackpressureTimerCancelledWhenDemandResumes() throws Exception {
+        ScheduledExecutorService timerExecutor = Executors.newSingleThreadScheduledExecutor();
+        try {
+            FanOutRecordsPublisher source = new FanOutRecordsPublisher(
+                    kinesisClient, SHARD_ID, CONSUMER_ARN, streamIdentifier, 30000, timerExecutor);
+
+            ArgumentCaptor<FanOutRecordsPublisher.RecordSubscription> captor =
+                    ArgumentCaptor.forClass(FanOutRecordsPublisher.RecordSubscription.class);
+            ArgumentCaptor<FanOutRecordsPublisher.RecordFlow> flowCaptor =
+                    ArgumentCaptor.forClass(FanOutRecordsPublisher.RecordFlow.class);
+
+            doNothing().when(publisher).subscribe(captor.capture());
+
+            source.start(
+                    ExtendedSequenceNumber.LATEST,
+                    InitialPositionInStreamExtended.newInitialPosition(InitialPositionInStream.LATEST));
+
+            final Subscription[] subHolder = new Subscription[1];
+            source.subscribe(new ShardConsumerNotifyingSubscriber(
+                    new Subscriber<RecordsRetrieved>() {
+                        @Override
+                        public void onSubscribe(Subscription s) {
+                            subHolder[0] = s;
+                            s.request(1);
+                        }
+
+                        @Override
+                        public void onNext(RecordsRetrieved input) {
+                            // Don't request — backpressure
+                        }
+
+                        @Override
+                        public void onError(Throwable t) {}
+
+                        @Override
+                        public void onComplete() {}
+                    },
+                    source));
+
+            verify(kinesisClient).subscribeToShard(any(SubscribeToShardRequest.class), flowCaptor.capture());
+            flowCaptor.getValue().onEventStream(publisher);
+            captor.getValue().onSubscribe(subscription);
+
+            SubscribeToShardEvent event = SubscribeToShardEvent.builder()
+                    .millisBehindLatest(100L)
+                    .records(Collections.singletonList(makeRecord(1)))
+                    .continuationSequenceNumber("seq-1")
+                    .childShards(Collections.emptyList())
+                    .build();
+
+            // Deliver event — no ack means no further flow.request(1), timer is ticking
+            captor.getValue().onNext(event);
+
+            // Demand resumes — this triggers flow.request(1) which reschedules the timer
+            subHolder[0].request(1);
+
+            // Wait longer than a short timeout would fire — should NOT cancel subscription
+            Thread.sleep(200);
+            verify(subscription, never()).cancel();
+        } finally {
+            timerExecutor.shutdownNow();
+        }
+    }
+
+    @Test
+    public void testBackpressureTimeoutCancelsFlowAndResubscribesOnDemand() throws Exception {
+        ScheduledExecutorService timerExecutor = Executors.newSingleThreadScheduledExecutor();
+        try {
+            // Use a very short timeout so the test doesn't take long
+            FanOutRecordsPublisher source = new FanOutRecordsPublisher(
+                    kinesisClient, SHARD_ID, CONSUMER_ARN, streamIdentifier, 1000, timerExecutor);
+
+            ArgumentCaptor<FanOutRecordsPublisher.RecordSubscription> captor =
+                    ArgumentCaptor.forClass(FanOutRecordsPublisher.RecordSubscription.class);
+            ArgumentCaptor<FanOutRecordsPublisher.RecordFlow> flowCaptor =
+                    ArgumentCaptor.forClass(FanOutRecordsPublisher.RecordFlow.class);
+
+            doNothing().when(publisher).subscribe(captor.capture());
+
+            source.start(
+                    new ExtendedSequenceNumber("seq-0"),
+                    InitialPositionInStreamExtended.newInitialPosition(InitialPositionInStream.LATEST));
+
+            final Subscription[] subHolder = new Subscription[1];
+            final AtomicBoolean errorCalled = new AtomicBoolean(false);
+            source.subscribe(new ShardConsumerNotifyingSubscriber(
+                    new Subscriber<RecordsRetrieved>() {
+                        @Override
+                        public void onSubscribe(Subscription s) {
+                            subHolder[0] = s;
+                            s.request(1);
+                        }
+
+                        @Override
+                        public void onNext(RecordsRetrieved input) {
+                            // Don't request — backpressure
+                        }
+
+                        @Override
+                        public void onError(Throwable t) {
+                            errorCalled.set(true);
+                        }
+
+                        @Override
+                        public void onComplete() {}
+                    },
+                    source));
+
+            verify(kinesisClient).subscribeToShard(any(SubscribeToShardRequest.class), flowCaptor.capture());
+            flowCaptor.getValue().onEventStream(publisher);
+            captor.getValue().onSubscribe(subscription);
+
+            SubscribeToShardEvent event = SubscribeToShardEvent.builder()
+                    .millisBehindLatest(100L)
+                    .records(Collections.singletonList(makeRecord(1)))
+                    .continuationSequenceNumber("seq-1")
+                    .childShards(Collections.emptyList())
+                    .build();
+
+            // Deliver event — no ack means no further flow.request(1), timer will fire
+            captor.getValue().onNext(event);
+
+            // Wait for timeout to fire
+            Thread.sleep(1500);
+
+            // Subscription should have been cancelled by the timeout
+            verify(subscription).cancel();
+            // Should NOT have called onError — this is a controlled cancellation
+            assertFalse(errorCalled.get());
+
+            // Now simulate demand resuming — should trigger re-subscribe
+            reset(kinesisClient);
+            doNothing().when(publisher).subscribe(captor.capture());
+
+            subHolder[0].request(1);
+
+            // Should have re-subscribed
+            verify(kinesisClient).subscribeToShard(any(SubscribeToShardRequest.class), any());
+        } finally {
+            timerExecutor.shutdownNow();
+        }
+    }
+
+    @Test
+    public void testBackpressureTimeoutNotStartedWhenFeatureDisabled() throws Exception {
+        // Default constructor — timeout is 0 (disabled)
+        FanOutRecordsPublisher source =
+                new FanOutRecordsPublisher(kinesisClient, SHARD_ID, CONSUMER_ARN, streamIdentifier);
+
+        ArgumentCaptor<FanOutRecordsPublisher.RecordSubscription> captor =
+                ArgumentCaptor.forClass(FanOutRecordsPublisher.RecordSubscription.class);
+        ArgumentCaptor<FanOutRecordsPublisher.RecordFlow> flowCaptor =
+                ArgumentCaptor.forClass(FanOutRecordsPublisher.RecordFlow.class);
+
+        doNothing().when(publisher).subscribe(captor.capture());
+
+        source.start(
+                ExtendedSequenceNumber.LATEST,
+                InitialPositionInStreamExtended.newInitialPosition(InitialPositionInStream.LATEST));
+
+        source.subscribe(new ShardConsumerNotifyingSubscriber(
+                new Subscriber<RecordsRetrieved>() {
+                    @Override
+                    public void onSubscribe(Subscription s) {
+                        s.request(1);
+                    }
+
+                    @Override
+                    public void onNext(RecordsRetrieved input) {
+                        // Don't request — backpressure
+                    }
+
+                    @Override
+                    public void onError(Throwable t) {}
+
+                    @Override
+                    public void onComplete() {}
+                },
+                source));
+
+        verify(kinesisClient).subscribeToShard(any(SubscribeToShardRequest.class), flowCaptor.capture());
+        flowCaptor.getValue().onEventStream(publisher);
+        captor.getValue().onSubscribe(subscription);
+
+        SubscribeToShardEvent event = SubscribeToShardEvent.builder()
+                .millisBehindLatest(100L)
+                .records(Collections.singletonList(makeRecord(1)))
+                .continuationSequenceNumber("seq-1")
+                .childShards(Collections.emptyList())
+                .build();
+
+        captor.getValue().onNext(event);
+
+        // Even after waiting, subscription should never be cancelled (no timer exists)
+        Thread.sleep(200);
+        verify(subscription, never()).cancel();
+    }
+
+    @Test
+    public void testBackpressureTimerCancelledOnShutdown() throws Exception {
+        ScheduledExecutorService timerExecutor = Executors.newSingleThreadScheduledExecutor();
+        try {
+            FanOutRecordsPublisher source = new FanOutRecordsPublisher(
+                    kinesisClient, SHARD_ID, CONSUMER_ARN, streamIdentifier, 1000, timerExecutor);
+
+            ArgumentCaptor<FanOutRecordsPublisher.RecordSubscription> captor =
+                    ArgumentCaptor.forClass(FanOutRecordsPublisher.RecordSubscription.class);
+            ArgumentCaptor<FanOutRecordsPublisher.RecordFlow> flowCaptor =
+                    ArgumentCaptor.forClass(FanOutRecordsPublisher.RecordFlow.class);
+
+            doNothing().when(publisher).subscribe(captor.capture());
+
+            source.start(
+                    ExtendedSequenceNumber.LATEST,
+                    InitialPositionInStreamExtended.newInitialPosition(InitialPositionInStream.LATEST));
+
+            source.subscribe(new ShardConsumerNotifyingSubscriber(
+                    new Subscriber<RecordsRetrieved>() {
+                        @Override
+                        public void onSubscribe(Subscription s) {
+                            s.request(1);
+                        }
+
+                        @Override
+                        public void onNext(RecordsRetrieved input) {}
+
+                        @Override
+                        public void onError(Throwable t) {}
+
+                        @Override
+                        public void onComplete() {}
+                    },
+                    source));
+
+            verify(kinesisClient).subscribeToShard(any(SubscribeToShardRequest.class), flowCaptor.capture());
+            flowCaptor.getValue().onEventStream(publisher);
+            captor.getValue().onSubscribe(subscription);
+
+            SubscribeToShardEvent event = SubscribeToShardEvent.builder()
+                    .millisBehindLatest(100L)
+                    .records(Collections.singletonList(makeRecord(1)))
+                    .continuationSequenceNumber("seq-1")
+                    .childShards(Collections.emptyList())
+                    .build();
+
+            // Deliver event — no ack means no further flow.request(1), timer will fire
+            captor.getValue().onNext(event);
+
+            // Shutdown should cancel the timer
+            source.shutdown();
+
+            // Wait past timeout — should NOT fire since we shut down
+            Thread.sleep(1500);
+            // subscription.cancel() is called by shutdown itself, but no error should propagate
+        } finally {
+            timerExecutor.shutdownNow();
+        }
+    }
+
+    @Test
+    public void testBackpressureTimerCancelledOnError() throws Exception {
+        ScheduledExecutorService timerExecutor = Executors.newSingleThreadScheduledExecutor();
+        try {
+            FanOutRecordsPublisher source = new FanOutRecordsPublisher(
+                    kinesisClient, SHARD_ID, CONSUMER_ARN, streamIdentifier, 1000, timerExecutor);
+
+            ArgumentCaptor<FanOutRecordsPublisher.RecordSubscription> captor =
+                    ArgumentCaptor.forClass(FanOutRecordsPublisher.RecordSubscription.class);
+            ArgumentCaptor<FanOutRecordsPublisher.RecordFlow> flowCaptor =
+                    ArgumentCaptor.forClass(FanOutRecordsPublisher.RecordFlow.class);
+
+            doNothing().when(publisher).subscribe(captor.capture());
+
+            source.start(
+                    ExtendedSequenceNumber.LATEST,
+                    InitialPositionInStreamExtended.newInitialPosition(InitialPositionInStream.LATEST));
+
+            final AtomicBoolean errorCalled = new AtomicBoolean(false);
+            source.subscribe(new ShardConsumerNotifyingSubscriber(
+                    new Subscriber<RecordsRetrieved>() {
+                        @Override
+                        public void onSubscribe(Subscription s) {
+                            s.request(1);
+                        }
+
+                        @Override
+                        public void onNext(RecordsRetrieved input) {}
+
+                        @Override
+                        public void onError(Throwable t) {
+                            errorCalled.set(true);
+                        }
+
+                        @Override
+                        public void onComplete() {}
+                    },
+                    source));
+
+            verify(kinesisClient).subscribeToShard(any(SubscribeToShardRequest.class), flowCaptor.capture());
+            flowCaptor.getValue().onEventStream(publisher);
+            captor.getValue().onSubscribe(subscription);
+
+            SubscribeToShardEvent event = SubscribeToShardEvent.builder()
+                    .millisBehindLatest(100L)
+                    .records(Collections.singletonList(makeRecord(1)))
+                    .continuationSequenceNumber("seq-1")
+                    .childShards(Collections.emptyList())
+                    .build();
+
+            // Deliver event — no ack means no further flow.request(1), timer will fire
+            captor.getValue().onNext(event);
+
+            // Simulate an error occurring on the flow (via RecordFlow.exceptionOccurred)
+            flowCaptor.getValue().exceptionOccurred(new RuntimeException("test error"));
+
+            // Error should have been propagated
+            assertTrue(errorCalled.get());
+
+            // Wait past timeout — should NOT fire since error cancelled the timer
+            Thread.sleep(1500);
+            // No additional cancel beyond what errorOccurred already did
+        } finally {
+            timerExecutor.shutdownNow();
+        }
+    }
+
+    @Test
+    public void testBackpressureStaleTimerIsNoOpWhenFlowChangedByError() throws Exception {
+        ScheduledExecutorService timerExecutor = Executors.newSingleThreadScheduledExecutor();
+        try {
+            FanOutRecordsPublisher source = new FanOutRecordsPublisher(
+                    kinesisClient, SHARD_ID, CONSUMER_ARN, streamIdentifier, 1000, timerExecutor);
+
+            ArgumentCaptor<FanOutRecordsPublisher.RecordSubscription> captor =
+                    ArgumentCaptor.forClass(FanOutRecordsPublisher.RecordSubscription.class);
+            ArgumentCaptor<FanOutRecordsPublisher.RecordFlow> flowCaptor =
+                    ArgumentCaptor.forClass(FanOutRecordsPublisher.RecordFlow.class);
+
+            doNothing().when(publisher).subscribe(captor.capture());
+
+            source.start(
+                    ExtendedSequenceNumber.LATEST,
+                    InitialPositionInStreamExtended.newInitialPosition(InitialPositionInStream.LATEST));
+
+            source.subscribe(new ShardConsumerNotifyingSubscriber(
+                    new Subscriber<RecordsRetrieved>() {
+                        @Override
+                        public void onSubscribe(Subscription s) {
+                            s.request(1);
+                        }
+
+                        @Override
+                        public void onNext(RecordsRetrieved input) {}
+
+                        @Override
+                        public void onError(Throwable t) {}
+
+                        @Override
+                        public void onComplete() {}
+                    },
+                    source));
+
+            verify(kinesisClient).subscribeToShard(any(SubscribeToShardRequest.class), flowCaptor.capture());
+            FanOutRecordsPublisher.RecordFlow firstFlow = flowCaptor.getValue();
+            firstFlow.onEventStream(publisher);
+            captor.getValue().onSubscribe(subscription);
+
+            SubscribeToShardEvent event = SubscribeToShardEvent.builder()
+                    .millisBehindLatest(100L)
+                    .records(Collections.singletonList(makeRecord(1)))
+                    .continuationSequenceNumber("seq-1")
+                    .childShards(Collections.emptyList())
+                    .build();
+
+            // Drive to zero queue space — triggers timer start for firstFlow
+            captor.getValue().onNext(event);
+
+            // Simulate error replacing the flow with a new one (via reconnect)
+            // The error cancels the timer, but let's test what happens if the timer
+            // sneaks through by simulating the scenario: error occurs, new flow starts,
+            // and then the stale timer would fire — but it shouldn't affect the new flow.
+            firstFlow.exceptionOccurred(new RuntimeException("connection reset"));
+
+            // Wait past the timeout — stale timer should be a no-op
+            Thread.sleep(1500);
+
+            // The first flow's subscription was cancelled via errorOccurred, but this is
+            // expected error handling, not backpressure timeout behavior.
+            // Key assertion: no backpressure-induced cancellation flag was set
+            // (verified by checking that a subsequent request doesn't trigger re-subscribe)
+            verify(subscription).cancel();
+        } finally {
+            timerExecutor.shutdownNow();
         }
     }
 


### PR DESCRIPTION
# Add backpressure-aware subscription management for EFO consumers

**Issue:** https://github.com/awslabs/amazon-kinesis-client/issues/1699

## Summary

This PR introduces a new opt-in capability that allows EFO consumers to signal backpressure by automatically cancelling SubscribeToShard subscriptions when the consumer cannot keep up with the incoming data rate. This prevents unbounded memory growth in the SDK's network buffers when `processRecords()` blocks for extended periods.

New configuration: `FanOutConfig.backpressureTimeoutMillis`. When set, KCL monitors upstream request activity and cancels the HTTP/2 subscription if no demand is issued within the configured duration. When the consumer catches up, KCL re-subscribes from the last successfully delivered sequence number.

## Background

### How EFO data flows through KCL

```
Kinesis Service
    │  (HTTP/2 push, data arrives whether or not KCL is ready)
    ▼
Netty receives HTTP/2 DATA frames
    │  (buffered in MessageDecoder.buf, unbounded, no backpressure from above)
    ▼
SDK deserializes into SubscribeToShardEvent
    │  (only delivered when KCL calls request(1) on RecordSubscription via Reactive Streams)
    ▼
FanOutRecordsPublisher.recordsReceived()
    │  (enqueues into recordsDeliveryQueue, bounded to 11 slots)
    ▼
FanOutRecordsPublisher.recordsDeliveryQueue
    │  (only drained when downstream calls notify() with an ack)
    ▼
RxJava observeOn buffer (8 slots)
    ▼
ShardConsumerSubscriber.onNext()
    │  (calls shardConsumer.handleInput() synchronously)
    ▼
ShardConsumer.handleInput() → processData() → ProcessTask.call()
    │  (invokes user's processRecords())
    ▼
ShardRecordProcessor.processRecords()  ← user code blocks here
```

### Where backpressure propagates and where it doesn't

**Within KCL (works correctly):** When the user blocks in `processRecords()`, the processing thread stalls inside `ShardConsumerSubscriber.onNext()`. No ack is sent back to the publisher, so `FanOutRecordsPublisher.notify()` is never called. Since `notify()` is the only path that calls `updateAvailableQueueSpaceAndRequestUpstream()` (which is where `flow.request(1)` is issued to the SDK), the SDK subscription goes idle. No more `SubscribeToShardEvent` objects are delivered to KCL.

**At the network layer (unbounded):** The HTTP/2 stream from Kinesis remains open. The service continues pushing data frames. Netty continues receiving them. The SDK's `MessageDecoder` accumulates raw bytes in its internal buffer, waiting for the application to request the next event so it can deserialize and deliver. This buffer has no bound and no feedback signal to the network.

### Heap dump from the reporter (20 GB heap, 14.5 GB in byte arrays)

| Source | Size | % | Cause |
|--------|------|---|-------|
| `MessageDecoder.buf` (Netty/SDK network layer) | ~9.5 GB | 65% | HTTP/2 stream open, bytes arriving, nobody consuming |
| `ProcessTask.processRecordsInput` (in-flight batch) | ~2.0 GB | 14% | Batch currently blocked in user code |
| Thread-local records (user's blocking buffer) | ~1.9 GB | 13% | User's own buffer holding records |
| `recordsDeliveryQueue` (KCL's 11-slot queue) | ~1.7 GB | 12% | KCL internal queue, bounded, working correctly |
| `lastAccepted` / RxJava buffer | ~0.2 GB | 1% | RxJava observeOn holding reference |

The dominant problem (65% of heap) is the `MessageDecoder` buffer: raw HTTP/2 bytes accumulating because the subscription remains alive. KCL's internal buffers are bounded and working as designed.

## Responses to issue questions

### Q1: Is blocking in `processRecords()` the right approach for backpressure?

**No, not for EFO.** Blocking correctly pauses KCL's internal reactive pipeline (no more `request(1)` calls propagate upstream). But EFO is push-based: the HTTP/2 stream keeps delivering data at the network level regardless. The only way to stop inbound data is to cancel the SubscribeToShard subscription entirely.

For polling mode, blocking works because no poll = no data. For EFO, the equivalent of "stop polling" is "cancel the subscription and re-subscribe later." This PR provides that mechanism via `backpressureTimeoutMillis`.

### Q2: Can we configure/decrease the EFO caches?

The caches are hardcoded today (`recordsDeliveryQueue` = 11 batches, RxJava buffer = 8 batches), but configuring them wouldn't address this problem. The backpressure at this layer already works correctly: the queue never overflows, and KCL correctly stops requesting events from the SDK when the queue is full. These buffers account for only ~13% of the OOM heap. The 65% that causes the OOM is below KCL's control, in the network layer.

### Q3: Can we limit `MessageDecoder` buffer sizes?

Not directly from KCL. The `MessageDecoder` lives in the AWS SDK (`software.amazon.eventstream` package). Its buffer grows as Netty delivers HTTP/2 DATA frames, which is below KCL's abstraction layer. HTTP/2 flow control (withholding WINDOW_UPDATE frames) or Netty channel configuration (`AUTO_READ`) could theoretically help but aren't exposed by the SDK.

The only lever KCL has: cancel the subscription, which terminates the HTTP/2 stream and stops data from arriving at the network level entirely. This PR does that.

### Q4: Should `MAX_TIME_BETWEEN_REQUEST_RESPONSE` (60s) be configurable for long-blocked consumers?

It's irrelevant to this problem. This timer is a dead-connection detector, not a backpressure mechanism.

During backpressure, the timer never fires because:
1. `onNext` enters, sets `lastRequestTime = null`
2. `handleInput()` blocks in user code (minutes pass)
3. Health check calls `restartIfRequestTimerExpired`, sees `lastRequestTime == null`, does nothing
4. User unblocks, `subscription.request(1)` sets `lastRequestTime = Instant.now()`
5. Data arrives instantly from Netty's buffers, resets the timer

The timer only fires when KCL has called `request(1)` but no `onNext` arrives within 60s, i.e. the HTTP/2 stream silently died. Since EFO is push-based with data already buffered in Netty, this never happens during backpressure.

## Approach

### Detection

After each `flow.request(1)`, schedule a one-shot timer for the configured timeout. Each subsequent `flow.request(1)` reschedules the timer (cancel + new schedule). If the timer fires without being rescheduled, no upstream request was made for the full timeout duration, so we cancel the flow.

A generation counter (`backpressureTimerEpoch`) prevents a race where a stale timer callback (already executing, blocked on the lock) could incorrectly cancel a live flow that was just rescheduled.

Note: tracking `availableQueueSpace == 0` does NOT work as a trigger. When the consumer blocks, `availableQueueSpace` stays positive (it's only decremented by ack receipt, which stops). The backpressure manifests as "no `flow.request(1)` calls" rather than "availableQueueSpace == 0".

### Cancellation

Call `flow.cancel()`, the same path already used for errors and timeouts. This cancels the `RecordSubscription`, which terminates the HTTP/2 stream.

### Recovery

Don't re-subscribe immediately. The consumer is still blocked; there's no point fetching more data. The `recordsDeliveryQueue` holds up to 11 batches that drain normally. When the queue empties and downstream calls `subscription.request(n)` again (meaning the consumer has caught up), we detect that `flow == null` and re-subscribe from `currentSequenceNumber`.

### Why time-based rather than byte-based

Neither option can observe `MessageDecoder` buffers directly since they're internal to the SDK. A byte-based threshold on the KCL queue would saturate immediately and reduce to "cancel as soon as the queue stops draining." The `MessageDecoder` accumulates at roughly `shard_throughput × time_subscription_stays_open_while_idle`. A time-based trigger directly caps this: `aggregate_throughput × timeout = max memory overshoot`.

Memory overshoot at ~400 MB/s aggregate (200 shards × 2 MB/s):
- 1s → ~400 MB
- 5s → ~2 GB
- 10s → ~4 GB

### Why this is safe

- Re-subscribing is already a normal, well-exercised event in KCL (connections drop, read timeouts, errors all trigger it)
- `currentSequenceNumber` tracks the last successfully delivered batch, so re-subscribe resumes from exactly where it left off
- The existing `recordsDeliveryQueue` and `availableQueueSpace` logic continues to work unchanged
- Users who never experience backpressure are never affected (the timer never fires if demand keeps up, because each `flow.request(1)` reschedules it)
- The generation counter prevents stale timer callbacks from cancelling a live flow under lock contention
- Timer state is cleaned up on all flow termination paths (shutdown, error, onComplete, Subscription.cancel, terminateExistingFlow)
- When disabled (default), zero overhead: no threads created, timer methods return on first line

## Configuration

```java
FanOutConfig fanOutConfig = new FanOutConfig(kinesisClient)
        .streamName(streamName)
        .consumerArn(consumerArn)
        .backpressureTimeoutMillis(5000);  // cancel subscription after 5s of no demand
```

- Default: `0` (disabled, current behavior preserved)
- Minimum: `1000ms` (enforced by validation, prevents subscription thrashing)
- Recommended: Set based on `aggregate_throughput × timeout < available_memory_headroom`

## Changes

### `FanOutConfig.java`
- Added `backpressureTimeoutMillis` field with default `0` (disabled)
- Added custom fluent setter with validation (`Validate.isTrue(value == 0 || value >= 1000)`)
- Updated `retrievalFactory()` to pass the timeout to `FanOutRetrievalFactory`

### `FanOutRetrievalFactory.java`
- Replaced `@RequiredArgsConstructor` with explicit constructors to support optional parameters
- Added `backpressureTimeoutMillis` and `backpressureTimerExecutor` fields
- Creates a shared single-thread daemon `ScheduledExecutorService` when timeout > 0 (no thread created when disabled)
- Passes both to each `FanOutRecordsPublisher` instance via `createGetRecordsCache()`
- Added `shutdown()` method to terminate the executor on Scheduler shutdown
- Added backward-compatible 4-arg constructor that delegates with timeout=0

### `FanOutRecordsPublisher.java`
- Added fields: `backpressureTimeoutMillis`, `backpressureTimerExecutor` (final, from config), `backpressureTimerFuture`, `backpressureTimerTargetFlow`, `cancelledByBackpressure`, `backpressureTimerEpoch` (guarded by `lockObject`)
- Added constructor overloads: existing 4-arg and 5-arg constructors delegate to new canonical 7-arg constructor; null `streamIdentifierSer` handled with ternary for `streamAndShardId`
- Added `rescheduleBackpressureTimer()`: called after every `flow.request(1)`, increments epoch, cancels existing timer, schedules new one-shot; includes `assert Thread.holdsLock(lockObject)`
- Added `cancelBackpressureTimer()`: cancels pending timer, nulls state; includes lock assertion
- Added `onBackpressureTimeout(long epoch)`: acquires lock, validates epoch + flow identity, cancels flow, sets `cancelledByBackpressure = true`, logs at WARN
- Modified `updateAvailableQueueSpaceAndRequestUpstream()`: calls `rescheduleBackpressureTimer()` after `triggeringFlow.request(1)`
- Modified `Subscription.request(n)` handler: added re-subscribe path when `flow == null && cancelledByBackpressure` (clears flag, increments space, calls `subscribeToShard`); calls `rescheduleBackpressureTimer()` after `flow.request(1)` on demand transition
- Modified `RecordSubscription.onSubscribe()`: calls `parent.rescheduleBackpressureTimer()` after initial `request(1)`
- Modified `shutdown()`: calls `cancelBackpressureTimer()` before cancelling flow
- Modified `errorOccurred()`: calls `cancelBackpressureTimer()` in active flow path
- Modified `onComplete()`: calls `cancelBackpressureTimer()` before cancelling flow
- Modified `terminateExistingFlow()`: calls `cancelBackpressureTimer()` and resets `cancelledByBackpressure`
- Modified `Subscription.cancel()`: calls `cancelBackpressureTimer()` and resets `cancelledByBackpressure`

### `RetrievalFactory.java`
- Added `default void shutdown() {}` to the interface, enabling polymorphic lifecycle management without instanceof checks

### `Scheduler.java`
- Added `retrievalConfig.retrievalFactory().shutdown()` in `finalShutdown()` to terminate the backpressure timer executor

### `FanOutRecordsPublisherTest.java`
- Added 7 unit tests covering: timer start, timer cancellation on demand resume, full timeout/cancel/resubscribe lifecycle, feature-disabled no-op, timer cancelled on shutdown, timer cancelled on error, stale timer no-op

## Backward compatibility

When `backpressureTimeoutMillis = 0` (default):
- No executor thread is created
- Timer methods return immediately on first check (no-op)
- No behavioral change to existing subscription lifecycle
- Old constructors delegate to canonical constructor with `0, null`
- Negligible performance cost (one branch per `flow.request(1)`)

## Testing

### Unit tests (`FanOutRecordsPublisherTest.java`)

- `testBackpressureTimerStartsOnFirstUpstreamRequest`: timer is scheduled after initial `flow.request(1)`, does not fire prematurely
- `testBackpressureTimerCancelledWhenDemandResumes`: demand resume reschedules timer, preventing false cancellation
- `testBackpressureTimeoutCancelsFlowAndResubscribesOnDemand`: full lifecycle (timeout fires, flow cancelled, demand resumes, re-subscribes from correct sequence number)
- `testBackpressureTimeoutNotStartedWhenFeatureDisabled`: default config (0) never creates a timer
- `testBackpressureTimerCancelledOnShutdown`: shutdown cancels pending timer cleanly
- `testBackpressureTimerCancelledOnError`: flow error cancels timer before it can fire
- `testBackpressureStaleTimerIsNoOpWhenFlowChangedByError`: stale timer from a previous flow does not affect a new flow

### E2E validation

A standalone test app that validates the feature against a real Kinesis stream with 10 shards and an EFO consumer. The record processor blocks indefinitely on `processRecords()`, reproducing the exact pattern from issue #1699.

**Setup:** 10-shard stream, EFO consumer registered, DynamoDB lease tables pre-created with a setup script.

**Test procedure:**
1. Run without timeout (`backpressureTimeoutMillis = 0`, `-Xmx256m`): OOMs within seconds of `processRecords` blocking
2. Run with timeout (`backpressureTimeoutMillis = 1000`, `-Xmx256m`): subscriptions cancelled after 1s of backpressure, heap stable indefinitely

**Without timeout (OOM):**
```
Filtering logs to: HEAP, processRecords, Backpressure, OOM, PRODUCER
Press Ctrl+C to stop.

11:50:55.363 [software.amazon.kinesis.e2e.BackpressureE2EApp.main()] INFO  s.a.kinesis.e2e.BackpressureE2EApp - Timeout: 0ms (DISABLED — expect OOM)
11:50:55.731 [pool-8-thread-1] INFO  s.a.kinesis.e2e.BackpressureE2EApp - [HEAP] 67MB / 256MB
...
...
11:51:22.581 [ShardRecordProcessor-0008] INFO  s.a.kinesis.e2e.SlowRecordProcessor - [shardId-000000000009] processRecords called with 914 records — blocking indefinitely
...
...
11:51:35.734 [pool-8-thread-1] INFO  s.a.kinesis.e2e.BackpressureE2EApp - [HEAP] 216MB / 256MB
OutOfMemoryError: Java heap space
11:51:36.500 [aws-java-sdk-NettyEventLoop-0-5] WARN  s.a.k.r.f.FanOutRecordsPublisher - shardId-000000000005: [SubscriptionLifetime] - (FanOutRecordsPublisher#errorOccurred) @ 2026-06-04T18:51:12.561252Z id: shardId-000000000005-1 -- java.lang.OutOfMemoryError: Java heap space. Last successful request details -- request id - <REDACTED>>, timestamp - 2026-06-04T18:51:12.561252Z
java.lang.OutOfMemoryError: Java heap space
```

**With timeout of 1 second (stable):**
```
11:52:32.821 [pool-8-thread-1] INFO  s.a.kinesis.e2e.BackpressureE2EApp - [HEAP] 66MB / 256MB
...
11:52:50.823 [pool-8-thread-1] INFO  s.a.kinesis.e2e.BackpressureE2EApp - [HEAP] 82MB / 256MB
11:52:51.003 [kinesis-backpressure-timer-0] WARN  s.a.k.r.f.FanOutRecordsPublisher - shardId-000000000001: [SubscriptionLifetime] Backpressure timeout fired (1000ms) -- cancelling flow id: shardId-000000000001-1. Will re-subscribe when demand resumes.
11:52:51.003 [kinesis-backpressure-timer-0] WARN  s.a.k.r.f.FanOutRecordsPublisher - shardId-000000000002: [SubscriptionLifetime] Backpressure timeout fired (1000ms) -- cancelling flow id: shardId-000000000002-1. Will re-subscribe when demand resumes.
11:52:51.003 [kinesis-backpressure-timer-0] WARN  s.a.k.r.f.FanOutRecordsPublisher - shardId-000000000008: [SubscriptionLifetime] Backpressure timeout fired (1000ms) -- cancelling flow id: shardId-000000000008-1. Will re-subscribe when demand resumes.
11:52:51.003 [kinesis-backpressure-timer-0] WARN  s.a.k.r.f.FanOutRecordsPublisher - shardId-000000000009: [SubscriptionLifetime] Backpressure timeout fired (1000ms) -- cancelling flow id: shardId-000000000009-1. Will re-subscribe when demand resumes.
11:52:51.003 [kinesis-backpressure-timer-0] WARN  s.a.k.r.f.FanOutRecordsPublisher - shardId-000000000003: [SubscriptionLifetime] Backpressure timeout fired (1000ms) -- cancelling flow id: shardId-000000000003-1. Will re-subscribe when demand resumes.
11:52:51.812 [kinesis-backpressure-timer-0] WARN  s.a.k.r.f.FanOutRecordsPublisher - shardId-000000000007: [SubscriptionLifetime] Backpressure timeout fired (1000ms) -- cancelling flow id: shardId-000000000007-1. Will re-subscribe when demand resumes.
11:52:51.831 [kinesis-backpressure-timer-0] WARN  s.a.k.r.f.FanOutRecordsPublisher - shardId-000000000006: [SubscriptionLifetime] Backpressure timeout fired (1000ms) -- cancelling flow id: shardId-000000000006-1. Will re-subscribe when demand resumes.
11:52:51.843 [kinesis-backpressure-timer-0] WARN  s.a.k.r.f.FanOutRecordsPublisher - shardId-000000000005: [SubscriptionLifetime] Backpressure timeout fired (1000ms) -- cancelling flow id: shardId-000000000005-1. Will re-subscribe when demand resumes.
11:52:51.843 [kinesis-backpressure-timer-0] WARN  s.a.k.r.f.FanOutRecordsPublisher - shardId-000000000004: [SubscriptionLifetime] Backpressure timeout fired (1000ms) -- cancelling flow id: shardId-000000000004-1. Will re-subscribe when demand resumes.
11:52:51.892 [kinesis-backpressure-timer-0] WARN  s.a.k.r.f.FanOutRecordsPublisher - shardId-000000000000: [SubscriptionLifetime] Backpressure timeout fired (1000ms) -- cancelling flow id: shardId-000000000000-1. Will re-subscribe when demand resumes.
11:52:52.821 [pool-8-thread-1] INFO  s.a.kinesis.e2e.BackpressureE2EApp - [HEAP] 114MB / 256MB
11:52:54.821 [pool-8-thread-1] INFO  s.a.kinesis.e2e.BackpressureE2EApp - [HEAP] 117MB / 256MB
11:52:56.825 [pool-8-thread-1] INFO  s.a.kinesis.e2e.BackpressureE2EApp - [HEAP] 79MB / 256MB
11:52:58.823 [pool-8-thread-1] INFO  s.a.kinesis.e2e.BackpressureE2EApp - [HEAP] 110MB / 256MB
...
...
11:53:26.826 [pool-8-thread-1] INFO  s.a.kinesis.e2e.BackpressureE2EApp - [HEAP] 65MB / 256MB
11:53:28.823 [pool-8-thread-1] INFO  s.a.kinesis.e2e.BackpressureE2EApp - [HEAP] 47MB / 256MB
11:53:48.824 [pool-8-thread-1] INFO  s.a.kinesis.e2e.BackpressureE2EApp - [HEAP] 111MB / 256MB
11:53:52.339 [kinesis-backpressure-timer-0] WARN  s.a.k.r.f.FanOutRecordsPublisher - shardId-000000000007: [SubscriptionLifetime] Backpressure timeout fired (1000ms) -- cancelling flow id: shardId-000000000007-2. Will re-subscribe when demand resumes.
11:53:52.340 [kinesis-backpressure-timer-0] WARN  s.a.k.r.f.FanOutRecordsPublisher - shardId-000000000001: [SubscriptionLifetime] Backpressure timeout fired (1000ms) -- cancelling flow id: shardId-000000000001-2. Will re-subscribe when demand resumes.
11:53:52.340 [kinesis-backpressure-timer-0] WARN  s.a.k.r.f.FanOutRecordsPublisher - shardId-000000000003: [SubscriptionLifetime] Backpressure timeout fired (1000ms) -- cancelling flow id: shardId-000000000003-2. Will re-subscribe when demand resumes.
11:53:52.340 [kinesis-backpressure-timer-0] WARN  s.a.k.r.f.FanOutRecordsPublisher - shardId-000000000008: [SubscriptionLifetime] Backpressure timeout fired (1000ms) -- cancelling flow id: shardId-000000000008-2. Will re-subscribe when demand resumes.
11:53:52.340 [kinesis-backpressure-timer-0] WARN  s.a.k.r.f.FanOutRecordsPublisher - shardId-000000000009: [SubscriptionLifetime] Backpressure timeout fired (1000ms) -- cancelling flow id: shardId-000000000009-2. Will re-subscribe when demand resumes.
11:53:52.340 [kinesis-backpressure-timer-0] WARN  s.a.k.r.f.FanOutRecordsPublisher - shardId-000000000000: [SubscriptionLifetime] Backpressure timeout fired (1000ms) -- cancelling flow id: shardId-000000000000-2. Will re-subscribe when demand resumes.
11:53:52.340 [kinesis-backpressure-timer-0] WARN  s.a.k.r.f.FanOutRecordsPublisher - shardId-000000000006: [SubscriptionLifetime] Backpressure timeout fired (1000ms) -- cancelling flow id: shardId-000000000006-2. Will re-subscribe when demand resumes.
11:53:52.340 [kinesis-backpressure-timer-0] WARN  s.a.k.r.f.FanOutRecordsPublisher - shardId-000000000002: [SubscriptionLifetime] Backpressure timeout fired (1000ms) -- cancelling flow id: shardId-000000000002-2. Will re-subscribe when demand resumes.
11:53:52.340 [kinesis-backpressure-timer-0] WARN  s.a.k.r.f.FanOutRecordsPublisher - shardId-000000000005: [SubscriptionLifetime] Backpressure timeout fired (1000ms) -- cancelling flow id: shardId-000000000005-2. Will re-subscribe when demand resumes.
11:53:52.340 [kinesis-backpressure-timer-0] WARN  s.a.k.r.f.FanOutRecordsPublisher - shardId-000000000004: [SubscriptionLifetime] Backpressure timeout fired (1000ms) -- cancelling flow id: shardId-000000000004-2. Will re-subscribe when demand resumes.
...
...
11:54:08.823 [pool-8-thread-1] INFO  s.a.kinesis.e2e.BackpressureE2EApp - [HEAP] 109MB / 256MB
11:54:10.828 [pool-8-thread-1] INFO  s.a.kinesis.e2e.BackpressureE2EApp - [HEAP] 78MB / 256MB
```
