### PR TITLE
Increase GSI creation timeout

### DIFF
--- a/.github/workflows/run_integ_tests.yml
+++ b/.github/workflows/run_integ_tests.yml
@@ -38,7 +38,7 @@ jobs:
     permissions:
       id-token: write
     if: ${{ always() && needs.check-if-should-run.outputs.should_run == 'true' && (needs.check-if-should-run.outputs.is_fork != 'true' || needs.wait-for-approval.result == 'success') }}
-    timeout-minutes: 20
+    timeout-minutes: 35
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/coordinator/DynamicMigrationComponentsInitializer.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/coordinator/DynamicMigrationComponentsInitializer.java
@@ -299,7 +299,7 @@ public final class DynamicMigrationComponentsInitializer {
         if (blockingWait) {
             log.info("Waiting for Lease table GSI creation");
             final long secondsBetweenPolls = 10L;
-            final long timeoutSeconds = 600L;
+            final long timeoutSeconds = 1800L;
             final boolean isIndexActive =
                     leaseRefresher.waitUntilLeaseOwnerToLeaseKeyIndexExists(secondsBetweenPolls, timeoutSeconds);
 

--- a/amazon-kinesis-client/src/test/java/software/amazon/kinesis/application/TestConsumer.java
+++ b/amazon-kinesis-client/src/test/java/software/amazon/kinesis/application/TestConsumer.java
@@ -107,10 +107,10 @@ public class TestConsumer {
             startConsumer();
 
             // The longest part of starting up a new KCL 3.x application is waiting for the lease table GSI to be
-            // created. This roughly takes between 5-10 minutes for a 4 shard lease table. Therefore, sleep for
-            // approximately 15 minutes to allow KCL to start up, assign leases, and process.
+            // created. This roughly takes between 15-20 minutes for a 4 shard lease table. Therefore, sleep for
+            // approximately 25 minutes to allow KCL to start up, assign leases, and process.
             // TODO: optimize the integration test runtime so we know when KCL has started so we don't sleep as long
-            Thread.sleep(TimeUnit.MINUTES.toMillis(15));
+            Thread.sleep(TimeUnit.MINUTES.toMillis(25));
 
             if (consumerConfig.getReshardFactorList() != null) {
                 performStreamScale();


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Recent changes to move all DDB entities to the lease table appear to have increased the time it takes for a new KCL application to create the GSI. Increase the timeout within the KCL to 30 minutes and increase the timeout for the integration test.

Example integ test run: https://github.com/awslabs/amazon-kinesis-client/actions/runs/27999135345/job/82867500158
```
2026-06-23 03:13:29,060 [pool-12-thread-1] INFO  s.a.k.l.d.DynamoDBLeaseRefresher [NONE] - GSI status was not active, after 600s 
```

From local testing this can take around 15-20 minutes now. Validated workflow in fork https://github.com/lucienlu-aws/amazon-kinesis-client/actions/runs/29048851719/job/86224205547

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
