### PR TITLE
Fix frequent lease rebalancing on low/zero throughput shards

### DIFF
--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/coordinator/assignment/LeaseAssignmentManager.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/coordinator/assignment/LeaseAssignmentManager.java
@@ -302,7 +302,8 @@ public final class LeaseAssignmentManager {
                     inMemoryStorageView,
                     config.dampeningPercentage(),
                     config.reBalanceThresholdPercentage(),
-                    config.allowThroughputOvershoot());
+                    config.allowThroughputOvershoot(),
+                    config.minCpuImpactForRebalance());
         }
         return leaseAssignmentDecider;
     }

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/coordinator/assignment/VarianceBasedLeaseAssignmentDecider.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/coordinator/assignment/VarianceBasedLeaseAssignmentDecider.java
@@ -53,23 +53,44 @@ import static java.util.Objects.nonNull;
 @Slf4j
 @KinesisClientInternalApi
 public final class VarianceBasedLeaseAssignmentDecider implements LeaseAssignmentDecider {
+    private static final double DEFAULT_MIN_CPU_IMPACT_FOR_REBALANCE = 1.0D;
+
     private final LeaseAssignmentManager.InMemoryStorageView inMemoryStorageView;
     private final int dampeningPercentageValue;
     private final int reBalanceThreshold;
     private final boolean allowThroughputOvershoot;
+    private final double minCpuImpactForRebalance;
     private final Map<String, Double> workerMetricsToFleetLevelAverageMap = new HashMap<>();
     private final PriorityQueue<WorkerMetricStats> assignableWorkerSortedByAvailableCapacity;
     private int targetLeasePerWorker;
 
+    /**
+     * Backward compatible constructor using default minimum CPU impact for rebalance.
+     */
     public VarianceBasedLeaseAssignmentDecider(
             final LeaseAssignmentManager.InMemoryStorageView inMemoryStorageView,
             final int dampeningPercentageValue,
             final int reBalanceThreshold,
             final boolean allowThroughputOvershoot) {
+        this(
+                inMemoryStorageView,
+                dampeningPercentageValue,
+                reBalanceThreshold,
+                allowThroughputOvershoot,
+                DEFAULT_MIN_CPU_IMPACT_FOR_REBALANCE);
+    }
+
+    public VarianceBasedLeaseAssignmentDecider(
+            final LeaseAssignmentManager.InMemoryStorageView inMemoryStorageView,
+            final int dampeningPercentageValue,
+            final int reBalanceThreshold,
+            final boolean allowThroughputOvershoot,
+            final double minCpuImpactForRebalance) {
         this.inMemoryStorageView = inMemoryStorageView;
         this.dampeningPercentageValue = dampeningPercentageValue;
         this.reBalanceThreshold = reBalanceThreshold;
         this.allowThroughputOvershoot = allowThroughputOvershoot;
+        this.minCpuImpactForRebalance = minCpuImpactForRebalance;
         initialize();
         final Comparator<WorkerMetricStats> comparator = Comparator.comparingDouble(
                 workerMetrics -> workerMetrics.computePercentageToReachAverage(workerMetricsToFleetLevelAverageMap));
@@ -261,6 +282,11 @@ public final class VarianceBasedLeaseAssignmentDecider implements LeaseAssignmen
 
             final double throughputToTake = workerIdToThroughputToTakeEntry.getValue();
 
+            // Skip if the expected CPU impact is too small to justify moving leases.
+            if (!isRebalanceImpactful(throughputToTake, largestOutlierWorkerMetricsName, workerId)) {
+                continue;
+            }
+
             final Queue<Lease> leasesToTake = getLeasesToTake(workerId, throughputToTake);
 
             log.info(
@@ -286,6 +312,32 @@ public final class VarianceBasedLeaseAssignmentDecider implements LeaseAssignmen
         }
 
         printWorkerToUtilizationLog(inMemoryStorageView.getActiveWorkerMetrics());
+    }
+
+    /**
+     * Checks if removing the given throughput from a worker would meaningfully change its CPU utilization.
+     * Returns false if the expected CPU drop is below the configured minimum, indicating the rebalance
+     * would not be worth the disruption of moving leases.
+     */
+    private boolean isRebalanceImpactful(
+            final double throughputToTake, final String metricName, final String workerId) {
+        final double avgThroughput = inMemoryStorageView.getTargetAverageThroughput();
+        final double fleetAvgMetric = workerMetricsToFleetLevelAverageMap.getOrDefault(metricName, 0D);
+        final double expectedCpuDrop;
+        if (avgThroughput > 0) {
+            expectedCpuDrop = throughputToTake * fleetAvgMetric / avgThroughput;
+        } else {
+            expectedCpuDrop = fleetAvgMetric / Math.max(1, targetLeasePerWorker);
+        }
+        if (expectedCpuDrop < minCpuImpactForRebalance) {
+            log.debug(
+                    "Skipping rebalance for worker {}: expected CPU drop {} is below minimum {}",
+                    workerId,
+                    expectedCpuDrop,
+                    minCpuImpactForRebalance);
+            return false;
+        }
+        return true;
     }
 
     private Queue<Lease> getLeasesToTake(final String workerId, final double throughputToTake) {
@@ -367,6 +419,11 @@ public final class VarianceBasedLeaseAssignmentDecider implements LeaseAssignmen
         final Queue<Lease> response = new ArrayDeque<>();
         double remainingThroughputToGet = throughputToGet;
         for (final Lease lease : assignedLeases) {
+            // Skip zero-throughput leases as they don't contribute to the throughput target
+            // and would be selected indefinitely (subtracting 0 never reduces the remaining target).
+            if (lease.throughputKBps() == 0D) {
+                continue;
+            }
             // if adding this lease makes throughout to take go below zero avoid taking this lease.
             if (remainingThroughputToGet - lease.throughputKBps() <= 0) {
                 continue;
@@ -376,8 +433,10 @@ public final class VarianceBasedLeaseAssignmentDecider implements LeaseAssignmen
         }
 
         // If allowThroughputOvershoot is set to true, take a minimum throughput lease
+        // but only if it has non-zero throughput to avoid moving silent shards needlessly.
         if (allowThroughputOvershoot && response.isEmpty()) {
             assignedLeases.stream()
+                    .filter(lease -> lease.throughputKBps() > 0D)
                     .min(Comparator.comparingDouble(Lease::throughputKBps))
                     .ifPresent(response::add);
         }

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/leases/LeaseManagementConfig.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/leases/LeaseManagementConfig.java
@@ -578,6 +578,15 @@ public class LeaseManagementConfig {
         private int reBalanceThresholdPercentage = 10;
 
         /**
+         * Minimum expected CPU impact (in percentage points) required for a lease rebalancing move.
+         * If removing throughput from a worker would change its CPU by less than this value,
+         * the move is skipped because it wouldn't meaningfully help the worker.
+         * This prevents unnecessary lease churn when all workers are lightly loaded.
+         * Default is 1.0 (1 percentage point).
+         */
+        private double minCpuImpactForRebalance = 1.0D;
+
+        /**
          * The allowThroughputOvershoot flag determines whether leases should still be taken even if
          * it causes the total assigned throughput to exceed the desired throughput to take for re-balance.
          * Enabling this flag provides more flexibility for the LeaseAssignmentManager to explore additional

--- a/amazon-kinesis-client/src/test/java/software/amazon/kinesis/coordinator/assignment/LeaseAssignmentManagerTest.java
+++ b/amazon-kinesis-client/src/test/java/software/amazon/kinesis/coordinator/assignment/LeaseAssignmentManagerTest.java
@@ -691,6 +691,142 @@ class LeaseAssignmentManagerTest {
     }
 
     @Test
+    void performAssignment_tinyThroughputWithZeroThroughputLeases_assertZeroThroughputLeasesNotMoved()
+            throws Exception {
+        // When throughputToTake is tiny but non-zero, zero-throughput leases should NOT be selected.
+        createLeaseAssignmentManager(
+                getWorkerUtilizationAwareAssignmentConfig(Double.MAX_VALUE, 20),
+                100L,
+                System::nanoTime,
+                Integer.MAX_VALUE);
+
+        workerMetricsDAO.updateMetrics(createDummyYieldWorkerMetrics(TEST_YIELD_WORKER_ID));
+        workerMetricsDAO.updateMetrics(createDummyTakeWorkerMetrics(TEST_TAKE_WORKER_ID));
+
+        // 9 leases with zero throughput, 1 with tiny throughput on yield worker
+        for (int i = 0; i < 9; ++i) {
+            final Lease lease = createDummyLease("lease" + i, TEST_YIELD_WORKER_ID);
+            lease.throughputKBps(0D);
+            populateLeasesInLeaseTable(lease);
+        }
+        final Lease leaseWithThroughput = createDummyLease("lease9", TEST_YIELD_WORKER_ID);
+        leaseWithThroughput.throughputKBps(0.001D);
+        populateLeasesInLeaseTable(leaseWithThroughput);
+
+        leaseAssignmentManagerRunnable.run();
+
+        final long leasesOnTakeWorker = leaseRefresher.listLeases().stream()
+                .filter(lease -> TEST_TAKE_WORKER_ID.equals(lease.leaseOwner()))
+                .count();
+
+        // Correct behavior: at most 1 lease should move.
+        // This test FAILS with current code because the bug selects all zero-throughput leases.
+        assertTrue(
+                leasesOnTakeWorker <= 1, "Expected at most 1 lease moved, but " + leasesOnTakeWorker + " were moved");
+    }
+
+    @Test
+    void performAssignment_mixedThroughputLeases_assertZeroThroughputLeasesNotMoved() throws Exception {
+        // When some leases have real throughput and others have 0, zero-throughput leases
+        // should NOT be dragged along during rebalancing.
+        createLeaseAssignmentManager(
+                getWorkerUtilizationAwareAssignmentConfig(Double.MAX_VALUE, 20),
+                Duration.ofHours(1).toMillis(),
+                System::nanoTime,
+                Integer.MAX_VALUE);
+
+        workerMetricsDAO.updateMetrics(createDummyYieldWorkerMetrics(TEST_YIELD_WORKER_ID));
+        workerMetricsDAO.updateMetrics(createDummyTakeWorkerMetrics(TEST_TAKE_WORKER_ID));
+
+        // 2 leases with real throughput, 3 with zero on yield worker
+        final Lease lease1 = createDummyLease("lease1", TEST_YIELD_WORKER_ID);
+        lease1.throughputKBps(10D);
+        final Lease lease2 = createDummyLease("lease2", TEST_YIELD_WORKER_ID);
+        lease2.throughputKBps(10D);
+        final Lease lease3 = createDummyLease("lease3", TEST_YIELD_WORKER_ID);
+        lease3.throughputKBps(0D);
+        final Lease lease4 = createDummyLease("lease4", TEST_YIELD_WORKER_ID);
+        lease4.throughputKBps(0D);
+        final Lease lease5 = createDummyLease("lease5", TEST_YIELD_WORKER_ID);
+        lease5.throughputKBps(0D);
+        // 1 lease on take worker
+        final Lease lease6 = createDummyLease("lease6", TEST_TAKE_WORKER_ID);
+        lease6.throughputKBps(30D);
+        populateLeasesInLeaseTable(lease1, lease2, lease3, lease4, lease5, lease6);
+
+        leaseAssignmentManagerRunnable.run();
+
+        final long zeroThroughputLeasesOnTakeWorker = leaseRefresher.listLeases().stream()
+                .filter(lease -> TEST_TAKE_WORKER_ID.equals(lease.leaseOwner()))
+                .filter(lease -> lease.throughputKBps() != null && lease.throughputKBps() == 0D)
+                .count();
+
+        // Correct behavior: zero-throughput leases should NOT be moved.
+        // This test FAILS with current code because they get dragged along.
+        assertEquals(
+                0,
+                zeroThroughputLeasesOnTakeWorker,
+                "Expected no zero-throughput leases moved, but " + zeroThroughputLeasesOnTakeWorker + " were moved");
+    }
+
+    @Test
+    void performAssignment_smallCpuDifference_assertNoRebalancing() throws Exception {
+        // When CPU difference between workers is trivially small,
+        // rebalancing should NOT trigger. Uses actual CPU values from reproduction
+        // where unnecessary moves were observed (00:05:50 UTC).
+        createLeaseAssignmentManager(
+                getWorkerUtilizationAwareAssignmentConfig(Double.MAX_VALUE, 10),
+                Duration.ofHours(1).toMillis(),
+                System::nanoTime,
+                Integer.MAX_VALUE);
+
+        // 4 workers with low CPU values from actual reproduction data
+        // avg=2.59, upper=2.85, lower=2.33
+        // worker1 at 3.82 > 2.85 → above upper limit → targeted
+        // worker4 at 1.69 < 2.33 → below lower limit → can accept
+        workerMetricsDAO.updateMetrics(createDummyWorkerMetrics("worker1", 3.82D, 80L));
+        workerMetricsDAO.updateMetrics(createDummyWorkerMetrics("worker2", 2.65D, 80L));
+        workerMetricsDAO.updateMetrics(createDummyWorkerMetrics("worker3", 2.19D, 80L));
+        workerMetricsDAO.updateMetrics(createDummyWorkerMetrics("worker4", 1.69D, 80L));
+
+        // Leases distributed across workers, all zero throughput
+        for (int i = 0; i < 5; ++i) {
+            final Lease lease = createDummyLease("lease" + i, "worker1");
+            lease.throughputKBps(0D);
+            populateLeasesInLeaseTable(lease);
+        }
+        for (int i = 5; i < 9; ++i) {
+            final Lease lease = createDummyLease("lease" + i, "worker2");
+            lease.throughputKBps(0D);
+            populateLeasesInLeaseTable(lease);
+        }
+        for (int i = 9; i < 13; ++i) {
+            final Lease lease = createDummyLease("lease" + i, "worker3");
+            lease.throughputKBps(0D);
+            populateLeasesInLeaseTable(lease);
+        }
+        for (int i = 13; i < 16; ++i) {
+            final Lease lease = createDummyLease("lease" + i, "worker4");
+            lease.throughputKBps(0D);
+            populateLeasesInLeaseTable(lease);
+        }
+
+        leaseAssignmentManagerRunnable.run();
+
+        final long leasesOnWorker1 = leaseRefresher.listLeases().stream()
+                .filter(lease -> "worker1".equals(lease.leaseOwner()))
+                .count();
+
+        // Correct behavior: no rebalancing because ~2% absolute CPU difference is trivially small.
+        // This test FAILS with current code because relative threshold triggers rebalancing
+        // and worker4 has enough room below average to accept the lease.
+        assertEquals(
+                5,
+                leasesOnWorker1,
+                "Expected no rebalancing (worker1 should keep all 5 leases), but has " + leasesOnWorker1);
+    }
+
+    @Test
     void performAssignment_continuousFailure_assertLeadershipRelease() throws Exception {
         final Supplier<Long> mockFailingNanoTimeProvider = Mockito.mock(Supplier.class);
         when(mockFailingNanoTimeProvider.get()).thenThrow(new RuntimeException("IAmAlwaysFailing"));


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
At low CPU, the relative ±10% rebalance threshold is too narrow which normal jitter triggers unnecessary lease moves. Zero-throughput leases compound this by being selected indefinitely during rebalancing.

Fix: skip rebalance when expected CPU impact < 1%, skip zero-throughput leases during selection. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
