### PR TITLE
Extend GSI creation timeout to 1 hour

### DIFF
--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/coordinator/DynamicMigrationComponentsInitializer.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/coordinator/DynamicMigrationComponentsInitializer.java
@@ -299,7 +299,12 @@ public final class DynamicMigrationComponentsInitializer {
         if (blockingWait) {
             log.info("Waiting for Lease table GSI creation");
             final long secondsBetweenPolls = 10L;
-            final long timeoutSeconds = 1800L;
+            // TODO: there exists an issue where if this timeout is reached the KCL starts up erroneously for a new
+            //   application (Scheduler appears to start but doesn't take any leases and some threads don't start
+            //   properly) where the only recovery is bouncing the worker after the GSI is created.
+            //   Extending the timeout to a long time to ensure GSI is created as a short term fix and will revisit
+            //   on the proper fix in the future
+            final long timeoutSeconds = 3600L;
             final boolean isIndexActive =
                     leaseRefresher.waitUntilLeaseOwnerToLeaseKeyIndexExists(secondsBetweenPolls, timeoutSeconds);
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Extend GSI creation timeout to 1 hour. There exists an issue where if this timeout is reached KCL starts up erroneously for a new application and does not take any leases. Will revisit for a proper fix in the future.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
