### PR TITLE
Fix phase1 worker count to include workers with active metrics but no leases

### DIFF
--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/coordinator/assignment/MigrationAwareLAMDataManager.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/coordinator/assignment/MigrationAwareLAMDataManager.java
@@ -320,9 +320,16 @@ public class MigrationAwareLAMDataManager implements LAMDataManager {
                 .filter(allActiveWorkersWithMetrics::contains)
                 .count();
 
-        // Compute support code distribution across lease-owning workers
+        // Compute support code distribution across all active workers (lease owners + active metrics).
+        // We include workers with active metrics even if they don't hold leases, because they are
+        // alive and their support code must be considered. Workers with both expired leases AND
+        // expired metrics are excluded (they are dead). This ensures newly started workers that
+        // emit SINGLE_TABLE_MIGRATION support code but haven't acquired leases yet are counted.
+        final Set<String> workersForSupportCodeEvaluation = new HashSet<>(unexpiredLeaseOwners);
+        workersForSupportCodeEvaluation.addAll(allActiveWorkersWithMetrics);
+
         final Map<Integer, Integer> supportCodeDistribution =
-                computeSupportCodeDistribution(unexpiredLeaseOwners, leaseTableMetrics, legacyTableMetrics);
+                computeSupportCodeDistribution(workersForSupportCodeEvaluation, leaseTableMetrics, legacyTableMetrics);
 
         // Derive min support code from distribution keys (0 if empty — no lease owners)
         final int minSupportCode =

--- a/amazon-kinesis-client/src/test/java/software/amazon/kinesis/coordinator/assignment/MigrationAwareLAMDataManagerTest.java
+++ b/amazon-kinesis-client/src/test/java/software/amazon/kinesis/coordinator/assignment/MigrationAwareLAMDataManagerTest.java
@@ -309,34 +309,43 @@ class MigrationAwareLAMDataManagerTest {
 
     @Test
     void loadData_migrationSummary_allWorkersWithFreshSupportCode_returnsMinCode() throws Exception {
-        manager = createManager(TableMigrationStatus.TABLE_MIGRATION_STATUS_COMPLETE);
+        manager = createManager(TableMigrationStatus.TABLE_MIGRATION_STATUS_INIT);
 
         long freshEpoch = Instant.now().getEpochSecond();
         WorkerMetricStats wm1 = createWorkerWithSupportCode("worker1", 2, freshEpoch);
         WorkerMetricStats wm2 = createWorkerWithSupportCode("worker2", 3, freshEpoch);
+        // worker3 has active metrics and support code but holds no leases (e.g., newly started)
+        // It should still be included in the support code distribution
+        WorkerMetricStats wm3 = createWorkerWithSupportCode("worker3", 2, freshEpoch);
         Lease lease1 = createLease("lease1", "worker1");
         Lease lease2 = createLease("lease2", "worker2");
 
         when(entityDAO.scanEntities(EntityType.LEASE, EntityType.WORKER_METRIC_STATS))
-                .thenReturn(buildScanResult(Arrays.asList(lease1, lease2), Arrays.asList(wm1, wm2)));
+                .thenReturn(buildScanResult(Arrays.asList(lease1, lease2), Collections.emptyList()));
+        when(legacyDelegate.getAllWorkerMetricStats()).thenReturn(Arrays.asList(wm1, wm2, wm3));
 
         manager.loadData(new NullMetricsScope());
 
         TableMigrationSummary summary = capturedSummary.get();
         assertNotNull(summary);
+        // min is 2 (worker1=2, worker2=3, worker3=2 with no lease but active metrics)
         assertEquals(2, summary.getMinSupportCode());
+        // worker3 is included in distribution despite having no leases
+        assertEquals(2, summary.getSupportCodeDistribution().get(2).intValue());
+        assertEquals(1, summary.getSupportCodeDistribution().get(3).intValue());
     }
 
     @Test
     void loadData_migrationSummary_workerWithNullSupportCode_returnsZero() throws Exception {
-        manager = createManager(TableMigrationStatus.TABLE_MIGRATION_STATUS_COMPLETE);
+        manager = createManager(TableMigrationStatus.TABLE_MIGRATION_STATUS_INIT);
 
         long freshEpoch = Instant.now().getEpochSecond();
         WorkerMetricStats wm1 = createWorkerWithSupportCode("worker1", null, freshEpoch);
         Lease lease1 = createLease("lease1", "worker1");
 
         when(entityDAO.scanEntities(EntityType.LEASE, EntityType.WORKER_METRIC_STATS))
-                .thenReturn(buildScanResult(Collections.singletonList(lease1), Collections.singletonList(wm1)));
+                .thenReturn(buildScanResult(Collections.singletonList(lease1), Collections.emptyList()));
+        when(legacyDelegate.getAllWorkerMetricStats()).thenReturn(Collections.singletonList(wm1));
 
         manager.loadData(new NullMetricsScope());
 
@@ -347,20 +356,27 @@ class MigrationAwareLAMDataManagerTest {
 
     @Test
     void loadData_migrationSummary_workerWithExpiredSupportCode_returnsZero() throws Exception {
-        manager = createManager(TableMigrationStatus.TABLE_MIGRATION_STATUS_COMPLETE);
+        manager = createManager(TableMigrationStatus.TABLE_MIGRATION_STATUS_INIT);
 
+        long freshEpoch = Instant.now().getEpochSecond();
         // Support code update epoch is very old (expired)
         long staleEpoch = Instant.now().minus(Duration.ofDays(10)).getEpochSecond();
-        WorkerMetricStats wm1 = createWorkerWithSupportCode("worker1", 2, staleEpoch);
+        // worker1 has a lease and valid support code
+        WorkerMetricStats wm1 = createWorkerWithSupportCode("worker1", 2, freshEpoch);
         Lease lease1 = createLease("lease1", "worker1");
+        // worker2 has active metrics but expired support code heartbeat and no leases
+        // It should be included (alive) and drag min to 0
+        WorkerMetricStats wm2 = createWorkerWithSupportCode("worker2", 2, staleEpoch);
 
         when(entityDAO.scanEntities(EntityType.LEASE, EntityType.WORKER_METRIC_STATS))
-                .thenReturn(buildScanResult(Collections.singletonList(lease1), Collections.singletonList(wm1)));
+                .thenReturn(buildScanResult(Collections.singletonList(lease1), Collections.emptyList()));
+        when(legacyDelegate.getAllWorkerMetricStats()).thenReturn(Arrays.asList(wm1, wm2));
 
         manager.loadData(new NullMetricsScope());
 
         TableMigrationSummary summary = capturedSummary.get();
         assertNotNull(summary);
+        // worker2 has active metrics (alive) but expired support code heartbeat → counted as 0
         assertEquals(0, summary.getMinSupportCode());
     }
 


### PR DESCRIPTION
Previously, computeSupportCodeDistribution only iterated over unexpiredLeaseOwners, causing workers that emit fleetSupportCode=SINGLE_TABLE_MIGRATION but don't hold any leases (e.g., newly started workers) to be invisible to the phase1 worker count and minSupportCode.

Fix: Pass the union of unexpiredLeaseOwners + allActiveWorkersWithMetrics to computeSupportCodeDistribution. This ensures:
- Workers with active metrics but no leases are included (alive)
- Workers with unexpired leases but expired metrics are included (code 0)
- Workers with both expired leases AND expired metrics are excluded (dead)

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
