### PR TITLE
Skip unnecessary DescribeStreamConsumer call and sleep for ACTIVE consumers

### DIFF
--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/fanout/FanOutConsumerRegistration.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/fanout/FanOutConsumerRegistration.java
@@ -124,6 +124,10 @@ public class FanOutConsumerRegistration implements ConsumerRegistration {
             // Update consumer arn, if describe was successful.
             if (response != null) {
                 streamConsumerArn(response.consumerDescription().consumerARN());
+                // Skip waitForActive if consumer is already ACTIVE from the initial describe
+                if (ConsumerStatus.ACTIVE.equals(response.consumerDescription().consumerStatus())) {
+                    return streamConsumerArn;
+                }
             }
 
             // Check if consumer is active before proceeding
@@ -179,8 +183,15 @@ public class FanOutConsumerRegistration implements ConsumerRegistration {
         try {
             while (!ConsumerStatus.ACTIVE.equals(status) && retries > 0) {
                 status = describeStreamConsumer().consumerDescription().consumerStatus();
+                if (ConsumerStatus.ACTIVE.equals(status)) {
+                    break;
+                }
                 retries--;
-                log.info("{} : Waiting for StreamConsumer {} to have ACTIVE status...", streamName, streamConsumerName);
+                log.info(
+                        "{} : Waiting for StreamConsumer {} to have ACTIVE status, current status: {}",
+                        streamName,
+                        streamConsumerName,
+                        status);
                 Thread.sleep(retryBackoffMillis);
             }
         } catch (InterruptedException ie) {

--- a/amazon-kinesis-client/src/test/java/software/amazon/kinesis/retrieval/fanout/FanOutConsumerRegistrationTest.java
+++ b/amazon-kinesis-client/src/test/java/software/amazon/kinesis/retrieval/fanout/FanOutConsumerRegistrationTest.java
@@ -187,7 +187,7 @@ public class FanOutConsumerRegistrationTest {
         final long endTime = System.currentTimeMillis();
 
         assertThat(consumerArn, equalTo(CONSUMER_ARN));
-        assertThat(endTime - startTime, greaterThanOrEqualTo(2 * BACKOFF_MILLIS));
+        assertThat(endTime - startTime, greaterThanOrEqualTo(BACKOFF_MILLIS));
 
         verify(client).registerStreamConsumer(any(RegisterStreamConsumerRequest.class));
     }


### PR DESCRIPTION
FanOutConsumerRegistration.getOrCreateStreamConsumerArn() calls describeStreamConsumer() to get the consumer ARN, but never checks the consumer status from that response. It then unconditionally calls waitForActive() which makes a second describeStreamConsumer() call and sleeps retryBackoffMillis (1s) even when the consumer is already ACTIVE.

For multi-stream EFO applications with many streams, this adds ~1s of unnecessary delay per unique stream during the Scheduler loop, causing significant startup latency (e.g., 160 streams x 1.1s = 176s blocking).

Fix:
- Check consumer status from the initial describeStreamConsumer() response
- If already ACTIVE, return immediately (skip waitForActive entirely)
- In waitForActive loop, break immediately when ACTIVE status detected (prevents sleeping before the while condition is re-evaluated)
- Log actual consumer status when waiting

Impact: Reduces per-stream consumer ARN lookup from ~1.1s to ~15-20ms for existing ACTIVE consumers (the common case after first registration).

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
