### PR TITLE
Prepare for KCL release v3.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ For **2.x** release notes, please see [v2.x/CHANGELOG.md](https://github.com/aws
 
 ---
 
+### Release 3.6.0 (July 14, 2026)
+* [#1779](https://github.com/awslabs/amazon-kinesis-client/pull/1779) Add Metrics for table migration
+    * KCL now emits CloudWatch metrics tracking the single-table metadata migration, giving operators visibility into migration progress and state transitions.
+* [#1790](https://github.com/awslabs/amazon-kinesis-client/pull/1790) Extend GSI creation timeout to 1 hour
+* [#1786](https://github.com/awslabs/amazon-kinesis-client/pull/1786) Increase GSI creation timeout
+* [#1788](https://github.com/awslabs/amazon-kinesis-client/pull/1788) Move DDBLeaseRenewer updateLease revert on failure to be inside the synchronized block
+* [#1787](https://github.com/awslabs/amazon-kinesis-client/pull/1787) Bump com.fasterxml.jackson.core:jackson-databind
+
 ### Release 3.5.0 (June 22, 2026)
 * [#1773](https://github.com/awslabs/amazon-kinesis-client/pull/1773) Single-table migration for KCL metadata
     * KCL 3.5 introduces a mechanism to consolidate all KCL metadata into a single DynamoDB lease table. In earlier KCL 3.x versions, KCL maintained separate DynamoDB tables for lease management, worker metrics (the worker metrics table), and coordinator state (the coordinator state table). Starting with KCL 3.5+, the WorkerMetricStats and CoordinatorState entities can be co-located alongside lease records in the lease table, reducing the number of DynamoDB tables your application provisions and operates. This is optional, but cannot be rolled back once completed.

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ The recommended way to use the KCL for Java is to consume it from Maven.
   <dependency>
       <groupId>software.amazon.kinesis</groupId>
       <artifactId>amazon-kinesis-client</artifactId>
-      <version>3.5.0</version>
+      <version>3.6.0</version>
   </dependency>
   ```
 

--- a/amazon-kinesis-client-multilang/pom.xml
+++ b/amazon-kinesis-client-multilang/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>amazon-kinesis-client-pom</artifactId>
     <groupId>software.amazon.kinesis</groupId>
-    <version>3.5.0</version>
+    <version>3.6.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/amazon-kinesis-client/pom.xml
+++ b/amazon-kinesis-client/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>software.amazon.kinesis</groupId>
     <artifactId>amazon-kinesis-client-pom</artifactId>
-    <version>3.5.0</version>
+    <version>3.6.0</version>
   </parent>
 
   <artifactId>amazon-kinesis-client</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
   <artifactId>amazon-kinesis-client-pom</artifactId>
   <packaging>pom</packaging>
   <name>Amazon Kinesis Client Library</name>
-  <version>3.5.0</version>
+  <version>3.6.0</version>
   <description>The Amazon Kinesis Client Library for Java enables Java developers to easily consume and process data
     from Amazon Kinesis.
   </description>


### PR DESCRIPTION
*Description of changes:*
Prepare for the KCL v3.6.0 release:
- Bump version 3.5.0 → 3.6.0 in the root `pom.xml`, `amazon-kinesis-client/pom.xml`, and `amazon-kinesis-client-multilang/pom.xml`
- Update the Version 3.x Maven dependency snippet in `README.md` to 3.6.0
- Add the 3.6.0 section to `CHANGELOG.md` covering the changes merged since 3.5.0:
    - #1779 Add Metrics for table migration
    - #1790 Extend GSI creation timeout to 1 hour
    - #1786 Increase GSI creation timeout
    - #1788 Move DDBLeaseRenewer updateLease revert on failure to be inside the synchronized block
    - #1787 Bump com.fasterxml.jackson.core:jackson-databind

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.