### PR TITLE
Fix lease discovery thread pool leak on shutdown

### DIFF
--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/leases/dynamodb/DynamoDBLeaseCoordinator.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/leases/dynamodb/DynamoDBLeaseCoordinator.java
@@ -403,6 +403,7 @@ public class DynamoDBLeaseCoordinator implements LeaseCoordinator {
         }
 
         leaseRenewalThreadpool.shutdownNow();
+        leaseDiscoveryThreadPool.shutdownNow();
         leaseGracefulShutdownHandler.stop();
         synchronized (shutdownLock) {
             leaseRenewer.clearCurrentlyHeldLeases();

--- a/amazon-kinesis-client/src/test/java/software/amazon/kinesis/leases/dynamodb/DynamoDBLeaseCoordinatorTest.java
+++ b/amazon-kinesis-client/src/test/java/software/amazon/kinesis/leases/dynamodb/DynamoDBLeaseCoordinatorTest.java
@@ -17,6 +17,7 @@ package software.amazon.kinesis.leases.dynamodb;
 import java.lang.reflect.Field;
 import java.util.Collections;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledFuture;
 
 import org.junit.jupiter.api.AfterEach;
@@ -35,6 +36,7 @@ import software.amazon.kinesis.metrics.NullMetricsFactory;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
 class DynamoDBLeaseCoordinatorTest {
@@ -159,5 +161,51 @@ class DynamoDBLeaseCoordinatorTest {
         Field field = DynamoDBLeaseCoordinator.class.getDeclaredField("takerFuture");
         field.setAccessible(true);
         return (ScheduledFuture<?>) field.get(coordinator);
+    }
+
+    private ExecutorService getLeaseDiscoveryThreadPool() throws Exception {
+        Field field = DynamoDBLeaseCoordinator.class.getDeclaredField("leaseDiscoveryThreadPool");
+        field.setAccessible(true);
+        return (ExecutorService) field.get(coordinator);
+    }
+
+    private ExecutorService getLeaseRenewalThreadpool() throws Exception {
+        Field field = DynamoDBLeaseCoordinator.class.getDeclaredField("leaseRenewalThreadpool");
+        field.setAccessible(true);
+        return (ExecutorService) field.get(coordinator);
+    }
+
+    /**
+     * Verifies that leaseRenewalThreadpool is shut down after stop() is called.
+     * This is the control case — leaseRenewalThreadpool IS properly cleaned up.
+     */
+    @Test
+    void stop_shutsDownLeaseRenewalThreadpool() throws Exception {
+        when(mockModeProvider.dynamicModeChangeSupportNeeded()).thenReturn(false);
+        when(mockModeProvider.getLeaseAssignmentMode())
+                .thenReturn(LeaseAssignmentMode.WORKER_UTILIZATION_AWARE_ASSIGNMENT);
+
+        coordinator.start(mockModeProvider);
+        coordinator.stop();
+
+        ExecutorService renewalPool = getLeaseRenewalThreadpool();
+        assertTrue(renewalPool.isShutdown(), "leaseRenewalThreadpool should be shut down after stop() is called");
+    }
+
+    /**
+     * Verifies that leaseDiscoveryThreadPool is shut down after stop() is called.
+     * This test exposes the bug: leaseDiscoveryThreadPool is never shut down in stop().
+     */
+    @Test
+    void stop_shutsDownLeaseDiscoveryThreadPool() throws Exception {
+        when(mockModeProvider.dynamicModeChangeSupportNeeded()).thenReturn(false);
+        when(mockModeProvider.getLeaseAssignmentMode())
+                .thenReturn(LeaseAssignmentMode.WORKER_UTILIZATION_AWARE_ASSIGNMENT);
+
+        coordinator.start(mockModeProvider);
+        coordinator.stop();
+
+        ExecutorService discoveryPool = getLeaseDiscoveryThreadPool();
+        assertTrue(discoveryPool.isShutdown(), "leaseDiscoveryThreadPool should be shut down after stop() is called");
     }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fixed thread leak where the lease discovery thread pool was not being shut down when the Scheduler stops, causing threads to accumulate across restarts

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
