### PR TITLE
Prepare for KCL release v3.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ For **2.x** release notes, please see [v2.x/CHANGELOG.md](https://github.com/aws
 
 ---
 
+### Release 3.5.2 (September 4, 2026)
+* [#1798](https://github.com/awslabs/amazon-kinesis-client/pull/1798) Update KCLMigrationTool
+* [#1799](https://github.com/awslabs/amazon-kinesis-client/pull/1799) Address memory leaks and improved overall memory usage
+* [#1804](https://github.com/awslabs/amazon-kinesis-client/pull/1804) Ensure worker re-initializes after startup failure
+
 ### Release 3.5.1 (July 14, 2026)
 * [#1779](https://github.com/awslabs/amazon-kinesis-client/pull/1779) Add Metrics for table migration
     * KCL now emits CloudWatch metrics tracking the single-table metadata migration, giving operators visibility into migration progress and state transitions.

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ The recommended way to use the KCL for Java is to consume it from Maven.
   <dependency>
       <groupId>software.amazon.kinesis</groupId>
       <artifactId>amazon-kinesis-client</artifactId>
-      <version>3.5.1</version>
+      <version>3.5.2</version>
   </dependency>
   ```
 

--- a/amazon-kinesis-client-multilang/pom.xml
+++ b/amazon-kinesis-client-multilang/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>amazon-kinesis-client-pom</artifactId>
     <groupId>software.amazon.kinesis</groupId>
-    <version>3.5.1</version>
+    <version>3.5.2</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/amazon-kinesis-client/pom.xml
+++ b/amazon-kinesis-client/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>software.amazon.kinesis</groupId>
     <artifactId>amazon-kinesis-client-pom</artifactId>
-    <version>3.5.1</version>
+    <version>3.5.2</version>
   </parent>
 
   <artifactId>amazon-kinesis-client</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
   <artifactId>amazon-kinesis-client-pom</artifactId>
   <packaging>pom</packaging>
   <name>Amazon Kinesis Client Library</name>
-  <version>3.5.1</version>
+  <version>3.5.2</version>
   <description>The Amazon Kinesis Client Library for Java enables Java developers to easily consume and process data
     from Amazon Kinesis.
   </description>


### PR DESCRIPTION
*Description of changes:*
Prepare for the KCL v3.5.2 release:
- Bump version 3.5.1 → 3.5.2 in the root `pom.xml`, `amazon-kinesis-client/pom.xml`, and `amazon-kinesis-client-multilang/pom.xml`
- Update the Version 3.x Maven dependency snippet in `README.md` to 3.5.2
- Add the 3.5.2 section to CHANGELOG.md covering the changes merged since 3.5.1

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
