### PR TITLE
Table Migration metrics fixes

### DIFF
--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/coordinator/migration/TableMigrationStateMachineImpl.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/coordinator/migration/TableMigrationStateMachineImpl.java
@@ -157,6 +157,17 @@ public class TableMigrationStateMachineImpl implements TableMigrationStateMachin
     private static final String COMPLETION_FAULT_METRIC = "CompletionFault";
     private static final String MOVE_BATCH_COUNT_METRIC = "BatchCount";
 
+    /**
+     * Number of consecutive observations of min support code NOT being met (while DDB has INIT state)
+     * required before deleting the state and resetting the bake timer.
+     *
+     * <p>This prevents premature resets caused by transient conditions such as worker restarts
+     * where the lease is still held (not expired) but the worker's WorkerMetricStats heartbeat
+     * has expired temporarily. By requiring multiple consecutive observations, we tolerate
+     * brief gaps and only reset when there is sustained evidence of a real rollback.</p>
+     */
+    static final int MIN_SUPPORT_CODE_NOT_MET_THRESHOLD = 20;
+
     private final TableMigrationStatusProvider statusProvider;
     private final CoordinatorStateDAO coordinatorStateDAO;
     private final LegacyTableCoordinatorStateDAODelegate legacyDao;
@@ -201,6 +212,19 @@ public class TableMigrationStateMachineImpl implements TableMigrationStateMachin
      * Access is guarded by {@code synchronized}.
      */
     private TableMigrationSummary latestMigrationSummary;
+
+    /**
+     * Counts consecutive observations where the min support code is NOT met while
+     * DDB has the INIT state persisted. The state is only deleted (bake timer reset)
+     * after this counter reaches {@link #MIN_SUPPORT_CODE_NOT_MET_THRESHOLD}.
+     *
+     * <p>This prevents premature resets when workers restart — they still hold leases
+     * (not expired) but their WorkerMetricStats heartbeat has temporarily expired.
+     * The counter resets to 0 whenever min support code IS met.</p>
+     *
+     * Access is guarded by {@code synchronized}.
+     */
+    private int consecutiveMinSupportCodeNotMetCount = 0;
 
     public TableMigrationStateMachineImpl(
             final TableMigrationStatusProvider statusProvider,
@@ -340,12 +364,10 @@ public class TableMigrationStateMachineImpl implements TableMigrationStateMachin
             }
 
             if (!isLeader) {
-                // If we lost leadership while an async move is in progress, cancel it.
-                if (pendingMoveFuture != null && !pendingMoveFuture.isDone()) {
-                    log.info("Lost leadership, cancelling in-progress async move.");
-                    pendingMoveFuture.cancel(true);
-                    pendingMoveFuture = null;
-                }
+                // Reset all leader-specific tracking state to prevent stale data from being
+                // used if this worker becomes leader again later. A new leader must start with
+                // fresh state from LAM before making any decisions.
+                resetLeaderState();
                 return;
             }
 
@@ -530,16 +552,57 @@ public class TableMigrationStateMachineImpl implements TableMigrationStateMachin
     private void handleInitState(final TableMigrationState stateFromDDB, final MetricsScope scope) {
         if (!isMinSupportCodeMet()) {
             if (stateFromDDB != null) {
-                // Min support code regressed (rollback scenario). Delete state so bake restarts.
-                // Best-effort: during actual rollback, 3.4 workers can't do this.
-                log.info("INIT: min support code NOT met but DDB has INIT — deleting state (best effort).");
-                deleteStateSafe(stateFromDDB, scope);
+                // Min support code appears not met while DDB has INIT state.
+                // This could be a genuine rollback OR a transient condition such as:
+                // - A new leader that hasn't received latestMigrationSummary from LAM yet
+                // - Workers that restarted and still hold leases (not expired) but their
+                //   WorkerMetricStats heartbeat has temporarily expired
+                //
+                // To avoid premature resets, we require multiple consecutive observations
+                // before deleting the state. If latestMigrationSummary is null, we have
+                // no actual fleet data yet (e.g., new leader, LAM hasn't run), so we
+                // skip the counter entirely and wait for real data.
+                if (latestMigrationSummary == null) {
+                    log.info("INIT: min support code NOT met but no migration summary available yet "
+                            + "(new leader? LAM hasn't run). Skipping reset, waiting for data.");
+                } else {
+                    consecutiveMinSupportCodeNotMetCount++;
+                    log.info(
+                            "INIT: min support code NOT met (observation {}/{}), DDB has INIT state.",
+                            consecutiveMinSupportCodeNotMetCount,
+                            MIN_SUPPORT_CODE_NOT_MET_THRESHOLD);
+                    if (consecutiveMinSupportCodeNotMetCount >= MIN_SUPPORT_CODE_NOT_MET_THRESHOLD) {
+                        // Sustained regression — likely a real rollback. Delete state so bake restarts.
+                        // Best-effort: during actual rollback, 3.4 workers can't do this.
+                        log.info(
+                                "INIT: min support code NOT met for {} consecutive observations. "
+                                        + "Deleting state to reset bake timer (best effort).",
+                                consecutiveMinSupportCodeNotMetCount);
+                        deleteStateSafe(stateFromDDB, scope);
+                        consecutiveMinSupportCodeNotMetCount = 0;
+                    }
+                }
             }
             log.debug("INIT: waiting for min support code across all workers.");
             return;
         }
 
-        // Min support code met.
+        // Min support code met — decrement the consecutive not-met counter toward 0.
+        // We don't immediately reset to 0 because a rollback can occur close to the end of bake time.
+        // By counting down, we ensure that the counter fully recovers before we proceed with any
+        // state transitions, preventing the bake time from being cut short by a brief regression.
+        if (consecutiveMinSupportCodeNotMetCount > 0) {
+            consecutiveMinSupportCodeNotMetCount--;
+            log.info(
+                    "INIT: min support code met, but recovering from previous regression. " + "Counting down: {}/{}",
+                    consecutiveMinSupportCodeNotMetCount,
+                    MIN_SUPPORT_CODE_NOT_MET_THRESHOLD);
+            if (consecutiveMinSupportCodeNotMetCount > 0) {
+                return;
+            }
+            log.info("INIT: counter recovered to 0, resuming normal state machine logic.");
+        }
+
         if (stateFromDDB == null) {
             // First time min support code is met — write INIT to legacy DDB.
             // The modifiedTimestamp on this write serves as the bake start time.
@@ -784,6 +847,36 @@ public class TableMigrationStateMachineImpl implements TableMigrationStateMachin
             Thread.currentThread().interrupt();
         }
         log.info("TableMigrationStateMachine shutdown complete.");
+    }
+
+    // ==================== Leader State Reset ====================
+
+    /**
+     * Resets all leader-specific tracking state. Called when this worker is NOT the leader
+     * (or loses leadership) to ensure that stale data from a previous leadership term is not
+     * carried over to a future leadership term.
+     *
+     * <p>On leadership change, the new leader must wait for fresh data from LAM before making
+     * any state machine decisions. Without this reset:</p>
+     * <ul>
+     *   <li>{@code latestMigrationSummary} could be stale (from a previous LAM run when this
+     *       worker was leader before), leading to incorrect decisions.</li>
+     *   <li>{@code consecutiveMinSupportCodeNotMetCount} could carry over from a different
+     *       leadership term, causing premature or delayed resets.</li>
+     *   <li>{@code pendingMoveFuture} from a previous leadership term would be invalid since
+     *       the leader fencing check in the transaction would fail anyway.</li>
+     * </ul>
+     *
+     * Called from synchronized context.
+     */
+    private void resetLeaderState() {
+        if (pendingMoveFuture != null && !pendingMoveFuture.isDone()) {
+            log.info("Not leader, cancelling in-progress async move.");
+            pendingMoveFuture.cancel(true);
+        }
+        pendingMoveFuture = null;
+        latestMigrationSummary = null;
+        consecutiveMinSupportCodeNotMetCount = 0;
     }
 
     // ==================== Async Copy Logic ====================

--- a/amazon-kinesis-client/src/test/java/software/amazon/kinesis/coordinator/migration/TableMigrationStateMachineImplTest.java
+++ b/amazon-kinesis-client/src/test/java/software/amazon/kinesis/coordinator/migration/TableMigrationStateMachineImplTest.java
@@ -743,6 +743,212 @@ class TableMigrationStateMachineImplTest {
                         .s());
     }
 
+    // --- handleInitState: new leader with no summary does NOT reset state ---
+
+    @Test
+    void handleLeaderLockResult_initState_newLeaderNoSummary_doesNotDeleteState() throws Exception {
+        // Simulate: DDB has INIT state (bake timer already started), but a new leader
+        // has no latestMigrationSummary yet (LAM hasn't run). Should NOT delete state.
+        putTableMigrationState(TableMigrationStatus.TABLE_MIGRATION_STATUS_INIT);
+
+        CoordinatorStateDAO dao = createCoordinatorStateDAO();
+        CoordinatorConfig coordConfig = createCoordinatorConfig(false);
+
+        TableMigrationStateMachineImpl sm = new TableMigrationStateMachineImpl(
+                statusProvider,
+                dao,
+                WORKER_ID,
+                coordConfig,
+                new NullMetricsFactory(),
+                Executors.newSingleThreadExecutor());
+        sm.initialize();
+
+        // Do NOT push any migration summary — simulates new leader before LAM runs
+
+        // Call as leader — should NOT delete DDB state
+        sm.handleLeaderLockResult(true);
+
+        // Verify DDB state still exists
+        Map<String, AttributeValue> key = new HashMap<>();
+        key.put("key", AttributeValue.fromS(TableMigrationState.TABLE_MIGRATION_HASH_KEY));
+        GetItemResponse result = ddbClient
+                .getItem(b -> b.tableName(LEGACY_TABLE).key(key).consistentRead(true))
+                .get();
+        assertTrue(result.item() != null && !result.item().isEmpty(), "State should NOT be deleted on new leader");
+        assertEquals(
+                TableMigrationStatus.TABLE_MIGRATION_STATUS_INIT.name(),
+                result.item()
+                        .get(TableMigrationState.TABLE_MIGRATION_STATUS_ATTRIBUTE_NAME)
+                        .s());
+    }
+
+    // --- handleInitState: requires consecutive observations before resetting ---
+
+    @Test
+    void handleLeaderLockResult_initState_minSupportCodeNotMet_requiresThresholdBeforeDelete() throws Exception {
+        putTableMigrationState(TableMigrationStatus.TABLE_MIGRATION_STATUS_INIT);
+
+        CoordinatorStateDAO dao = createCoordinatorStateDAO();
+        CoordinatorConfig coordConfig = createCoordinatorConfig(false);
+
+        TableMigrationStateMachineImpl sm = new TableMigrationStateMachineImpl(
+                statusProvider,
+                dao,
+                WORKER_ID,
+                coordConfig,
+                new NullMetricsFactory(),
+                Executors.newSingleThreadExecutor());
+        sm.initialize();
+
+        // Push summary with min support code NOT met (minSupportCode=0)
+        TableMigrationSummary notMetSummary = TableMigrationSummary.builder()
+                .minSupportCode(0)
+                .workersWithUnexpiredLeases(2)
+                .totalWorkersWithLeases(2)
+                .totalActiveWorkersWithMetrics(2)
+                .leaseOwnersWithActiveMetrics(2)
+                .activeWorkersWithMetricsInLeaseTable(0)
+                .activeWorkersWithMetricsInLegacyTable(2)
+                .build();
+        sm.updateMigrationSummary(notMetSummary);
+
+        // Call fewer than threshold times — state should NOT be deleted
+        for (int i = 0; i < TableMigrationStateMachineImpl.MIN_SUPPORT_CODE_NOT_MET_THRESHOLD - 1; i++) {
+            sm.handleLeaderLockResult(true);
+        }
+
+        Map<String, AttributeValue> key = new HashMap<>();
+        key.put("key", AttributeValue.fromS(TableMigrationState.TABLE_MIGRATION_HASH_KEY));
+        GetItemResponse result = ddbClient
+                .getItem(b -> b.tableName(LEGACY_TABLE).key(key).consistentRead(true))
+                .get();
+        assertTrue(
+                result.item() != null && !result.item().isEmpty(),
+                "State should NOT be deleted before threshold is reached");
+
+        // One more call should trigger the delete
+        sm.handleLeaderLockResult(true);
+
+        result = ddbClient
+                .getItem(b -> b.tableName(LEGACY_TABLE).key(key).consistentRead(true))
+                .get();
+        assertTrue(
+                result.item() == null || result.item().isEmpty(), "State should be deleted after threshold is reached");
+    }
+
+    // --- handleInitState: counter decrements on recovery before proceeding ---
+
+    @Test
+    void handleLeaderLockResult_initState_minSupportCodeRecovery_decrementsCounterBeforeProceeding() throws Exception {
+        // Scenario: counter incremented to 2, then min support code recovers. Must count down to 0.
+        putTableMigrationState(TableMigrationStatus.TABLE_MIGRATION_STATUS_INIT);
+
+        CoordinatorStateDAO dao = createCoordinatorStateDAO();
+        CoordinatorConfig coordConfig = createCoordinatorConfig(false);
+
+        TableMigrationStateMachineImpl sm = new TableMigrationStateMachineImpl(
+                statusProvider,
+                dao,
+                WORKER_ID,
+                coordConfig,
+                new NullMetricsFactory(),
+                Executors.newSingleThreadExecutor());
+        sm.initialize();
+
+        // Push NOT met summary — increment counter twice
+        TableMigrationSummary notMetSummary = TableMigrationSummary.builder()
+                .minSupportCode(0)
+                .workersWithUnexpiredLeases(2)
+                .totalWorkersWithLeases(2)
+                .totalActiveWorkersWithMetrics(2)
+                .leaseOwnersWithActiveMetrics(2)
+                .activeWorkersWithMetricsInLeaseTable(0)
+                .activeWorkersWithMetricsInLegacyTable(2)
+                .build();
+        sm.updateMigrationSummary(notMetSummary);
+
+        sm.handleLeaderLockResult(true); // counter = 1
+        sm.handleLeaderLockResult(true); // counter = 2
+
+        // Now push a MET summary — counter should decrement
+        TableMigrationSummary metSummary = TableMigrationSummary.builder()
+                .minSupportCode(1)
+                .workersWithUnexpiredLeases(2)
+                .totalWorkersWithLeases(2)
+                .totalActiveWorkersWithMetrics(2)
+                .leaseOwnersWithActiveMetrics(2)
+                .activeWorkersWithMetricsInLeaseTable(2)
+                .activeWorkersWithMetricsInLegacyTable(0)
+                .build();
+        sm.updateMigrationSummary(metSummary);
+
+        // First call with met: counter 2->1, returns early (doesn't proceed to bake logic)
+        sm.handleLeaderLockResult(true);
+        // Status should still be INIT since counter hasn't reached 0 yet
+        assertEquals(TableMigrationStatus.TABLE_MIGRATION_STATUS_INIT, statusProvider.getTableMigrationStatus());
+
+        // Second call with met: counter 1->0, now proceeds
+        sm.handleLeaderLockResult(true);
+        // Now the state machine should proceed to normal logic (state exists, bake time check)
+        assertEquals(TableMigrationStatus.TABLE_MIGRATION_STATUS_INIT, statusProvider.getTableMigrationStatus());
+    }
+
+    // --- Leader change resets tracking state ---
+
+    @Test
+    void handleLeaderLockResult_leaderChange_resetsTrackingState() throws Exception {
+        putTableMigrationState(TableMigrationStatus.TABLE_MIGRATION_STATUS_INIT);
+
+        CoordinatorStateDAO dao = createCoordinatorStateDAO();
+        CoordinatorConfig coordConfig = createCoordinatorConfig(false);
+
+        TableMigrationStateMachineImpl sm = new TableMigrationStateMachineImpl(
+                statusProvider,
+                dao,
+                WORKER_ID,
+                coordConfig,
+                new NullMetricsFactory(),
+                Executors.newSingleThreadExecutor());
+        sm.initialize();
+
+        // Push summary with NOT met, increment counter
+        TableMigrationSummary notMetSummary = TableMigrationSummary.builder()
+                .minSupportCode(0)
+                .workersWithUnexpiredLeases(2)
+                .totalWorkersWithLeases(2)
+                .totalActiveWorkersWithMetrics(2)
+                .leaseOwnersWithActiveMetrics(2)
+                .activeWorkersWithMetricsInLeaseTable(0)
+                .activeWorkersWithMetricsInLegacyTable(2)
+                .build();
+        sm.updateMigrationSummary(notMetSummary);
+
+        sm.handleLeaderLockResult(true); // counter = 1
+        sm.handleLeaderLockResult(true); // counter = 2
+
+        // Lose leadership — should reset everything
+        sm.handleLeaderLockResult(false);
+
+        // Re-gain leadership. Since latestMigrationSummary was reset (null),
+        // calling as leader with NOT met should NOT increment counter (no summary available).
+        sm.handleLeaderLockResult(true);
+
+        // Push NOT met again and verify we need full threshold observations again
+        sm.updateMigrationSummary(notMetSummary);
+        sm.handleLeaderLockResult(true); // counter = 1 (reset to fresh)
+        sm.handleLeaderLockResult(true); // counter = 2
+
+        // State should still exist (threshold is 3)
+        Map<String, AttributeValue> key = new HashMap<>();
+        key.put("key", AttributeValue.fromS(TableMigrationState.TABLE_MIGRATION_HASH_KEY));
+        GetItemResponse result = ddbClient
+                .getItem(b -> b.tableName(LEGACY_TABLE).key(key).consistentRead(true))
+                .get();
+        assertTrue(
+                result.item() != null && !result.item().isEmpty(),
+                "State should still exist — counter was reset on leader change");
+    }
+
     // --- Helpers ---
 
     private void putTableMigrationState(TableMigrationStatus status) {


### PR DESCRIPTION
Fix the flaky rollback detection from phase2 to phase1. This is because anytime leader changes, it doesnt have the latest LAM state yet until LAM runs again, therefore it ends up using stale data to determine the phase2 vs phase1 worker and triggers a rollback.

Put in 2 fixes for this:
1. Reset state (LAM state) when leadership is lost and dont perform rollback check without latest LAM state
2. Monitor consistent rollback signals and not a one off, worker restart triggering the rollback. So a rollback signal must exist consecutively 20 iterations before rollback will be performed

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
