### PR TITLE
Bump logback-classic to 1.3.16

### DIFF
--- a/amazon-kinesis-client-multilang/pom.xml
+++ b/amazon-kinesis-client-multilang/pom.xml
@@ -59,7 +59,7 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>1.3.14</version>
+      <version>1.3.16</version>
     </dependency>
     <dependency>
       <groupId>com.beust</groupId>

--- a/amazon-kinesis-client/pom.xml
+++ b/amazon-kinesis-client/pom.xml
@@ -290,7 +290,7 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>1.3.14</version>
+      <version>1.3.16</version>
       <scope>test</scope>
     </dependency>
 


### PR DESCRIPTION
## Summary
Bumps the `ch.qos.logback:logback-classic` dependency from 1.3.14 to 1.3.16 in both modules:
- `amazon-kinesis-client/pom.xml` (test scope)
- `amazon-kinesis-client-multilang/pom.xml`

## Testing
Dependency version-only change. CI build/tests to validate.