### PR TITLE
Addressed memory leaks and improved overall memory usage

### DIFF
--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/coordinator/PeriodicShardSyncManager.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/coordinator/PeriodicShardSyncManager.java
@@ -216,19 +216,16 @@ class PeriodicShardSyncManager {
             boolean isRunSuccess = false;
             final long runStartMillis = System.currentTimeMillis();
 
+            // Create a copy of the streams to be considered for this run to avoid data race with Scheduler.
+            final Set<StreamIdentifier> streamIdentifiers = new HashSet<>(currentStreamConfigMap.keySet());
+
             try {
-                // Create a copy of the streams to be considered for this run to avoid data race with Scheduler.
-                final Set<StreamIdentifier> streamConfigMap = new HashSet<>(currentStreamConfigMap.keySet());
 
                 // Construct the stream to leases map to be used in the lease sync
-                final Map<StreamIdentifier, List<Lease>> streamToLeasesMap = getStreamToLeasesMap(streamConfigMap);
+                final Map<StreamIdentifier, List<Lease>> streamToLeasesMap = getStreamToLeasesMap(streamIdentifiers);
 
                 // For each of the stream, check if shard sync needs to be done based on the leases state.
-                for (StreamIdentifier streamIdentifier : streamConfigMap) {
-                    if (!currentStreamConfigMap.containsKey(streamIdentifier)) {
-                        log.info("Skipping shard sync task for {} as stream is purged", streamIdentifier);
-                        continue;
-                    }
+                for (StreamIdentifier streamIdentifier : streamIdentifiers) {
                     final ShardSyncResponse shardSyncResponse =
                             checkForShardSync(streamIdentifier, streamToLeasesMap.get(streamIdentifier));
 
@@ -288,6 +285,10 @@ class PeriodicShardSyncManager {
             } catch (Exception e) {
                 log.error("Caught exception while running periodic shard syncer.", e);
             } finally {
+
+                // Clean up any deleted streams from hashRangeHoleTrackerMap
+                hashRangeHoleTrackerMap.keySet().retainAll(streamIdentifiers);
+
                 scope.addData(
                         "NumStreamsWithPartialLeases",
                         numStreamsWithPartialLeases,

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/coordinator/Scheduler.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/coordinator/Scheduler.java
@@ -747,7 +747,7 @@ public class Scheduler implements Runnable {
                                 log.info(
                                         "Removing stream {} from currentStreamConfigMap due to not being active",
                                         stream);
-                                currentStreamConfigMap.remove(stream);
+                                cleanupConfigForStream(stream);
                                 staleStreamDeletionMap.remove(stream);
                                 streamsSynced.add(stream);
                             });
@@ -938,7 +938,7 @@ public class Scheduler implements Runnable {
             // it will be retried again since stream will still show up in the staleStreamDeletionMap.
             // It is fine for PSSM to detect holes and it should not do shardsync because it takes few iterations
             // to breach the hole confidence interval threshold.
-            currentStreamConfigMap.remove(streamIdentifier);
+            cleanupConfigForStream(streamIdentifier);
             // Deleting leases will cause the workers to shutdown the record processors for these shards.
             if (deleteMultiStreamLeases(streamIdToShardsMap.get(streamIdentifier.serialize()))) {
                 streamInfoManager.deleteStreamInfo(streamIdentifier);
@@ -1392,6 +1392,17 @@ public class Scheduler implements Runnable {
         }
         Validate.notNull(streamIdentifier, "Stream identifier should not be empty");
         return streamIdentifier;
+    }
+
+    /**
+     * Remove the streamConfig for a given stream from the relevant maps.
+     * @param streamIdentifier Stream identifier to identify the config
+     */
+    private void cleanupConfigForStream(StreamIdentifier streamIdentifier) {
+        final StreamConfig streamConfig = currentStreamConfigMap.remove(streamIdentifier);
+        if (streamConfig != null) {
+            streamToShardSyncTaskManagerMap.remove(streamConfig);
+        }
     }
 
     private Region getKinesisRegion() {

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/coordinator/assignment/LeaseAssignmentManager.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/coordinator/assignment/LeaseAssignmentManager.java
@@ -117,7 +117,7 @@ public final class LeaseAssignmentManager {
         final long leaseCounter;
         final long lastCounterIncrementNanos;
         final boolean shutdownRequested;
-        final long checkpointOwnerTimeoutTimestampMillis;
+        final Long checkpointOwnerTimeoutTimestampMillis;
         final String leaseOwner;
         final String checkpointOwner;
     }

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/coordinator/assignment/LeaseAssignmentManager.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/coordinator/assignment/LeaseAssignmentManager.java
@@ -31,7 +31,6 @@ import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
@@ -105,10 +104,25 @@ public final class LeaseAssignmentManager {
     private final LeaseManagementConfig.GracefulLeaseHandoffConfig gracefulLeaseHandoffConfig;
     private final LeaseAssignmentStrategy leaseAssignmentStrategy;
     private boolean tookOverLeadershipInThisRun = false;
-    private final Map<String, Lease> prevRunLeasesState = new HashMap<>();
     private final long leaseAssignmentIntervalMillis;
     private final StreamIdCacheManager streamIdCacheManager;
     private final LAMDataManager lamDataManager;
+
+    /**
+     * Lease snapshot class to reduce memory usage by only containing attributes
+     * needed for subsequent checks rather than the entire lease.
+     */
+    @RequiredArgsConstructor
+    private static class LeaseCounterSnapshot {
+        final long leaseCounter;
+        final long lastCounterIncrementNanos;
+        final boolean shutdownRequested;
+        final long checkpointOwnerTimeoutTimestampMillis;
+        final String leaseOwner;
+        final String checkpointOwner;
+    }
+
+    private final Map<String, LeaseCounterSnapshot> prevRunLeasesState = new HashMap<>();
 
     private Future<?> managerFuture;
 
@@ -392,7 +406,7 @@ public final class LeaseAssignmentManager {
     private void updateLeasesLastCounterIncrementNanosAndLeaseShutdownTimeout(
             final List<Lease> leaseList, final Long scanTime) {
         for (final Lease lease : leaseList) {
-            final Lease prevLease = prevRunLeasesState.get(lease.leaseKey());
+            final LeaseCounterSnapshot prev = prevRunLeasesState.get(lease.leaseKey());
 
             // make sure lease shutdown timeouts are tracked.
             if (lease.shutdownRequested()) {
@@ -400,16 +414,16 @@ public final class LeaseAssignmentManager {
                 // guarantee that the latest shutdown is the same shutdown in the previous lease for example
                 // some other leaders change the lease states while this worker waiting for it's LAM run.
                 // This is the best effort to prevent marking the incorrect timeout.
-                if (isNull(prevLease) || !prevLease.shutdownRequested() || !isSameOwners(lease, prevLease)) {
+                if (isNull(prev) || !prev.shutdownRequested || !isSameOwners(lease, prev)) {
                     // Add new value if previous is null, previous lease is not shutdown pending or the owners
                     // don't match
                     lease.checkpointOwnerTimeoutTimestampMillis(getCheckpointOwnerTimeoutTimestampMillis());
                 } else {
-                    lease.checkpointOwnerTimeoutTimestampMillis(prevLease.checkpointOwnerTimeoutTimestampMillis());
+                    lease.checkpointOwnerTimeoutTimestampMillis(prev.checkpointOwnerTimeoutTimestampMillis);
                 }
             }
 
-            if (isNull(prevLease)) {
+            if (isNull(prev)) {
                 lease.lastCounterIncrementNanos(
                         isNull(lease.actualOwner())
                                 // This is an unassigned lease, mark as 0L that puts this in first in assignment order
@@ -417,13 +431,21 @@ public final class LeaseAssignmentManager {
                                 : scanTime);
             } else {
                 lease.lastCounterIncrementNanos(
-                        lease.leaseCounter() > prevLease.leaseCounter()
-                                ? scanTime
-                                : prevLease.lastCounterIncrementNanos());
+                        lease.leaseCounter() > prev.leaseCounter ? scanTime : prev.lastCounterIncrementNanos);
             }
         }
         prevRunLeasesState.clear();
-        prevRunLeasesState.putAll(leaseList.stream().collect(Collectors.toMap(Lease::leaseKey, Function.identity())));
+        for (Lease lease : leaseList) {
+            prevRunLeasesState.put(
+                    lease.leaseKey(),
+                    new LeaseCounterSnapshot(
+                            lease.leaseCounter(),
+                            lease.lastCounterIncrementNanos(),
+                            lease.shutdownRequested(),
+                            lease.checkpointOwnerTimeoutTimestampMillis(),
+                            lease.leaseOwner(),
+                            lease.checkpointOwner()));
+        }
     }
 
     private void prepareAfterLeaderSwitch() {
@@ -639,8 +661,8 @@ public final class LeaseAssignmentManager {
         return TimeUnit.NANOSECONDS.toMillis(nanoTimeProvider.get());
     }
 
-    private static boolean isSameOwners(Lease currentLease, Lease previousLease) {
-        return Objects.equals(currentLease.leaseOwner(), previousLease.leaseOwner())
-                && Objects.equals(currentLease.checkpointOwner(), previousLease.checkpointOwner());
+    private static boolean isSameOwners(Lease currentLease, LeaseCounterSnapshot previousLease) {
+        return Objects.equals(currentLease.leaseOwner(), previousLease.leaseOwner)
+                && Objects.equals(currentLease.checkpointOwner(), previousLease.checkpointOwner);
     }
 }

--- a/amazon-kinesis-client/src/test/java/software/amazon/kinesis/coordinator/PeriodicShardSyncManagerTest.java
+++ b/amazon-kinesis-client/src/test/java/software/amazon/kinesis/coordinator/PeriodicShardSyncManagerTest.java
@@ -18,9 +18,12 @@ package software.amazon.kinesis.coordinator;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -49,6 +52,7 @@ import software.amazon.kinesis.metrics.NullMetricsFactory;
 import software.amazon.kinesis.retrieval.kpl.ExtendedSequenceNumber;
 
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyLong;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static software.amazon.kinesis.common.HashKeyRangeForLease.deserialize;
@@ -604,6 +608,392 @@ public class PeriodicShardSyncManagerTest {
                     .hasHoleInLeases(streamIdentifier, leases)
                     .isPresent());
         }
+    }
+
+    // ==================== Tests for memory leak fix: hashRangeHoleTrackerMap cleanup ====================
+
+    @Test
+    public void testCheckForShardSync_holeDetected_populatesHashRangeHoleTrackerMap() {
+        final StreamIdentifier stream1 = StreamIdentifier.singleStreamInstance("stream1");
+        final Map<StreamIdentifier, StreamConfig> realStreamConfigMap = new HashMap<>();
+        realStreamConfigMap.put(stream1, new StreamConfig(stream1, null));
+
+        final PeriodicShardSyncManager manager = new PeriodicShardSyncManager(
+                "worker",
+                leaseRefresher,
+                realStreamConfigMap,
+                shardSyncTaskManagerProvider,
+                new HashMap<>(),
+                mockScheduledExecutor,
+                false,
+                new NullMetricsFactory(),
+                60000L,
+                3,
+                new AtomicBoolean(true));
+
+        // Create leases with a hole in hash range coverage
+        List<Lease> leasesWithHole = createLeasesWithHole();
+
+        // Call checkForShardSync which should populate hashRangeHoleTrackerMap
+        manager.checkForShardSync(stream1, leasesWithHole);
+
+        // The hashRangeHoleTrackerMap should now contain an entry for stream1
+        Assert.assertTrue(manager.getHashRangeHoleTrackerMap().containsKey(stream1));
+    }
+
+    @Test
+    public void testCheckForShardSync_noHole_removesFromHashRangeHoleTrackerMap() {
+        final StreamIdentifier stream1 = StreamIdentifier.singleStreamInstance("stream1");
+        final Map<StreamIdentifier, StreamConfig> realStreamConfigMap = new HashMap<>();
+        realStreamConfigMap.put(stream1, new StreamConfig(stream1, null));
+
+        final PeriodicShardSyncManager manager = new PeriodicShardSyncManager(
+                "worker",
+                leaseRefresher,
+                realStreamConfigMap,
+                shardSyncTaskManagerProvider,
+                new HashMap<>(),
+                mockScheduledExecutor,
+                false,
+                new NullMetricsFactory(),
+                60000L,
+                3,
+                new AtomicBoolean(true));
+
+        // First call: create hole to populate tracker
+        List<Lease> leasesWithHole = createLeasesWithHole();
+        manager.checkForShardSync(stream1, leasesWithHole);
+        Assert.assertTrue(manager.getHashRangeHoleTrackerMap().containsKey(stream1));
+
+        // Second call: no hole, complete hash range
+        List<Lease> completeLeases = createCompleteLeaseCoverage();
+        manager.checkForShardSync(stream1, completeLeases);
+
+        // hashRangeHoleTrackerMap should no longer contain stream1
+        Assert.assertFalse(manager.getHashRangeHoleTrackerMap().containsKey(stream1));
+    }
+
+    @Test
+    public void testRunShardSync_deletedStreamCleanedUpFromHashRangeHoleTrackerMap() throws Exception {
+        final StreamIdentifier stream1 = StreamIdentifier.multiStreamInstance("123456789012:stream1:1");
+        final StreamIdentifier stream2 = StreamIdentifier.multiStreamInstance("123456789012:stream2:2");
+        final StreamIdentifier stream3 = StreamIdentifier.multiStreamInstance("123456789012:stream3:3");
+
+        final Map<StreamIdentifier, StreamConfig> realStreamConfigMap = new HashMap<>();
+        realStreamConfigMap.put(stream1, new StreamConfig(stream1, null));
+        realStreamConfigMap.put(stream2, new StreamConfig(stream2, null));
+        realStreamConfigMap.put(stream3, new StreamConfig(stream3, null));
+
+        final ScheduledExecutorService localMockExecutor = mock(ScheduledExecutorService.class);
+        final Runnable[] capturedRunnable = new Runnable[1];
+        when(localMockExecutor.scheduleWithFixedDelay(any(Runnable.class), anyLong(), anyLong(), any(TimeUnit.class)))
+                .thenAnswer(invocation -> {
+                    capturedRunnable[0] = invocation.getArgument(0);
+                    return mock(ScheduledFuture.class);
+                });
+
+        final PeriodicShardSyncManager manager = new PeriodicShardSyncManager(
+                "worker",
+                leaseRefresher,
+                realStreamConfigMap,
+                shardSyncTaskManagerProvider,
+                new HashMap<>(),
+                localMockExecutor,
+                true,
+                new NullMetricsFactory(),
+                60000L,
+                3,
+                new AtomicBoolean(true));
+
+        // Populate hashRangeHoleTrackerMap for all 3 streams by calling checkForShardSync with holes
+        List<Lease> leasesWithHole = createLeasesWithHole();
+        manager.checkForShardSync(stream1, leasesWithHole);
+        manager.checkForShardSync(stream2, leasesWithHole);
+        manager.checkForShardSync(stream3, leasesWithHole);
+
+        Assert.assertEquals(3, manager.getHashRangeHoleTrackerMap().size());
+
+        // Now remove stream2 and stream3 from currentStreamConfigMap to simulate deletion
+        realStreamConfigMap.remove(stream2);
+        realStreamConfigMap.remove(stream3);
+
+        // Setup mock to return complete leases for the remaining stream (no shard sync needed)
+        List<Lease> completeMultiStreamLeases = createCompleteMultiStreamLeaseCoverage(stream1);
+        when(leaseRefresher.listLeases()).thenReturn(completeMultiStreamLeases);
+
+        // Start the manager to capture the runnable and then invoke it
+        LeaderDecider localLeaderDecider = mock(LeaderDecider.class);
+        when(localLeaderDecider.isLeader(any())).thenReturn(true);
+        manager.start(localLeaderDecider);
+        capturedRunnable[0].run();
+
+        // After runShardSync, hashRangeHoleTrackerMap should not contain stream2 or stream3
+        Assert.assertFalse(
+                "Deleted stream2 should be removed from hashRangeHoleTrackerMap",
+                manager.getHashRangeHoleTrackerMap().containsKey(stream2));
+        Assert.assertFalse(
+                "Deleted stream3 should be removed from hashRangeHoleTrackerMap",
+                manager.getHashRangeHoleTrackerMap().containsKey(stream3));
+        // stream1 was cleaned by checkForShardSync since it has complete coverage now
+        Assert.assertFalse(
+                "stream1 should be removed since leases have complete coverage",
+                manager.getHashRangeHoleTrackerMap().containsKey(stream1));
+    }
+
+    @Test
+    public void testRunShardSync_deletedStreamWithHoleTracker_retainAllCleansUp() throws Exception {
+        final StreamIdentifier activeStream = StreamIdentifier.multiStreamInstance("123456789012:activeStream:1");
+        final StreamIdentifier deletedStream = StreamIdentifier.multiStreamInstance("123456789012:deletedStream:2");
+
+        final Map<StreamIdentifier, StreamConfig> realStreamConfigMap = new HashMap<>();
+        realStreamConfigMap.put(activeStream, new StreamConfig(activeStream, null));
+        realStreamConfigMap.put(deletedStream, new StreamConfig(deletedStream, null));
+
+        final ScheduledExecutorService localMockExecutor = mock(ScheduledExecutorService.class);
+        final Runnable[] capturedRunnable = new Runnable[1];
+        when(localMockExecutor.scheduleWithFixedDelay(any(Runnable.class), anyLong(), anyLong(), any(TimeUnit.class)))
+                .thenAnswer(invocation -> {
+                    capturedRunnable[0] = invocation.getArgument(0);
+                    return mock(ScheduledFuture.class);
+                });
+
+        final PeriodicShardSyncManager manager = new PeriodicShardSyncManager(
+                "worker",
+                leaseRefresher,
+                realStreamConfigMap,
+                shardSyncTaskManagerProvider,
+                new HashMap<>(),
+                localMockExecutor,
+                true,
+                new NullMetricsFactory(),
+                60000L,
+                3,
+                new AtomicBoolean(true));
+
+        // Populate hashRangeHoleTrackerMap for both streams
+        List<Lease> leasesWithHole = createLeasesWithHole();
+        manager.checkForShardSync(activeStream, leasesWithHole);
+        manager.checkForShardSync(deletedStream, leasesWithHole);
+
+        Assert.assertEquals(2, manager.getHashRangeHoleTrackerMap().size());
+
+        // Simulate stream deletion: remove deletedStream from config
+        realStreamConfigMap.remove(deletedStream);
+
+        // Setup mock: return leases with hole for active stream (so its tracker entry persists)
+        List<Lease> multiStreamLeasesWithHole = createMultiStreamLeasesWithHole(activeStream);
+        when(leaseRefresher.listLeases()).thenReturn(multiStreamLeasesWithHole);
+
+        // Trigger runShardSync
+        LeaderDecider localLeaderDecider = mock(LeaderDecider.class);
+        when(localLeaderDecider.isLeader(any())).thenReturn(true);
+        manager.start(localLeaderDecider);
+        capturedRunnable[0].run();
+
+        // Active stream should still have its tracker entry (hole still present)
+        Assert.assertTrue(
+                "Active stream with hole should retain its tracker entry",
+                manager.getHashRangeHoleTrackerMap().containsKey(activeStream));
+        // Deleted stream should be cleaned up
+        Assert.assertFalse(
+                "Deleted stream should be cleaned from hashRangeHoleTrackerMap",
+                manager.getHashRangeHoleTrackerMap().containsKey(deletedStream));
+        Assert.assertEquals(1, manager.getHashRangeHoleTrackerMap().size());
+    }
+
+    @Test
+    public void testRunShardSync_noDeletedStreams_hashRangeHoleTrackerMapUnchanged() throws Exception {
+        final StreamIdentifier stream1 = StreamIdentifier.multiStreamInstance("123456789012:stream1:1");
+        final StreamIdentifier stream2 = StreamIdentifier.multiStreamInstance("123456789012:stream2:2");
+
+        final Map<StreamIdentifier, StreamConfig> realStreamConfigMap = new HashMap<>();
+        realStreamConfigMap.put(stream1, new StreamConfig(stream1, null));
+        realStreamConfigMap.put(stream2, new StreamConfig(stream2, null));
+
+        final ScheduledExecutorService localMockExecutor = mock(ScheduledExecutorService.class);
+        final Runnable[] capturedRunnable = new Runnable[1];
+        when(localMockExecutor.scheduleWithFixedDelay(any(Runnable.class), anyLong(), anyLong(), any(TimeUnit.class)))
+                .thenAnswer(invocation -> {
+                    capturedRunnable[0] = invocation.getArgument(0);
+                    return mock(ScheduledFuture.class);
+                });
+
+        final PeriodicShardSyncManager manager = new PeriodicShardSyncManager(
+                "worker",
+                leaseRefresher,
+                realStreamConfigMap,
+                shardSyncTaskManagerProvider,
+                new HashMap<>(),
+                localMockExecutor,
+                true,
+                new NullMetricsFactory(),
+                60000L,
+                3,
+                new AtomicBoolean(true));
+
+        // Populate hashRangeHoleTrackerMap for both streams
+        List<Lease> leasesWithHole = createLeasesWithHole();
+        manager.checkForShardSync(stream1, leasesWithHole);
+        manager.checkForShardSync(stream2, leasesWithHole);
+
+        Assert.assertEquals(2, manager.getHashRangeHoleTrackerMap().size());
+
+        // Both streams remain in config - no deletions. Return leases with holes for both.
+        List<Lease> allMultiStreamLeases = new ArrayList<>();
+        allMultiStreamLeases.addAll(createMultiStreamLeasesWithHole(stream1));
+        allMultiStreamLeases.addAll(createMultiStreamLeasesWithHole(stream2));
+        when(leaseRefresher.listLeases()).thenReturn(allMultiStreamLeases);
+
+        // Trigger runShardSync
+        LeaderDecider localLeaderDecider = mock(LeaderDecider.class);
+        when(localLeaderDecider.isLeader(any())).thenReturn(true);
+        manager.start(localLeaderDecider);
+        capturedRunnable[0].run();
+
+        // Both entries should still be in the map since no streams were deleted
+        Assert.assertTrue(manager.getHashRangeHoleTrackerMap().containsKey(stream1));
+        Assert.assertTrue(manager.getHashRangeHoleTrackerMap().containsKey(stream2));
+        Assert.assertEquals(2, manager.getHashRangeHoleTrackerMap().size());
+    }
+
+    @Test
+    public void testRunShardSync_allStreamsDeleted_hashRangeHoleTrackerMapCleared() throws Exception {
+        final StreamIdentifier stream1 = StreamIdentifier.multiStreamInstance("123456789012:stream1:1");
+        final StreamIdentifier stream2 = StreamIdentifier.multiStreamInstance("123456789012:stream2:2");
+
+        final Map<StreamIdentifier, StreamConfig> realStreamConfigMap = new HashMap<>();
+        realStreamConfigMap.put(stream1, new StreamConfig(stream1, null));
+        realStreamConfigMap.put(stream2, new StreamConfig(stream2, null));
+
+        final ScheduledExecutorService localMockExecutor = mock(ScheduledExecutorService.class);
+        final Runnable[] capturedRunnable = new Runnable[1];
+        when(localMockExecutor.scheduleWithFixedDelay(any(Runnable.class), anyLong(), anyLong(), any(TimeUnit.class)))
+                .thenAnswer(invocation -> {
+                    capturedRunnable[0] = invocation.getArgument(0);
+                    return mock(ScheduledFuture.class);
+                });
+
+        final PeriodicShardSyncManager manager = new PeriodicShardSyncManager(
+                "worker",
+                leaseRefresher,
+                realStreamConfigMap,
+                shardSyncTaskManagerProvider,
+                new HashMap<>(),
+                localMockExecutor,
+                true,
+                new NullMetricsFactory(),
+                60000L,
+                3,
+                new AtomicBoolean(true));
+
+        // Populate hashRangeHoleTrackerMap
+        List<Lease> leasesWithHole = createLeasesWithHole();
+        manager.checkForShardSync(stream1, leasesWithHole);
+        manager.checkForShardSync(stream2, leasesWithHole);
+
+        Assert.assertEquals(2, manager.getHashRangeHoleTrackerMap().size());
+
+        // Remove all streams from config
+        realStreamConfigMap.clear();
+
+        // Mock returns empty list since no leases
+        when(leaseRefresher.listLeases()).thenReturn(Collections.emptyList());
+
+        // Trigger runShardSync
+        LeaderDecider localLeaderDecider = mock(LeaderDecider.class);
+        when(localLeaderDecider.isLeader(any())).thenReturn(true);
+        manager.start(localLeaderDecider);
+        capturedRunnable[0].run();
+
+        // All entries should be cleaned up
+        Assert.assertTrue(
+                "hashRangeHoleTrackerMap should be empty when all streams are deleted",
+                manager.getHashRangeHoleTrackerMap().isEmpty());
+    }
+
+    /**
+     * Creates leases with a hole in hash range coverage.
+     * Covers [0, mid] but NOT (mid, MAX] — creating a detectable hole.
+     */
+    private List<Lease> createLeasesWithHole() {
+        final BigInteger mid = MAX_HASH_KEY.divide(BigInteger.valueOf(2));
+        List<Lease> leases = new ArrayList<>();
+
+        Lease lease1 = new Lease();
+        lease1.leaseKey("shard-001");
+        lease1.checkpoint(ExtendedSequenceNumber.TRIM_HORIZON);
+        lease1.hashKeyRange(new HashKeyRangeForLease(MIN_HASH_KEY, mid));
+        leases.add(lease1);
+
+        // Gap from mid+1 to MAX_HASH_KEY — no lease covers this range
+        return leases;
+    }
+
+    /**
+     * Creates leases that cover the complete hash range [0, MAX] with no holes.
+     */
+    private List<Lease> createCompleteLeaseCoverage() {
+        final BigInteger mid = MAX_HASH_KEY.divide(BigInteger.valueOf(2));
+        List<Lease> leases = new ArrayList<>();
+
+        Lease lease1 = new Lease();
+        lease1.leaseKey("shard-001");
+        lease1.checkpoint(ExtendedSequenceNumber.TRIM_HORIZON);
+        lease1.hashKeyRange(new HashKeyRangeForLease(MIN_HASH_KEY, mid));
+        leases.add(lease1);
+
+        Lease lease2 = new Lease();
+        lease2.leaseKey("shard-002");
+        lease2.checkpoint(ExtendedSequenceNumber.TRIM_HORIZON);
+        lease2.hashKeyRange(new HashKeyRangeForLease(mid.add(BigInteger.ONE), MAX_HASH_KEY));
+        leases.add(lease2);
+
+        return leases;
+    }
+
+    /**
+     * Creates MultiStreamLease objects with a hole for a given stream (for multi-stream mode runShardSync tests).
+     */
+    private List<Lease> createMultiStreamLeasesWithHole(StreamIdentifier stream) {
+        final BigInteger mid = MAX_HASH_KEY.divide(BigInteger.valueOf(2));
+        List<Lease> leases = new ArrayList<>();
+
+        MultiStreamLease lease1 = new MultiStreamLease();
+        lease1.leaseKey(MultiStreamLease.getLeaseKey(stream.serialize(), "shard-001"));
+        lease1.shardId("shard-001");
+        lease1.streamIdentifier(stream.serialize());
+        lease1.checkpoint(ExtendedSequenceNumber.TRIM_HORIZON);
+        lease1.hashKeyRange(new HashKeyRangeForLease(MIN_HASH_KEY, mid));
+        leases.add(lease1);
+
+        // Gap from mid+1 to MAX_HASH_KEY — no lease covers this range
+        return leases;
+    }
+
+    /**
+     * Creates MultiStreamLease objects with complete hash range coverage for a given stream.
+     */
+    private List<Lease> createCompleteMultiStreamLeaseCoverage(StreamIdentifier stream) {
+        final BigInteger mid = MAX_HASH_KEY.divide(BigInteger.valueOf(2));
+        List<Lease> leases = new ArrayList<>();
+
+        MultiStreamLease lease1 = new MultiStreamLease();
+        lease1.leaseKey(MultiStreamLease.getLeaseKey(stream.serialize(), "shard-001"));
+        lease1.shardId("shard-001");
+        lease1.streamIdentifier(stream.serialize());
+        lease1.checkpoint(ExtendedSequenceNumber.TRIM_HORIZON);
+        lease1.hashKeyRange(new HashKeyRangeForLease(MIN_HASH_KEY, mid));
+        leases.add(lease1);
+
+        MultiStreamLease lease2 = new MultiStreamLease();
+        lease2.leaseKey(MultiStreamLease.getLeaseKey(stream.serialize(), "shard-002"));
+        lease2.shardId("shard-002");
+        lease2.streamIdentifier(stream.serialize());
+        lease2.checkpoint(ExtendedSequenceNumber.TRIM_HORIZON);
+        lease2.hashKeyRange(new HashKeyRangeForLease(mid.add(BigInteger.ONE), MAX_HASH_KEY));
+        leases.add(lease2);
+
+        return leases;
     }
 
     private List<Lease> generateInitialLeases(int initialShardCount) {


### PR DESCRIPTION
1. Fixed a memory leak in PeriodicShardSyncManager where hashRangeHoleTrackerMap retained entries for deleted streams by adding cleanup via retainAll after each sync run.
2. Reduced memory overhead in LeaseAssignmentManager by replacing full Lease object storage in prevRunLeasesState with a lightweight LeaseCounterSnapshot that only retains the fields actually needed
3. streamToShardSyncTaskManagerMap in the Scheduler is a class level map that is always added to but never cleaned up. The only time this map was getting "flushed" was during a deployment where the leader is bounced. This change introduces cleanup logic to that map.